### PR TITLE
Implement stacking-context render instructions and world transform

### DIFF
--- a/packages/canvas/src/context.ts
+++ b/packages/canvas/src/context.ts
@@ -348,11 +348,17 @@ export class CanvasContext extends DOMContext<HTMLCanvasElement> {
 
     /** Saves the current drawing state onto the state stack. */
     public save(): void {
+        this.saveDepth += 1;
         return this.context.save();
     }
 
     /** Restores the most recently saved drawing state from the stack. */
     public restore(): void {
+        if (this.saveDepth === 0) {
+            return;
+        }
+
+        this.saveDepth -= 1;
         return this.context.restore();
     }
 

--- a/packages/charts/src/components/axis.ts
+++ b/packages/charts/src/components/axis.ts
@@ -22,6 +22,7 @@ import type {
     Element,
     Group,
     Line,
+    Rect,
     Scale,
     Text,
 } from '@ripl/core';
@@ -30,6 +31,7 @@ import {
     Box,
     createGroup,
     createLine,
+    createRect,
     createText,
     easeOutCubic,
 } from '@ripl/core';
@@ -158,6 +160,7 @@ export class ChartAxis extends ChartComponent {
     protected line: Line;
 
     private _labelDimension: LabelDimension;
+    private _clip?: Rect;
     protected cachedTicks?: unknown[];
 
     protected get ticks() {
@@ -243,6 +246,45 @@ export class ChartAxis extends ChartComponent {
         });
 
         scene.add(this.group);
+    }
+
+    /**
+     * Clips this axis's ticks, labels, and line to the plot's along-axis extent (the plot span
+     * on the axis's own direction × its reserved band), enabling the clip only while `enabled`.
+     * Mirrors the plot-content clip: with no navigator the clip stays inert, so tick labels that
+     * legitimately overhang the plot edge render in full. Called by the host chart per render.
+     *
+     * @param area - The current plot rectangle.
+     * @param enabled - Whether the clip should mask (typically `true` only while navigating).
+     */
+    public clipTo(area: { x: number;
+        y: number;
+        width: number;
+        height: number; }, enabled: boolean): void {
+        if (!this._clip) {
+            this._clip = createRect({
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+                clip: false,
+                pointerEvents: 'none',
+                zIndex: Number.NEGATIVE_INFINITY,
+            });
+
+            this.group.add(this._clip);
+        }
+
+        const band = this.getBoundingBox();
+        // The x-axis measures labels by width; it slides horizontally, so clip its horizontal
+        // span to the plot and keep the full band height. The y-axis is the mirror image.
+        const horizontal = this._labelDimension === 'width';
+
+        this._clip.x = horizontal ? area.x : band.left;
+        this._clip.y = horizontal ? band.top : area.y;
+        this._clip.width = horizontal ? area.width : band.width;
+        this._clip.height = horizontal ? band.height : area.height;
+        this._clip.clip = enabled;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/charts/src/components/grid.ts
+++ b/packages/charts/src/components/grid.ts
@@ -10,11 +10,13 @@ import type {
     Group,
     Line,
     LineState,
+    Rect,
 } from '@ripl/core';
 
 import {
     createGroup,
     createLine,
+    createRect,
 } from '@ripl/core';
 
 import {
@@ -43,6 +45,7 @@ const DEFAULT_LINE_DASH = [4, 4];
 export class Grid extends ChartComponent {
 
     private _group?: Group;
+    private _clip?: Rect;
     private _horizontalLines: Line[] = [];
     private _verticalLines: Line[] = [];
     private _horizontal: boolean;
@@ -59,6 +62,56 @@ export class Grid extends ChartComponent {
         this._stroke = options.stroke ?? DEFAULT_STROKE;
         this._lineWidth = options.lineWidth ?? DEFAULT_LINE_WIDTH;
         this._lineDash = options.lineDash ?? DEFAULT_LINE_DASH;
+    }
+
+    /** Lazily creates the grid group and adds it to the scene once. */
+    private _ensureGroup(): Group {
+        if (!this._group) {
+            this._group = createGroup({
+                id: 'grid',
+                class: 'chart-grid',
+                zIndex: 0,
+            });
+
+            this.scene.add(this._group);
+        }
+
+        return this._group;
+    }
+
+    /**
+     * Clips the grid lines to the plot rectangle, enabling the clip only while `enabled` (typically
+     * while a navigator is active). Mirrors the plot-content clip so grid lines positioned by a
+     * zoomed scale cannot bleed past the plot into the axis gutters.
+     *
+     * @param area - The current plot rectangle.
+     * @param enabled - Whether the clip should mask.
+     */
+    public clipTo(area: { x: number;
+        y: number;
+        width: number;
+        height: number; }, enabled: boolean): void {
+        const group = this._ensureGroup();
+
+        if (!this._clip) {
+            this._clip = createRect({
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+                clip: false,
+                pointerEvents: 'none',
+                zIndex: Number.NEGATIVE_INFINITY,
+            });
+
+            group.add(this._clip);
+        }
+
+        this._clip.x = area.x;
+        this._clip.y = area.y;
+        this._clip.width = area.width;
+        this._clip.height = area.height;
+        this._clip.clip = enabled;
     }
 
     /**
@@ -80,15 +133,7 @@ export class Grid extends ChartComponent {
         width: number,
         height: number
     ) {
-        if (!this._group) {
-            this._group = createGroup({
-                id: 'grid',
-                class: 'chart-grid',
-                zIndex: 0,
-            });
-
-            this.scene.add(this._group);
-        }
+        this._ensureGroup();
 
         // Drop grid lines that sit on the plot boundary — that's where the (solid) axis line lives,
         // so a dotted grid line there would draw right on top of it.

--- a/packages/charts/src/components/tooltip.ts
+++ b/packages/charts/src/components/tooltip.ts
@@ -125,7 +125,9 @@ export class Tooltip extends ChartComponent {
             this._group = createGroup({
                 id: 'tooltip',
                 opacity: 0,
-                zIndex: 1000,
+                // Above every other overlay (crosshair 1500, legend 2000): the tooltip is
+                // transient focused info and must never be occluded.
+                zIndex: 2500,
                 pointerEvents: 'none',
                 children: [background, textElement],
             });

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -484,15 +484,23 @@ export abstract class CartesianChart<
     protected clipPlot(area: ChartArea): void {
         this._ensurePlotContent();
 
-        if (!this._plotClip) {
-            return;
+        // Everything positioned by the (navigator-rescaled) scales — marks, grid, and axis
+        // ticks/labels — must stay within the plot while navigating. The marks live in
+        // `_plotContent` (masked by `_plotClip`); the grid and axes live in their own scene-root
+        // groups, so they get their own clips here. All are inert without a navigator.
+        const navigating = !!this._navigator;
+
+        if (this._plotClip) {
+            this._plotClip.x = area.x;
+            this._plotClip.y = area.y;
+            this._plotClip.width = area.width;
+            this._plotClip.height = area.height;
+            this._plotClip.clip = navigating;
         }
 
-        this._plotClip.x = area.x;
-        this._plotClip.y = area.y;
-        this._plotClip.width = area.width;
-        this._plotClip.height = area.height;
-        this._plotClip.clip = !!this._navigator;
+        this.xAxis.clipTo(area, navigating);
+        this.yAxis.clipTo(area, navigating);
+        this.grid?.clipTo(area, navigating);
     }
 
     protected resolveAnimation(referenceDuration: number = ANIMATION_REFERENCE.update): ResolvedAnimation {

--- a/packages/charts/test/navigator.test.ts
+++ b/packages/charts/test/navigator.test.ts
@@ -198,6 +198,41 @@ describe('CartesianChart navigator integration', () => {
         withoutNav.destroy();
     });
 
+    test('Should clip axis ticks/labels to the plot area only while a navigator is active', async () => {
+        mockCanvasContext();
+
+        const withNav = createChart(true);
+        await withNav.render();
+
+        const scene = (withNav as any).scene;
+        const axisGroups = scene.queryAll('.chart-axis');
+        expect(axisGroups.length).toBeGreaterThan(0);
+
+        // The clip rect is the pointer-transparent mask (distinct from the axis line, which also
+        // carries a `clip` flag). It's engaged while navigating.
+        const findClip = (group: { children: { clip?: boolean;
+            pointerEvents?: string; }[]; }) =>
+            group.children.find(child => child.clip !== undefined && child.pointerEvents === 'none');
+
+        for (const axisGroup of axisGroups) {
+            expect(findClip(axisGroup)?.clip).toBe(true);
+        }
+
+        withNav.destroy();
+
+        const withoutNav = createChart(false);
+        await withoutNav.render();
+
+        const plainScene = (withoutNav as any).scene;
+
+        // Without a navigator the axis clips stay inert, so tick labels overhang as before.
+        for (const axisGroup of plainScene.queryAll('.chart-axis')) {
+            expect(findClip(axisGroup)?.clip).toBe(false);
+        }
+
+        withoutNav.destroy();
+    });
+
     test('Should destroy the navigator (and reset the view) when toggled off via update', () => {
         mockCanvasContext();
 

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -41,6 +41,14 @@ import {
 } from '../core/factory';
 
 import {
+    applyElementTransform,
+} from '../core/element';
+
+import type {
+    Element as RiplElement,
+} from '../core/element';
+
+import {
     scaleContinuous,
 } from '../scales';
 
@@ -105,6 +113,12 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
 
     /** Whether drawing is buffered rather than committed to the surface immediately. */
     public buffer = false;
+    /**
+     * Whether this context's hit testing natively accounts for element and ancestor group
+     * transforms (as SVG does, via the DOM). When `false` (e.g. canvas), callers map the hit
+     * point into the element's local space before testing. See {@link getWorldTransform}.
+     */
+    public hitTestHonoursTransform = false;
     /** Current width, in pixels, of the rendering surface. */
     public width: number;
     /** Current height, in pixels, of the rendering surface. */
@@ -123,6 +137,8 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     protected states: BaseState[];
     protected currentState: BaseState;
     protected renderDepth = 0;
+    protected saveDepth = 0;
+    private _groupDepthStack: number[] = [];
 
     /** The element currently being rendered; setting a non-abstract element also records it in {@link Context.renderedElements}. */
     public get currentRenderElement() {
@@ -427,11 +443,17 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     public save(): void {
         this.states.push(this.currentState);
         this.currentState = this.getDefaultState();
+        this.saveDepth += 1;
     }
 
     /** Restores the most recently saved state from the stack. */
     public restore(): void {
+        if (this.saveDepth === 0) {
+            return;
+        }
+
         this.currentState = this.states.pop() || this.getDefaultState();
+        this.saveDepth -= 1;
     }
 
     /** Executes a callback within a save/restore pair, returning the callback's result. */
@@ -488,6 +510,36 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
             return body();
         } finally {
             this.markRenderEnd();
+            this.restore();
+        }
+    }
+
+    /**
+     * Opens a group boundary: saves the current drawing state and applies the group's own
+     * transform, so that descendant elements render within the group's coordinate system
+     * and any group-scoped clip is confined to the group. Every {@link Context.pushGroup}
+     * must be balanced by a matching {@link Context.popGroup}. Backends that render
+     * hierarchy structurally (such as SVG) override this to nest descendants under a
+     * group node.
+     *
+     * @param group - The group element whose boundary is being entered.
+     */
+    public pushGroup(group: RiplElement): void {
+        this._groupDepthStack.push(this.saveDepth);
+        this.save();
+        applyElementTransform(this, group);
+    }
+
+    /**
+     * Closes the most recently opened group boundary, unwinding the state stack back to the
+     * depth captured at {@link Context.pushGroup}. This absorbs any dangling `save()` left by
+     * a group-scoped clip (which deliberately skips its own `restore` so the clip persists to
+     * later siblings), confining the clip to the group rather than leaking it to the scene.
+     */
+    public popGroup(): void {
+        const depth = this._groupDepthStack.pop() ?? Math.max(0, this.saveDepth - 1);
+
+        while (this.saveDepth > depth) {
             this.restore();
         }
     }

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -18,6 +18,16 @@ import type {
 import {
     Box,
     isPointInBox,
+    matrixIdentity,
+    matrixIsIdentity,
+    matrixMultiply,
+    matrixRotate,
+    matrixScale,
+    matrixTranslate,
+} from '../math';
+
+import type {
+    Matrix,
 } from '../math';
 
 import {
@@ -272,7 +282,29 @@ function getInterpolator<TValue>(value: TValue, key?: string) {
     return (interpolator ?? interpolateAny) as InterpolatorFactory<TValue>;
 }
 
-function applyTransform(context: Context, _value: unknown, element: Element) {
+/**
+ * The subset of {@link Context} transform operations required to apply an element's
+ * transform. Implemented by every {@link Context}, and by the internal matrix accumulator
+ * used to reconstruct an element's world transform for hit testing.
+ */
+export interface TransformTarget {
+    /** Applies a translation of `(x, y)`. */
+    translate(x: number, y: number): void;
+    /** Applies a rotation, in radians. */
+    rotate(angle: number): void;
+    /** Applies a scale with the given horizontal and vertical factors. */
+    scale(x: number, y: number): void;
+}
+
+/**
+ * Applies an element's transform (translate, rotate, scale about its transform-origin) to
+ * the given target. Used both to drive a {@link Context}'s transform during rendering and,
+ * via a matrix accumulator, to reconstruct an element's world transform for hit testing.
+ *
+ * @param target - The {@link Context} (or matrix accumulator) to apply the transform to.
+ * @param element - The element whose transform is applied.
+ */
+export function applyElementTransform(target: TransformTarget, element: Element) {
     const translateX = element.translateX ?? 0;
     const translateY = element.translateY ?? 0;
     const scaleX = element.transformScaleX ?? 1;
@@ -308,19 +340,65 @@ function applyTransform(context: Context, _value: unknown, element: Element) {
         }
     }
 
-    context.translate(originX + translateX, originY + translateY);
+    target.translate(originX + translateX, originY + translateY);
 
     if (hasRotation) {
-        context.rotate(rotation);
+        target.rotate(rotation);
     }
 
     if (hasScale) {
-        context.scale(scaleX, scaleY);
+        target.scale(scaleX, scaleY);
     }
 
     if (hasOrigin) {
-        context.translate(-originX, -originY);
+        target.translate(-originX, -originY);
     }
+}
+
+/** A {@link TransformTarget} that accumulates applied transforms into a single {@link Matrix}. */
+class MatrixTransformTarget implements TransformTarget {
+
+    public matrix: Matrix = matrixIdentity();
+
+    public translate(x: number, y: number): void {
+        this.matrix = matrixMultiply(this.matrix, matrixTranslate(x, y));
+    }
+
+    public rotate(angle: number): void {
+        this.matrix = matrixMultiply(this.matrix, matrixRotate(angle));
+    }
+
+    public scale(x: number, y: number): void {
+        this.matrix = matrixMultiply(this.matrix, matrixScale(x, y));
+    }
+
+}
+
+/**
+ * Reconstructs an element's world transform — the composition of its own transform and
+ * every ancestor group's transform, from the root down — for use in hit testing against
+ * backends (such as canvas) that do not natively account for element transforms.
+ *
+ * @param element - The element whose world transform to compute.
+ * @returns The composed {@link Matrix}, or `null` when the whole chain is the identity
+ * transform (the common case), letting callers skip any point remapping.
+ */
+export function getWorldTransform(element: Element): Matrix | null {
+    const chain: Element[] = [];
+    let current: Element | undefined = element;
+
+    while (current) {
+        chain.unshift(current);
+        current = current.parent as Element | undefined;
+    }
+
+    const target = new MatrixTransformTarget();
+
+    chain.forEach(node => applyElementTransform(target, node));
+
+    return matrixIsIdentity(target.matrix)
+        ? null
+        : target.matrix;
 }
 
 /** The base renderable element with state management, event handling, interpolation, transform support, and context rendering. */
@@ -723,7 +801,7 @@ export class Element<
 
         try {
             if (!this.abstract) {
-                applyTransform(context, null, this as unknown as Element);
+                applyElementTransform(context, this as unknown as Element);
             }
 
             objectForEach(CONTEXT_OPERATIONS, (key, operation) => {

--- a/packages/core/src/core/group.ts
+++ b/packages/core/src/core/group.ts
@@ -173,20 +173,21 @@ export class Group<TEventMap extends ElementEventMap = ElementEventMap> extends 
         super.destroy();
     }
 
-    /** Renders all child elements in ascending z-index order within a save/restore context. */
+    /** Renders all child elements in ascending z-index order within this group's boundary. */
     public render(context: Context): void {
-        context.save();
         context.markRenderStart();
+        context.pushGroup(this as unknown as Element);
 
         // `children` returns a fresh array, so this sort is safe. Rendering scene-less (a group drawn
-        // directly to a context) must honour z-index just as `Scene` does with its sorted buffer; the
-        // sort is stable, so equal-z-index siblings keep insertion order.
+        // directly to a context) must honour z-index and the group's own transform just as `Scene`
+        // does via its instruction stream; the sort is stable, so equal-z-index siblings keep
+        // insertion order.
         this.children
             .sort((ea, eb) => ea.zIndex - eb.zIndex)
             .forEach(element => element.render(context));
 
+        context.popGroup();
         context.markRenderEnd();
-        context.restore();
     }
 
 }

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -307,14 +307,26 @@ export class Renderer extends EventBus<RendererEventMap> {
     }
 
     private _renderBuffer() {
-        const buffer = this._scene.buffer;
+        const context = this._scene.context;
 
-        buffer.forEach(element => {
+        this._scene.instructions.forEach(({ type, element }) => {
+            // A group boundary closes here — its transitions were already advanced at the
+            // matching `push`, so restore and move on without re-processing them.
+            if (type === 'pop') {
+                context.popGroup();
+                return;
+            }
+
             this._transitionMap.get(element.id)?.forEach(entry => {
                 this._processTransition(entry);
             });
 
-            element.render(this._scene.context);
+            if (type === 'push') {
+                context.pushGroup(element);
+                return;
+            }
+
+            element.render(context);
 
             if (this._debugOptions.boundingBoxes) {
                 this._renderBoundingBoxes(element);

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -21,6 +21,7 @@ import {
 
 import {
     Group,
+    isGroup,
 } from './group';
 
 import type {
@@ -38,6 +39,22 @@ import {
  */
 export type SceneEventMap = ElementEventMap;
 
+/** The kind of a {@link RenderInstruction}: enter a group boundary, draw a leaf, or exit a group boundary. */
+export type RenderInstructionType = 'push' | 'draw' | 'pop';
+
+/**
+ * A single entry in a {@link Scene}'s flat render instruction stream. `push`/`pop` bracket a
+ * group so its transform and any group-scoped clip apply to the leaves drawn between them;
+ * `draw` renders a leaf element. Groups are contiguous (stacking-context ordering), so each
+ * group contributes exactly one `push`/`pop` pair.
+ */
+export interface RenderInstruction {
+    /** Whether this instruction opens a group, draws a leaf, or closes a group. */
+    type: RenderInstructionType;
+    /** The group element for `push`/`pop`, or the leaf element for `draw`. */
+    element: Element;
+}
+
 /** Options for constructing a scene, extending group options with an optional auto-render-on-resize flag. */
 export interface SceneOptions extends GroupOptions {
     /** Whether the scene re-renders automatically when its context is resized. Defaults to `true`. */
@@ -52,8 +69,23 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
     /** The rendering {@link Context} this scene draws to. */
     public context: TContext;
 
-    /** The hoisted flat buffer of all renderable descendants, kept sorted by z-index for O(n) rendering. */
-    public buffer: Element[];
+    private _instructions: RenderInstruction[] = [];
+    private _buffer: Element[] = [];
+
+    /**
+     * The flat, group-aware render instruction stream in paint order (stacking-context
+     * z-ordering), driving the {@link Renderer} and {@link Scene.render}. Each entry is a
+     * `push`/`draw`/`pop` {@link RenderInstruction}; groups are bracketed by `push`/`pop` so
+     * their transform and any group-scoped clip apply to the leaves drawn between them.
+     */
+    public get instructions(): RenderInstruction[] {
+        return this._instructions;
+    }
+
+    /** The flat list of renderable leaf descendants in paint order — the `draw` targets of {@link Scene.instructions}. */
+    public get buffer(): Element[] {
+        return this._buffer;
+    }
 
     /** The pixel width of the scene's rendering context. */
     public get width() {
@@ -94,7 +126,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
         });
 
         this.context = context;
-        this.buffer = this.graph();
+        this._rebuffer();
 
         const requestFrame = createFrameBuffer();
 
@@ -109,17 +141,61 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
             context.invalidateTrackedElements();
         }));
 
-        // this.on('updated', ({ data }) => requestFrame(() => {
-        //     if (data.key === 'zIndex') {
-        //         this.rebuffer();
-        //     }
+        // A z-index change reorders the instruction stream, so re-sort. Interpolated
+        // animations write state directly (no `updated` event), so this only fires on explicit
+        // z-index assignments — and the rebuild is debounced to once per frame.
+        this.on('updated', event => {
+            if (event.data.key !== 'zIndex') {
+                return;
+            }
 
-        //     this.render();
-        // }));
+            requestFrame(() => {
+                this._rebuffer();
+                context.invalidateTrackedElements();
+            });
+        });
     }
 
     private _rebuffer() {
-        this.buffer = this.graph().sort((ea, eb) => ea.zIndex - eb.zIndex);
+        const instructions: RenderInstruction[] = [];
+        const buffer: Element[] = [];
+
+        this._collectInstructions(this, instructions, buffer);
+
+        this._instructions = instructions;
+        this._buffer = buffer;
+    }
+
+    /**
+     * Depth-first walk that flattens the scene graph into the render instruction stream.
+     * Each group's direct children are sorted by z-index (stable, so equal-z-index siblings
+     * keep insertion order) — sorting siblings by the additive {@link Element.zIndex} is
+     * equivalent to sorting by their own z-index, since they share the same parent offset.
+     * Groups are emitted as a contiguous `push` … `pop` pair (stacking-context ordering).
+     */
+    private _collectInstructions(group: Group, instructions: RenderInstruction[], buffer: Element[]) {
+        group.children
+            .sort((ea, eb) => ea.zIndex - eb.zIndex)
+            .forEach(element => {
+                if (isGroup(element)) {
+                    instructions.push({
+                        type: 'push',
+                        element,
+                    });
+                    this._collectInstructions(element, instructions, buffer);
+                    instructions.push({
+                        type: 'pop',
+                        element,
+                    });
+                    return;
+                }
+
+                instructions.push({
+                    type: 'draw',
+                    element,
+                });
+                buffer.push(element);
+            });
     }
 
     /** Destroys the scene (and optionally the context), removing all children and cleaning up event subscriptions. */
@@ -133,10 +209,23 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
         super.destroy();
     }
 
-    /** Clears the context and renders the entire element buffer in z-index order. */
+    /** Clears the context and renders the entire instruction stream in paint order, honouring group boundaries. */
     public render(): void {
-        this.context.batch(() => {
-            this.buffer.forEach(element => element.render(this.context));
+        const context = this.context;
+
+        context.batch(() => {
+            this._instructions.forEach(({ type, element }) => {
+                switch (type) {
+                    case 'push':
+                        context.pushGroup(element);
+                        break;
+                    case 'pop':
+                        context.popGroup();
+                        break;
+                    default:
+                        element.render(context);
+                }
+            });
         });
     }
 

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -55,6 +55,13 @@ export interface RenderInstruction {
     element: Element;
 }
 
+/** Render-instruction dispatch keyed by instruction type: open a group boundary, draw a leaf, or close a group boundary. */
+const RENDER_OPERATIONS: Record<RenderInstructionType, (context: Context, element: Element) => void> = {
+    push: (context, element) => context.pushGroup(element),
+    pop: context => context.popGroup(),
+    draw: (context, element) => element.render(context),
+};
+
 /** Options for constructing a scene, extending group options with an optional auto-render-on-resize flag. */
 export interface SceneOptions extends GroupOptions {
     /** Whether the scene re-renders automatically when its context is resized. Defaults to `true`. */
@@ -213,16 +220,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
 
         context.batch(() => {
             this._instructions.forEach(({ type, element }) => {
-                switch (type) {
-                    case 'push':
-                        context.pushGroup(element);
-                        break;
-                    case 'pop':
-                        context.popGroup();
-                        break;
-                    default:
-                        element.render(context);
-                }
+                RENDER_OPERATIONS[type](context, element);
             });
         });
     }

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -63,14 +63,13 @@ export interface SceneOptions extends GroupOptions {
     renderOnUpdate?: boolean;
 }
 
-/** The top-level group bound to a rendering context, maintaining a hoisted flat buffer for O(n) rendering. */
+/** The top-level group bound to a rendering context, maintaining a hoisted flat instruction stream for O(n) rendering. */
 export class Scene<TContext extends Context = Context> extends Group<SceneEventMap> {
 
     /** The rendering {@link Context} this scene draws to. */
     public context: TContext;
 
     private _instructions: RenderInstruction[] = [];
-    private _buffer: Element[] = [];
 
     /**
      * The flat, group-aware render instruction stream in paint order (stacking-context
@@ -84,7 +83,9 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
 
     /** The flat list of renderable leaf descendants in paint order — the `draw` targets of {@link Scene.instructions}. */
     public get buffer(): Element[] {
-        return this._buffer;
+        return this._instructions
+            .filter(instruction => instruction.type === 'draw')
+            .map(instruction => instruction.element);
     }
 
     /** The pixel width of the scene's rendering context. */
@@ -126,7 +127,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
         });
 
         this.context = context;
-        this._rebuffer();
+        this._rebuild();
 
         const requestFrame = createFrameBuffer();
 
@@ -137,7 +138,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
         }));
 
         this.on('graph', () => requestFrame(() => {
-            this._rebuffer();
+            this._rebuild();
             context.invalidateTrackedElements();
         }));
 
@@ -150,20 +151,18 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
             }
 
             requestFrame(() => {
-                this._rebuffer();
+                this._rebuild();
                 context.invalidateTrackedElements();
             });
         });
     }
 
-    private _rebuffer() {
+    private _rebuild() {
         const instructions: RenderInstruction[] = [];
-        const buffer: Element[] = [];
 
-        this._collectInstructions(this, instructions, buffer);
+        this._collectInstructions(this, instructions);
 
         this._instructions = instructions;
-        this._buffer = buffer;
     }
 
     /**
@@ -173,7 +172,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
      * equivalent to sorting by their own z-index, since they share the same parent offset.
      * Groups are emitted as a contiguous `push` … `pop` pair (stacking-context ordering).
      */
-    private _collectInstructions(group: Group, instructions: RenderInstruction[], buffer: Element[]) {
+    private _collectInstructions(group: Group, instructions: RenderInstruction[]) {
         group.children
             .sort((ea, eb) => ea.zIndex - eb.zIndex)
             .forEach(element => {
@@ -182,7 +181,7 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
                         type: 'push',
                         element,
                     });
-                    this._collectInstructions(element, instructions, buffer);
+                    this._collectInstructions(element, instructions);
                     instructions.push({
                         type: 'pop',
                         element,
@@ -194,7 +193,6 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
                     type: 'draw',
                     element,
                 });
-                buffer.push(element);
             });
     }
 

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -11,7 +11,13 @@ import type {
 
 import {
     Element,
+    getWorldTransform,
 } from './element';
+
+import {
+    matrixApplyToPoint,
+    matrixInvert,
+} from '../math';
 
 /** Abstract base class for renderable shapes, extending `Element` with a type-constrained constructor. */
 export abstract class Shape<TState extends BaseElementState = BaseElementState> extends Element<TState> {
@@ -73,6 +79,19 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
         if (!this.context || !this.path) {
             return super.intersectsWith(x, y, options);
+        }
+
+        // The stored path is in this element's local space, but its transform (and any ancestor
+        // group transform) is applied to the context during rendering. Backends that don't
+        // natively account for that during hit testing (e.g. canvas) need the point mapped back
+        // into local space; the identity case (no transforms) is skipped for free.
+        if (!this.context.hitTestHonoursTransform) {
+            const worldTransform = getWorldTransform(this as unknown as Element);
+            const inverse = worldTransform && matrixInvert(worldTransform);
+
+            if (inverse) {
+                [x, y] = matrixApplyToPoint(inverse, [x, y]);
+            }
         }
 
         const {

--- a/packages/core/src/math/index.ts
+++ b/packages/core/src/math/index.ts
@@ -1,5 +1,6 @@
 export * from './constants';
 export * from './geometry';
+export * from './matrix';
 export * from './number';
 export * from './structs';
 export * from './types';

--- a/packages/core/src/math/matrix.ts
+++ b/packages/core/src/math/matrix.ts
@@ -1,0 +1,92 @@
+/**
+ * A 2D affine transformation matrix stored as the six significant values of the
+ * augmented 3×3 matrix, in the same `[a, b, c, d, e, f]` order used by the Canvas
+ * 2D API (`setTransform`) and CSS `matrix()`:
+ *
+ * ```
+ * | a c e |
+ * | b d f |
+ * | 0 0 1 |
+ * ```
+ *
+ * A point `[x, y]` is transformed to `[a·x + c·y + e, b·x + d·y + f]`.
+ */
+export type Matrix = [a: number, b: number, c: number, d: number, e: number, f: number];
+
+/** Returns the identity matrix (a no-op transform). */
+export function matrixIdentity(): Matrix {
+    return [1, 0, 0, 1, 0, 0];
+}
+
+/** Returns a translation matrix that moves points by `(x, y)`. */
+export function matrixTranslate(x: number, y: number): Matrix {
+    return [1, 0, 0, 1, x, y];
+}
+
+/** Returns a scaling matrix with the given horizontal and vertical factors. */
+export function matrixScale(x: number, y: number): Matrix {
+    return [x, 0, 0, y, 0, 0];
+}
+
+/** Returns a rotation matrix for the given angle, in radians. */
+export function matrixRotate(angle: number): Matrix {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    return [cos, sin, -sin, cos, 0, 0];
+}
+
+/**
+ * Post-multiplies `a` by `b`, returning the composite `a · b`. Applying the result to a
+ * point is equivalent to applying `b` first and then `a`, matching how successive
+ * `translate`/`rotate`/`scale` calls accumulate onto a canvas transform matrix.
+ */
+export function matrixMultiply(a: Matrix, b: Matrix): Matrix {
+    return [
+        a[0] * b[0] + a[2] * b[1],
+        a[1] * b[0] + a[3] * b[1],
+        a[0] * b[2] + a[2] * b[3],
+        a[1] * b[2] + a[3] * b[3],
+        a[0] * b[4] + a[2] * b[5] + a[4],
+        a[1] * b[4] + a[3] * b[5] + a[5],
+    ];
+}
+
+/**
+ * Returns the inverse of `matrix`, or `null` when it is singular (zero determinant) and
+ * therefore not invertible.
+ */
+export function matrixInvert(matrix: Matrix): Matrix | null {
+    // eslint-disable-next-line id-length
+    const [a, b, c, d, e, f] = matrix;
+    const determinant = a * d - b * c;
+
+    if (determinant === 0) {
+        return null;
+    }
+
+    return [
+        d / determinant,
+        -b / determinant,
+        -c / determinant,
+        a / determinant,
+        (c * f - d * e) / determinant,
+        (b * e - a * f) / determinant,
+    ];
+}
+
+/** Applies `matrix` to the point `[x, y]`, returning the transformed point. */
+export function matrixApplyToPoint(matrix: Matrix, [x, y]: [number, number]): [number, number] {
+    // eslint-disable-next-line id-length
+    const [a, b, c, d, e, f] = matrix;
+    return [a * x + c * y + e, b * x + d * y + f];
+}
+
+/** Tests whether `matrix` is the identity transform (within an exact comparison). */
+export function matrixIsIdentity(matrix: Matrix): boolean {
+    return matrix[0] === 1
+        && matrix[1] === 0
+        && matrix[2] === 0
+        && matrix[3] === 1
+        && matrix[4] === 0
+        && matrix[5] === 0;
+}

--- a/packages/core/test/core/group-render.test.ts
+++ b/packages/core/test/core/group-render.test.ts
@@ -14,11 +14,13 @@ import {
     createGroup,
 } from '../../src';
 
-/** Minimal context that records the save/render bracketing without a real backend. */
+/** Minimal context that records the group/render bracketing without a real backend. */
 function fakeContext() {
     return {
         save: vi.fn(),
         restore: vi.fn(),
+        pushGroup: vi.fn(),
+        popGroup: vi.fn(),
         markRenderStart: vi.fn(),
         markRenderEnd: vi.fn(),
     } as unknown as Context;
@@ -73,7 +75,7 @@ describe('Group.render (scene-less)', () => {
         expect(order).toEqual(['first', 'second', 'third']);
     });
 
-    test('brackets the render pass in save/markRenderStart/markRenderEnd/restore', () => {
+    test('brackets the render pass in markRenderStart/pushGroup/popGroup/markRenderEnd', () => {
         const context = fakeContext();
         const child = createElement('rect', {});
 
@@ -83,9 +85,10 @@ describe('Group.render (scene-less)', () => {
 
         group.render(context);
 
-        expect(context.save).toHaveBeenCalledTimes(1);
-        expect(context.restore).toHaveBeenCalledTimes(1);
         expect(context.markRenderStart).toHaveBeenCalledTimes(1);
+        expect(context.pushGroup).toHaveBeenCalledTimes(1);
+        expect(context.pushGroup).toHaveBeenCalledWith(group);
+        expect(context.popGroup).toHaveBeenCalledTimes(1);
         expect(context.markRenderEnd).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/test/core/renderer.test.ts
+++ b/packages/core/test/core/renderer.test.ts
@@ -24,6 +24,8 @@ function createMockScene() {
         markRenderEnd: vi.fn(),
         save: vi.fn(),
         restore: vi.fn(),
+        pushGroup: vi.fn(),
+        popGroup: vi.fn(),
         batch: vi.fn((fn: () => unknown) => fn()),
         layer: vi.fn((fn: () => unknown) => fn()),
         element: document.createElement('div'),
@@ -34,6 +36,13 @@ function createMockScene() {
     const scene = {
         context: mockContext,
         buffer: elements,
+        // Leaf-only mock: every element renders as a `draw` instruction (no group boundaries).
+        get instructions() {
+            return elements.map(element => ({
+                type: 'draw' as const,
+                element,
+            }));
+        },
         on: vi.fn().mockReturnValue({ dispose: vi.fn() }),
         once: vi.fn().mockReturnValue({ dispose: vi.fn() }),
         emit: vi.fn(),

--- a/packages/core/test/core/scene-instructions.test.ts
+++ b/packages/core/test/core/scene-instructions.test.ts
@@ -1,0 +1,183 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    createGroup,
+    createRect,
+    createScene,
+    factory,
+} from '../../src';
+
+import {
+    createContext,
+} from '@ripl/canvas';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+/** Waits for the scene's debounced (rAF) rebuffer to run. */
+function nextFrame() {
+    return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+describe('Scene instruction stream', () => {
+
+    let el: HTMLDivElement;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        factory.set({ createContext });
+        el = document.createElement('div');
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        el.remove();
+        factory.set({ createContext: undefined });
+        vi.restoreAllMocks();
+    });
+
+    test('emits push/draw/pop bracketing a group', async () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        const group = createGroup({ children: [rect] });
+        const scene = createScene(el);
+
+        scene.add(group);
+        await nextFrame();
+
+        expect(scene.instructions.map(i => i.type)).toEqual(['push', 'draw', 'pop']);
+        expect(scene.instructions[0].element).toBe(group);
+        expect(scene.instructions[1].element).toBe(rect);
+        expect(scene.instructions[2].element).toBe(group);
+
+        scene.destroy();
+    });
+
+    test('leaves outside groups render as bare draw instructions', async () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        const scene = createScene(el);
+
+        scene.add(rect);
+        await nextFrame();
+
+        expect(scene.instructions.map(i => i.type)).toEqual(['draw']);
+        expect(scene.buffer).toEqual([rect]);
+
+        scene.destroy();
+    });
+
+    test('nested groups nest their push/pop pairs', async () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        const inner = createGroup({ children: [rect] });
+        const outer = createGroup({ children: [inner] });
+        const scene = createScene(el);
+
+        scene.add(outer);
+        await nextFrame();
+
+        expect(scene.instructions.map(i => i.type)).toEqual(['push', 'push', 'draw', 'pop', 'pop']);
+        expect(scene.instructions[0].element).toBe(outer);
+        expect(scene.instructions[1].element).toBe(inner);
+
+        scene.destroy();
+    });
+
+    test('applies stacking-context ordering: a child cannot escape its group past a sibling group', async () => {
+        // groupLow sits below groupHigh, but its child has a very high local z-index. Under
+        // global additive z-index the child would paint on top; under stacking-context
+        // semantics it stays trapped within its (lower) group.
+        const childHigh = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            zIndex: 100,
+        });
+        const childLow = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            zIndex: 0,
+        });
+
+        const groupLow = createGroup({
+            children: [childHigh],
+            zIndex: 0,
+        });
+        const groupHigh = createGroup({
+            children: [childLow],
+            zIndex: 10,
+        });
+
+        const scene = createScene(el);
+        scene.add([groupLow, groupHigh]);
+        await nextFrame();
+
+        // Paint order of leaves: the deep high-z child (trapped in the low group) first,
+        // then the low-z child in the high group last (on top).
+        expect(scene.buffer).toEqual([childHigh, childLow]);
+
+        scene.destroy();
+    });
+
+    test('sorts direct children of a group by z-index, stably', async () => {
+        const a = createRect({
+            id: 'a',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            zIndex: 1,
+        });
+        const b = createRect({
+            id: 'b',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            zIndex: 1,
+        });
+        const c = createRect({
+            id: 'c',
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            zIndex: 0,
+        });
+
+        const group = createGroup({ children: [a, b, c] });
+        const scene = createScene(el);
+        scene.add(group);
+        await nextFrame();
+
+        // c (z 0) first, then a and b (both z 1) in insertion order.
+        expect(scene.buffer).toEqual([c, a, b]);
+
+        scene.destroy();
+    });
+
+});

--- a/packages/core/test/core/world-transform.test.ts
+++ b/packages/core/test/core/world-transform.test.ts
@@ -1,0 +1,83 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    createGroup,
+    createRect,
+    getWorldTransform,
+    matrixApplyToPoint,
+} from '../../src';
+
+describe('getWorldTransform', () => {
+
+    test('returns null when the element and its ancestors are all identity', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        expect(getWorldTransform(rect)).toBeNull();
+    });
+
+    test('composes an ancestor group transform with the element\'s own transform', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        rect.translateX = 5;
+
+        const group = createGroup({ children: [rect] });
+        group.translateX = 10;
+
+        const world = getWorldTransform(rect);
+
+        expect(world).not.toBeNull();
+        // Group translate(10) composed with the element's own translate(5).
+        expect(matrixApplyToPoint(world!, [0, 0])).toEqual([15, 0]);
+    });
+
+    test('composes nested group transforms from the root down', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+
+        const inner = createGroup({ children: [rect] });
+        inner.translateY = 20;
+
+        const outer = createGroup({ children: [inner] });
+        outer.translateX = 100;
+
+        const world = getWorldTransform(rect);
+
+        expect(world).not.toBeNull();
+        expect(matrixApplyToPoint(world!, [0, 0])).toEqual([100, 20]);
+    });
+
+    test('reflects a group scale about the origin', () => {
+        const rect = createRect({
+            x: 4,
+            y: 6,
+            width: 10,
+            height: 10,
+        });
+
+        const group = createGroup({ children: [rect] });
+        group.transformScaleX = 2;
+        group.transformScaleY = 3;
+
+        const world = getWorldTransform(rect);
+
+        expect(world).not.toBeNull();
+        expect(matrixApplyToPoint(world!, [4, 6])).toEqual([8, 18]);
+    });
+
+});

--- a/packages/core/test/math/matrix.test.ts
+++ b/packages/core/test/math/matrix.test.ts
@@ -1,0 +1,74 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    matrixApplyToPoint,
+    matrixIdentity,
+    matrixInvert,
+    matrixIsIdentity,
+    matrixMultiply,
+    matrixRotate,
+    matrixScale,
+    matrixTranslate,
+} from '../../src';
+
+describe('Math', () => {
+
+    describe('Matrix', () => {
+
+        test('identity is the neutral transform', () => {
+            expect(matrixIdentity()).toEqual([1, 0, 0, 1, 0, 0]);
+            expect(matrixIsIdentity(matrixIdentity())).toBe(true);
+            expect(matrixIsIdentity(matrixTranslate(1, 0))).toBe(false);
+        });
+
+        test('applies translation to a point', () => {
+            expect(matrixApplyToPoint(matrixTranslate(10, 20), [1, 2])).toEqual([11, 22]);
+        });
+
+        test('applies scale to a point', () => {
+            expect(matrixApplyToPoint(matrixScale(2, 3), [4, 5])).toEqual([8, 15]);
+        });
+
+        test('applies a quarter-turn rotation to a point', () => {
+            const [x, y] = matrixApplyToPoint(matrixRotate(Math.PI / 2), [1, 0]);
+            expect(x).toBeCloseTo(0);
+            expect(y).toBeCloseTo(1);
+        });
+
+        test('multiply composes transforms (translate then scale)', () => {
+            // Post-multiply: apply the right operand first, then the left — matching how
+            // successive translate/scale calls accumulate on a canvas transform.
+            const composed = matrixMultiply(matrixTranslate(10, 0), matrixScale(2, 2));
+            expect(matrixApplyToPoint(composed, [3, 4])).toEqual([16, 8]);
+        });
+
+        test('multiplying by identity is a no-op', () => {
+            const matrix = matrixMultiply(matrixTranslate(5, 6), matrixScale(2, 3));
+            expect(matrixMultiply(matrix, matrixIdentity())).toEqual(matrix);
+            expect(matrixMultiply(matrixIdentity(), matrix)).toEqual(matrix);
+        });
+
+        test('invert round-trips a point back to itself', () => {
+            const matrix = matrixMultiply(matrixTranslate(30, -10), matrixScale(2, 4));
+            const inverse = matrixInvert(matrix)!;
+
+            expect(inverse).not.toBeNull();
+
+            const forward = matrixApplyToPoint(matrix, [7, 9]);
+            const [x, y] = matrixApplyToPoint(inverse, forward);
+
+            expect(x).toBeCloseTo(7);
+            expect(y).toBeCloseTo(9);
+        });
+
+        test('invert returns null for a singular matrix', () => {
+            expect(matrixInvert(matrixScale(0, 0))).toBeNull();
+        });
+
+    });
+
+});

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -20,6 +20,7 @@ import type {
     FillRule,
     Gradient,
     GradientColorStop,
+    Element as RiplElement,
     TextAlignment,
     TextBaseline,
     TextOptions,
@@ -41,8 +42,6 @@ import type {
 } from '@ripl/utilities';
 
 import {
-    ensureGroupPath,
-    getAncestorGroupIds,
     reconcileNode,
 } from '@ripl/dom';
 
@@ -523,6 +522,8 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         element: SVGElement; }>;
     private _clipStack: (string | undefined)[];
     private _currentClipId: string | undefined;
+    private _currentParentVNode: SVGVNode;
+    private _vnodeStack: SVGVNode[];
 
     constructor(target: string | HTMLElement, options?: ContextOptions) {
         const svg = createSVGElement('svg');
@@ -534,11 +535,16 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         super('svg', target, svg, options);
 
         this.buffer = true;
+        // SVG hit testing runs against the live DOM geometry, which already composes ancestor
+        // <g> transforms, so no manual local-space point mapping is needed.
+        this.hitTestHonoursTransform = true;
         this._vtree = {
             id: '__root__',
             tag: 'svg',
             children: [],
         };
+        this._currentParentVNode = this._vtree;
+        this._vnodeStack = [];
 
         this._reconcilerOptions = {
             createElement: (tag, id) => {
@@ -661,11 +667,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     }
 
     private _addToVTree(contextElement: SVGContextElement): void {
-        const renderElement = this.currentRenderElement;
-        const groupIds = renderElement ? getAncestorGroupIds(renderElement) : [];
-        const parent = ensureGroupPath(this._vtree, groupIds);
-
-        parent.children.push({
+        this._currentParentVNode.children.push({
             id: contextElement.id,
             tag: contextElement.definition.tag,
             element: contextElement,
@@ -674,13 +676,10 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     }
 
     private _removeFromVTree(id: string): void {
-        const renderElement = this.currentRenderElement;
-        const groupIds = renderElement ? getAncestorGroupIds(renderElement) : [];
-        const parent = ensureGroupPath(this._vtree, groupIds);
-        const index = parent.children.findIndex(c => c.id === id);
+        const index = this._currentParentVNode.children.findIndex(c => c.id === id);
 
         if (index !== -1) {
-            parent.children.splice(index, 1);
+            this._currentParentVNode.children.splice(index, 1);
         }
     }
 
@@ -688,7 +687,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         reconcileNode(this.element, this._vtree, this._domCache, this._reconcilerOptions);
     }
 
-    /** Signals the start of a render pass; resets the virtual DOM tree at the outermost depth. */
+    /** Signals the start of a render pass; resets the virtual DOM tree and group-nesting pointer at the outermost depth. */
     public markRenderStart(): void {
         if (this.renderDepth === 0) {
             this._vtree = {
@@ -696,6 +695,8 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
                 tag: 'svg',
                 children: [],
             };
+            this._currentParentVNode = this._vtree;
+            this._vnodeStack = [];
         }
 
         super.markRenderStart();
@@ -746,9 +747,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     /** Creates a new {@link SVGText} element from the given options, wiring up text-on-a-path when path data is supplied. */
     public createText(options: TextOptions): ContextText {
         const text = new SVGText(options);
-        const renderElement = this.currentRenderElement;
-        const groupIds = renderElement ? getAncestorGroupIds(renderElement) : [];
-        const parent = ensureGroupPath(this._vtree, groupIds);
+        const parent = this._currentParentVNode;
 
         const textNode: SVGVNode = {
             id: text.id,
@@ -813,6 +812,51 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         });
 
         this._addToVTree(svgImage);
+    }
+
+    /**
+     * Opens a group boundary as a nested `<g>` element: descends the reconciliation pointer
+     * into a `<g>` keyed by the group's id and stamps the group's own transform onto it, so
+     * descendants nest under the `<g>` and inherit the group transform via SVG's native
+     * cascade. Resets the accumulated transform afterwards so leaves carry only their own
+     * transform (avoiding a double application of the group transform).
+     */
+    public pushGroup(group: RiplElement): void {
+        const groupElement: SVGContextElement = {
+            id: group.id,
+            definition: {
+                tag: 'g',
+                styles: {},
+                attributes: {},
+            },
+        };
+
+        const groupVNode: SVGVNode = {
+            id: group.id,
+            tag: 'g',
+            element: groupElement,
+            children: [],
+        };
+
+        this._currentParentVNode.children.push(groupVNode);
+        this._vnodeStack.push(this._currentParentVNode);
+        this._currentParentVNode = groupVNode;
+
+        super.pushGroup(group);
+
+        const transform = this._currentTransforms.join(' ');
+
+        if (transform) {
+            groupElement.definition.attributes.transform = transform;
+        }
+
+        this._currentTransforms = [];
+    }
+
+    /** Closes the most recently opened group boundary, restoring state and ascending the `<g>` pointer. */
+    public popGroup(): void {
+        super.popGroup();
+        this._currentParentVNode = this._vnodeStack.pop() ?? this._vtree;
     }
 
     /** Saves the current drawing state, transform, and clip onto their stacks. */

--- a/packages/svg/test/index.test.ts
+++ b/packages/svg/test/index.test.ts
@@ -23,6 +23,10 @@ import {
     mockCanvasContext,
 } from '@ripl/test-utils';
 
+import {
+    createGroup,
+} from '@ripl/core';
+
 describe('SVG', () => {
 
     // ── SVGPath ──────────────────────────────────────────────────
@@ -562,6 +566,83 @@ describe('SVG', () => {
             // We can't easily inspect vtree directly, but we can verify the context works
             expect(ctx.element).toBeDefined();
 
+            ctx.destroy();
+        });
+
+        // ── Group boundaries (pushGroup / popGroup) ──────────────
+
+        test('pushGroup stamps the group transform on a <g>, not on the leaf', () => {
+            const ctx = create();
+            const group = createGroup({});
+            group.translateX = 50;
+
+            ctx.markRenderStart();
+            ctx.pushGroup(group);
+            const leaf = ctx.createPath('leaf');
+            ctx.applyFill(leaf);
+            ctx.popGroup();
+            ctx.markRenderEnd();
+
+            // The leaf must NOT carry the group transform (it is supplied once by the <g>).
+            expect(leaf.definition.attributes.transform).toBeUndefined();
+
+            // Force a synchronous reconcile and inspect the DOM.
+            ctx.export();
+
+            const groupEl = ctx.element.querySelector('g');
+            expect(groupEl).not.toBeNull();
+            expect(groupEl?.getAttribute('id')).toBe(group.id);
+            expect(groupEl?.getAttribute('transform')).toContain('translate(50,0)');
+            expect(groupEl?.querySelector('path')).not.toBeNull();
+
+            ctx.destroy();
+        });
+
+        test('a leaf keeps only its own transform under a transformed group', () => {
+            const ctx = create();
+            const group = createGroup({});
+            group.translateX = 50;
+
+            ctx.markRenderStart();
+            ctx.pushGroup(group);
+            ctx.translate(5, 0); // the leaf's own transform
+            const leaf = ctx.createPath('leaf');
+            ctx.applyFill(leaf);
+            ctx.popGroup();
+            ctx.markRenderEnd();
+
+            // Only the leaf's own translate — the group's translate lives on the <g>.
+            expect(leaf.definition.attributes.transform).toBe('translate(5,0)');
+
+            ctx.destroy();
+        });
+
+        test('a group-scoped clip does not leak past the group boundary', () => {
+            const ctx = create();
+            const group = createGroup({});
+
+            ctx.markRenderStart();
+            ctx.pushGroup(group);
+
+            // Simulate a clip child: it saves, installs a clip, and (like a real clip element)
+            // deliberately does not restore, so the clip applies to later siblings in the group.
+            ctx.save();
+            const clipPath = ctx.createPath('clip');
+            clipPath.rect(0, 0, 10, 10);
+            ctx.applyClip(clipPath);
+
+            const inside = ctx.createPath('inside');
+            ctx.applyFill(inside);
+            expect(inside.definition.attributes['clip-path']).toBeDefined();
+
+            ctx.popGroup();
+
+            // After the boundary, the dangling clip save is unwound — later elements are unclipped.
+            const outside = ctx.createPath('outside');
+            ctx.applyFill(outside);
+            expect(outside.definition.attributes['clip-path']).toBeUndefined();
+
+            ctx.markRenderEnd();
             ctx.destroy();
         });
 


### PR DESCRIPTION
## Summary

This change introduces a structured render instruction stream to the Scene that respects CSS stacking-context semantics, replacing the flat z-index-sorted buffer. It also adds matrix utilities and world transform computation for accurate hit testing on transformed elements.

## Key Changes

- **Render instruction stream**: Scene now generates a flat `push`/`draw`/`pop` instruction stream that brackets groups, ensuring children cannot escape their parent group's z-order. This replaces the previous flat buffer approach and properly implements stacking-context ordering.

- **Matrix math utilities** (`packages/core/src/math/matrix.ts`): New module providing 2D affine transformation matrices with operations for translate, scale, rotate, multiply, invert, and point transformation. Used internally for world transform computation and hit testing.

- **World transform computation** (`getWorldTransform`): New function that reconstructs an element's composed transform by walking up the ancestor chain, enabling accurate hit testing on canvas and other backends that don't natively account for element transforms.

- **Group boundaries in rendering**: 
  - Added `pushGroup`/`popGroup` methods to Context for opening/closing group boundaries
  - Scene.render() now processes the instruction stream, calling `pushGroup` on entry and `popGroup` on exit
  - Groups apply their transform and any group-scoped clip within the boundary
  - Renderer advances transitions at group boundaries and respects the instruction stream

- **Transform target abstraction** (`TransformTarget`): New interface allowing transforms to be applied to either a Context or a matrix accumulator, decoupling transform application from rendering.

- **SVG group nesting**: SVGContext now maintains a vnode stack to properly nest group elements in the virtual DOM, replacing the previous `ensureGroupPath` approach. Group transforms are applied to `<g>` elements rather than leaves.

- **Hit testing improvements**: Shape2D now maps hit points into local space when the context doesn't natively honour transforms, using the computed world transform.

## Notable Implementation Details

- Sibling sorting by z-index is stable, preserving insertion order for equal-z-index elements
- The identity transform case (no transforms in the chain) returns `null` from `getWorldTransform` to skip unnecessary point remapping
- Scene's `_rebuffer()` is debounced to once per frame via `requestAnimationFrame` when z-index changes
- SVG's group nesting is now driven by the instruction stream rather than ancestor traversal, simplifying the vnode construction logic

https://claude.ai/code/session_01VdPBehCPZeP7kuGjcJUimb