### PR TITLE
Group-targetable transitions, own-only cascade, transform-aware bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Every element follows this exact pattern:
 1. **State interface** extending `BaseElementState`
 2. **Class** extending `Shape<TState>` with getter/setter pairs using `getStateValue`/`setStateValue`
 3. **Constructor** calling `super(type, options)` with a string type name
-4. **`getBoundingBox()`** returning a `Box` instance
+4. **`_getLocalBoundingBox()`** returning the element's raw (untransformed) local-space `Box` — the base `Element` composes the public `getBoundingBox(local?)` (world box by default, local when `local` is `true`) from it
 5. **`render(context)`** calling `super.render(context, path => { ... })`
 6. **Factory function** `createX()`
 7. **Type guard** `elementIsX()`
@@ -116,7 +116,7 @@ export class Circle extends Shape<CircleState> {
         super('circle', options);
     }
 
-    public getBoundingBox(): Box {
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radius,
             this.cx - this.radius,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Every built-in element follows this pattern:
 1. **State interface** extending `BaseElementState`
 2. **Class** extending `Shape<TState>` with getter/setter pairs via `getStateValue`/`setStateValue`
 3. **Constructor** calling `super(type, options)`
-4. **`getBoundingBox()`** returning a `Box`
+4. **`_getLocalBoundingBox()`** returning the element's raw local-space `Box` (the base composes the public `getBoundingBox(local?)` from it)
 5. **`render(context)`** calling `super.render(context, path => { ... })`
 6. **Factory function** — `createX()`
 7. **Type guard** — `elementIsX()`

--- a/app/src/.vitepress/components/example-3d-webgpu.vue
+++ b/app/src/.vitepress/components/example-3d-webgpu.vue
@@ -17,9 +17,9 @@
 
 <script lang="ts" setup>
 import {
+    onUnmounted,
     ref,
     watchEffect,
-    onUnmounted,
 } from 'vue';
 
 import {
@@ -46,13 +46,13 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
             reason => {
                 clearTimeout(timer);
                 reject(reason);
-            },
+            }
         );
     });
 }
 
 const emit = defineEmits<{
-    'context-changed': [context: Context3D]
+    'context-changed': [context: Context3D];
 }>();
 
 const root = ref<HTMLElement>();
@@ -68,11 +68,11 @@ watchEffect(async () => {
                     clearColor: [0.05, 0.05, 0.1, 1],
                 }),
                 WEBGPU_TIMEOUT_MS,
-                'WebGPU initialisation timed out.',
+                'WebGPU initialisation timed out.'
             );
 
             emit('context-changed', context);
-        } catch (e) {
+        } catch {
             if (root.value) {
                 root.value.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--vp-c-text-2);font-size:14px;padding:2rem;text-align:center;">WebGPU is not supported in this browser. Try Chrome 113+ or Edge 113+.</div>';
             }

--- a/app/src/.vitepress/components/example-3d.vue
+++ b/app/src/.vitepress/components/example-3d.vue
@@ -63,13 +63,13 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
             reason => {
                 clearTimeout(timer);
                 reject(reason);
-            },
+            }
         );
     });
 }
 
 const emit = defineEmits<{
-    'context-changed': [context: Context3D]
+    'context-changed': [context: Context3D];
 }>();
 
 const type = ref<ContextType>('canvas');
@@ -110,7 +110,7 @@ async function updateContext([element, currentType]: [HTMLElement | undefined, C
         const created = await withTimeout(
             createWebGPUContext(element),
             WEBGPU_TIMEOUT_MS,
-            'WebGPU initialisation timed out.',
+            'WebGPU initialisation timed out.'
         );
 
         if (token !== generation) {

--- a/app/src/.vitepress/components/example-terminal-interactive.vue
+++ b/app/src/.vitepress/components/example-terminal-interactive.vue
@@ -218,23 +218,66 @@ function runLineChart(ctx: TerminalContext) {
 
     createLineChart(ctx, {
         data: [
-            { day: 'Mon', high: 24, low: 14 },
-            { day: 'Tue', high: 27, low: 16 },
-            { day: 'Wed', high: 22, low: 12 },
-            { day: 'Thu', high: 29, low: 18 },
-            { day: 'Fri', high: 31, low: 20 },
-            { day: 'Sat', high: 26, low: 15 },
-            { day: 'Sun', high: 23, low: 13 },
+            {
+                day: 'Mon',
+                high: 24,
+                low: 14,
+            },
+            {
+                day: 'Tue',
+                high: 27,
+                low: 16,
+            },
+            {
+                day: 'Wed',
+                high: 22,
+                low: 12,
+            },
+            {
+                day: 'Thu',
+                high: 29,
+                low: 18,
+            },
+            {
+                day: 'Fri',
+                high: 31,
+                low: 20,
+            },
+            {
+                day: 'Sat',
+                high: 26,
+                low: 15,
+            },
+            {
+                day: 'Sun',
+                high: 23,
+                low: 13,
+            },
         ],
         key: 'day',
         series: [
-            { id: 'high', label: 'High', value: 'high', markers: true },
-            { id: 'low', label: 'Low', value: 'low', markers: true },
+            {
+                id: 'high',
+                label: 'High',
+                value: 'high',
+                markers: true,
+            },
+            {
+                id: 'low',
+                label: 'Low',
+                value: 'low',
+                markers: true,
+            },
         ],
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
+        padding: {
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+        },
     });
 }
 
@@ -243,23 +286,64 @@ function runBarChart(ctx: TerminalContext) {
 
     createBarChart(ctx, {
         data: [
-            { day: 'Mon', sales: 42, returns: 8 },
-            { day: 'Tue', sales: 78, returns: 12 },
-            { day: 'Wed', sales: 55, returns: 5 },
-            { day: 'Thu', sales: 91, returns: 15 },
-            { day: 'Fri', sales: 63, returns: 9 },
-            { day: 'Sat', sales: 35, returns: 4 },
-            { day: 'Sun', sales: 48, returns: 7 },
+            {
+                day: 'Mon',
+                sales: 42,
+                returns: 8,
+            },
+            {
+                day: 'Tue',
+                sales: 78,
+                returns: 12,
+            },
+            {
+                day: 'Wed',
+                sales: 55,
+                returns: 5,
+            },
+            {
+                day: 'Thu',
+                sales: 91,
+                returns: 15,
+            },
+            {
+                day: 'Fri',
+                sales: 63,
+                returns: 9,
+            },
+            {
+                day: 'Sat',
+                sales: 35,
+                returns: 4,
+            },
+            {
+                day: 'Sun',
+                sales: 48,
+                returns: 7,
+            },
         ],
         key: 'day',
         series: [
-            { id: 'sales', label: 'Sales', value: 'sales' },
-            { id: 'returns', label: 'Returns', value: 'returns' },
+            {
+                id: 'sales',
+                label: 'Sales',
+                value: 'sales',
+            },
+            {
+                id: 'returns',
+                label: 'Returns',
+                value: 'returns',
+            },
         ],
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
+        padding: {
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+        },
     });
 }
 
@@ -268,14 +352,70 @@ function runStockChart(ctx: TerminalContext) {
 
     createStockChart(ctx, {
         data: [
-            { date: 'Mar 3', open: 171, high: 175, low: 169, close: 174, vol: 48000 },
-            { date: 'Mar 4', open: 174, high: 178, low: 172, close: 176, vol: 52000 },
-            { date: 'Mar 5', open: 176, high: 180, low: 174, close: 178, vol: 61000 },
-            { date: 'Mar 6', open: 178, high: 179, low: 170, close: 172, vol: 73000 },
-            { date: 'Mar 7', open: 172, high: 174, low: 168, close: 170, vol: 65000 },
-            { date: 'Mar 10', open: 170, high: 176, low: 169, close: 175, vol: 58000 },
-            { date: 'Mar 11', open: 175, high: 182, low: 174, close: 181, vol: 71000 },
-            { date: 'Mar 12', open: 181, high: 185, low: 179, close: 183, vol: 67000 },
+            {
+                date: 'Mar 3',
+                open: 171,
+                high: 175,
+                low: 169,
+                close: 174,
+                vol: 48000,
+            },
+            {
+                date: 'Mar 4',
+                open: 174,
+                high: 178,
+                low: 172,
+                close: 176,
+                vol: 52000,
+            },
+            {
+                date: 'Mar 5',
+                open: 176,
+                high: 180,
+                low: 174,
+                close: 178,
+                vol: 61000,
+            },
+            {
+                date: 'Mar 6',
+                open: 178,
+                high: 179,
+                low: 170,
+                close: 172,
+                vol: 73000,
+            },
+            {
+                date: 'Mar 7',
+                open: 172,
+                high: 174,
+                low: 168,
+                close: 170,
+                vol: 65000,
+            },
+            {
+                date: 'Mar 10',
+                open: 170,
+                high: 176,
+                low: 169,
+                close: 175,
+                vol: 58000,
+            },
+            {
+                date: 'Mar 11',
+                open: 175,
+                high: 182,
+                low: 174,
+                close: 181,
+                vol: 71000,
+            },
+            {
+                date: 'Mar 12',
+                open: 181,
+                high: 185,
+                low: 179,
+                close: 183,
+                vol: 67000,
+            },
         ],
         key: 'date',
         open: 'open',
@@ -287,7 +427,12 @@ function runStockChart(ctx: TerminalContext) {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
+        padding: {
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+        },
     });
 }
 
@@ -303,11 +448,41 @@ function runGanttChart(ctx: TerminalContext) {
 
     createGanttChart(ctx, {
         data: [
-            { id: '1', task: 'Research', start: day(-5), end: day(-1), progress: 1 },
-            { id: '2', task: 'Design', start: day(-2), end: day(3), progress: 0.6 },
-            { id: '3', task: 'Develop', start: day(1), end: day(10), progress: 0.2 },
-            { id: '4', task: 'Testing', start: day(8), end: day(14), progress: 0 },
-            { id: '5', task: 'Deploy', start: day(13), end: day(16), progress: 0 },
+            {
+                id: '1',
+                task: 'Research',
+                start: day(-5),
+                end: day(-1),
+                progress: 1,
+            },
+            {
+                id: '2',
+                task: 'Design',
+                start: day(-2),
+                end: day(3),
+                progress: 0.6,
+            },
+            {
+                id: '3',
+                task: 'Develop',
+                start: day(1),
+                end: day(10),
+                progress: 0.2,
+            },
+            {
+                id: '4',
+                task: 'Testing',
+                start: day(8),
+                end: day(14),
+                progress: 0,
+            },
+            {
+                id: '5',
+                task: 'Deploy',
+                start: day(13),
+                end: day(16),
+                progress: 0,
+            },
         ],
         key: 'id',
         label: 'task',
@@ -316,7 +491,12 @@ function runGanttChart(ctx: TerminalContext) {
         progress: 'progress',
         tooltip: false,
         animation: { duration: 2000 },
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
+        padding: {
+            top: 10,
+            right: 10,
+            bottom: 10,
+            left: 10,
+        },
     });
 }
 
@@ -420,7 +600,8 @@ function rebuildContext() {
             return state.rows;
         },
         onResize(callback: (c: number, r: number) => void) {
-            const disposable = term.onResize(({ cols: nc, rows: nr }: { cols: number; rows: number }) => callback(nc, nr));
+            const disposable = term.onResize(({ cols: nc, rows: nr }: { cols: number;
+                rows: number; }) => callback(nc, nr));
             return () => disposable.dispose();
         },
     };

--- a/app/src/.vitepress/components/example-terminal.vue
+++ b/app/src/.vitepress/components/example-terminal.vue
@@ -81,7 +81,8 @@ onMounted(async () => {
             return state.rows;
         },
         onResize(callback: (c: number, r: number) => void) {
-            const disposable = term.onResize(({ cols: nc, rows: nr }: { cols: number; rows: number }) => callback(nc, nr));
+            const disposable = term.onResize(({ cols: nc, rows: nr }: { cols: number;
+                rows: number; }) => callback(nc, nr));
 
             return () => disposable.dispose();
         },

--- a/app/src/.vitepress/components/example.vue
+++ b/app/src/.vitepress/components/example.vue
@@ -50,8 +50,11 @@ import RiplConfigDrawer from './ripl-config-drawer.vue';
 import RiplExportButton from './ripl-export-button.vue';
 import RiplSpinner from './ripl-spinner.vue';
 
-import {
+import type {
     Context,
+} from '@ripl/web';
+
+import {
     createContext as createCanvasContext,
 } from '@ripl/web';
 
@@ -75,8 +78,8 @@ const CONTEXT_MAP = {
 } as Record<'canvas' | 'svg', typeof createCanvasContext | typeof createSVGContext>;
 
 const emit = defineEmits<{
-    'ready': [context: Context]
-    'context-changed': [context: Context]
+    'ready': [context: Context];
+    'context-changed': [context: Context];
 }>();
 
 const type = ref<ContextType>('canvas');
@@ -91,7 +94,8 @@ let terminalDispose: (() => void) | undefined;
 let generation = 0;
 
 /** Loads xterm.js, mounts it into the demo root, and builds a Ripl terminal context bound to it. */
-async function createTerminal(element: HTMLElement): Promise<{ context: Context; dispose: () => void }> {
+async function createTerminal(element: HTMLElement): Promise<{ context: Context;
+    dispose: () => void; }> {
     const [{ Terminal }, { FitAddon }] = await Promise.all([
         import('@xterm/xterm'),
         import('@xterm/addon-fit'),

--- a/app/src/.vitepress/components/playground/playground-editor.vue
+++ b/app/src/.vitepress/components/playground/playground-editor.vue
@@ -46,11 +46,11 @@
 
 <script lang="ts" setup>
 import {
-    ref,
-    onMounted,
     onBeforeUnmount,
-    watch,
+    onMounted,
+    ref,
     shallowRef,
+    watch,
 } from 'vue';
 
 import {
@@ -103,7 +103,8 @@ const emit = defineEmits<{
     'update:mode': [value: PlaygroundMode];
     'update:importMap': [value: Record<string, string>];
     'reset': [];
-    'load-example': [example: { mode: PlaygroundMode; code: string }];
+    'load-example': [example: { mode: PlaygroundMode;
+        code: string; }];
 }>();
 
 const activeTab = ref<EditorTab>('code');
@@ -115,15 +116,19 @@ const editorInstance = shallowRef<any>();
 const importMapEditorInstance = shallowRef<any>();
 const typeLibDisposables = new Map<string, { dispose: () => void }>();
 
-const examples2d = EXAMPLES.filter(e => e.mode === '2d');
-const examples3d = EXAMPLES.filter(e => e.mode === '3d');
+const examples2d = EXAMPLES.filter(example => example.mode === '2d');
+const examples3d = EXAMPLES.filter(example => example.mode === '3d');
 
 const { isDark } = useData();
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- the whole lazily-imported module type has no top-level `import type` equivalent
 let monacoModule: typeof import('monaco-editor') | null = null;
 
 function loadExample(example: PlaygroundExample) {
-    emit('load-example', { mode: example.mode, code: example.code });
+    emit('load-example', {
+        mode: example.mode,
+        code: example.code,
+    });
     examplesDropdown.value?.close();
 }
 
@@ -286,6 +291,7 @@ async function initMonaco() {
     });
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- the whole lazily-imported module type has no top-level `import type` equivalent
 function initImportMapEditor(monaco: typeof import('monaco-editor')) {
     if (!importMapContainer.value) {
         return;

--- a/app/src/.vitepress/components/playground/playground-preview.vue
+++ b/app/src/.vitepress/components/playground/playground-preview.vue
@@ -73,10 +73,10 @@
 
 <script lang="ts" setup>
 import {
+    onBeforeUnmount,
+    onMounted,
     ref,
     watch,
-    onMounted,
-    onBeforeUnmount,
 } from 'vue';
 
 import {
@@ -114,7 +114,10 @@ const error = ref('');
 const settingsDropdown = ref<InstanceType<typeof RiplDropdown>>();
 
 function updateSetting<K extends keyof PlaygroundSettings>(key: K, value: PlaygroundSettings[K]) {
-    emit('update:settings', { ...props.settings, [key]: value });
+    emit('update:settings', {
+        ...props.settings,
+        [key]: value,
+    });
 }
 
 watch(() => props.srcdoc, () => {

--- a/app/src/.vitepress/components/playground/ripl-playground.vue
+++ b/app/src/.vitepress/components/playground/ripl-playground.vue
@@ -29,10 +29,10 @@
 
 <script lang="ts" setup>
 import {
+    onBeforeUnmount,
+    onMounted,
     ref,
     watch,
-    onMounted,
-    onBeforeUnmount,
 } from 'vue';
 
 import {
@@ -44,8 +44,8 @@ import PlaygroundPreview from './playground-preview.vue';
 
 import {
     buildSrcdoc,
-    encodeState,
     decodeState,
+    encodeState,
 } from './sandbox';
 
 import {
@@ -53,8 +53,8 @@ import {
 } from './examples';
 
 import type {
-    PlaygroundMode,
     ContextType,
+    PlaygroundMode,
     PlaygroundSettings,
     PlaygroundState,
 } from './sandbox';
@@ -82,7 +82,7 @@ let manifestKeys = new Set<string>();
 let pendingState: PlaygroundState | null = null;
 
 function getDefaultCode(m: PlaygroundMode): string {
-    return EXAMPLES.find(e => e.mode === m)!.code;
+    return EXAMPLES.find(example => example.mode === m)!.code;
 }
 
 function loadStateFromHash(): PlaygroundState | null {
@@ -174,7 +174,8 @@ watch(mode, (newMode) => {
     debouncedSave();
 });
 
-function onLoadExample(example: { mode: string; code: string }) {
+function onLoadExample(example: { mode: string;
+    code: string; }) {
     loadingExample = true;
     mode.value = example.mode as PlaygroundMode;
     code.value = example.code;

--- a/app/src/.vitepress/components/ripl-dropdown.vue
+++ b/app/src/.vitepress/components/ripl-dropdown.vue
@@ -18,11 +18,11 @@
 
 <script lang="ts" setup>
 import {
-    ref,
     computed,
-    onMounted,
-    onBeforeUnmount,
     nextTick,
+    onBeforeUnmount,
+    onMounted,
+    ref,
 } from 'vue';
 
 export type DropdownAlign = 'left' | 'right';

--- a/app/src/.vitepress/components/ripple-background.vue
+++ b/app/src/.vitepress/components/ripple-background.vue
@@ -4,8 +4,8 @@
 
 <script lang="ts" setup>
 import {
-    onMounted,
     onBeforeUnmount,
+    onMounted,
     ref,
 } from 'vue';
 
@@ -14,12 +14,13 @@ import {
     createContext,
     createRenderer,
     createScene,
-    Scene,
 } from '@ripl/web';
 
 import type {
     Circle,
     Renderer,
+
+    Scene,
 } from '@ripl/web';
 
 const container = ref<HTMLElement>();

--- a/app/src/demos/freeform-drawing/components/tool-bar.vue
+++ b/app/src/demos/freeform-drawing/components/tool-bar.vue
@@ -25,8 +25,8 @@ import {
     Highlighter,
     Minus,
     MousePointer2,
-    PenTool,
     Pencil,
+    PenTool,
     Spline,
     Square,
     Type,
@@ -52,17 +52,72 @@ defineEmits<{
 }>();
 
 const tools: ToolButton[] = [
-    { id: 'select', label: 'Select', key: 'V', icon: MousePointer2 },
-    { id: 'hand', label: 'Pan', key: 'H', icon: Hand },
-    { id: 'pencil', label: 'Pencil', key: 'P', icon: Pencil },
-    { id: 'pen', label: 'Pen', key: 'N', icon: PenTool },
-    { id: 'highlighter', label: 'Highlighter', key: 'I', icon: Highlighter },
-    { id: 'rect', label: 'Rectangle', key: 'R', icon: Square },
-    { id: 'ellipse', label: 'Ellipse', key: 'O', icon: Circle },
-    { id: 'line', label: 'Line', key: 'L', icon: Minus },
-    { id: 'connector', label: 'Connector', key: 'C', icon: Spline },
-    { id: 'text', label: 'Text', key: 'T', icon: Type },
-    { id: 'eraser', label: 'Eraser', key: 'E', icon: Eraser },
+    {
+        id: 'select',
+        label: 'Select',
+        key: 'V',
+        icon: MousePointer2,
+    },
+    {
+        id: 'hand',
+        label: 'Pan',
+        key: 'H',
+        icon: Hand,
+    },
+    {
+        id: 'pencil',
+        label: 'Pencil',
+        key: 'P',
+        icon: Pencil,
+    },
+    {
+        id: 'pen',
+        label: 'Pen',
+        key: 'N',
+        icon: PenTool,
+    },
+    {
+        id: 'highlighter',
+        label: 'Highlighter',
+        key: 'I',
+        icon: Highlighter,
+    },
+    {
+        id: 'rect',
+        label: 'Rectangle',
+        key: 'R',
+        icon: Square,
+    },
+    {
+        id: 'ellipse',
+        label: 'Ellipse',
+        key: 'O',
+        icon: Circle,
+    },
+    {
+        id: 'line',
+        label: 'Line',
+        key: 'L',
+        icon: Minus,
+    },
+    {
+        id: 'connector',
+        label: 'Connector',
+        key: 'C',
+        icon: Spline,
+    },
+    {
+        id: 'text',
+        label: 'Text',
+        key: 'T',
+        icon: Type,
+    },
+    {
+        id: 'eraser',
+        label: 'Eraser',
+        key: 'E',
+        icon: Eraser,
+    },
 ];
 </script>
 

--- a/app/src/demos/jet-engine-webgpu/jet-engine-webgpu.vue
+++ b/app/src/demos/jet-engine-webgpu/jet-engine-webgpu.vue
@@ -42,11 +42,11 @@
 
 <script lang="ts" setup>
 import {
-    ref,
-    reactive,
     computed,
     onMounted,
     onUnmounted,
+    reactive,
+    ref,
 } from 'vue';
 
 import RiplSwitch from '../../.vitepress/components/ripl-switch.vue';
@@ -56,8 +56,8 @@ import {
 } from '@ripl/3d';
 
 import {
-    createScene,
     createRenderer,
+    createScene,
     easeInOutCubic,
 } from '@ripl/web';
 
@@ -70,8 +70,8 @@ import type {
 } from '@ripl/webgpu';
 
 import type {
-    Scene,
     Renderer,
+    Scene,
 } from '@ripl/web';
 
 import type {
@@ -79,15 +79,15 @@ import type {
 } from '@ripl/3d';
 
 import {
+    createCentralShaft,
+    createCombustionChamber,
+    createExhaustNozzle,
     createFan,
     createFanCase,
-    createLPCompressor,
     createHPCompressor,
-    createCombustionChamber,
     createHPTurbine,
+    createLPCompressor,
     createLPTurbine,
-    createExhaustNozzle,
-    createCentralShaft,
 } from '../jet-engine/elements';
 
 const DEFAULT_COLOR = '#C8C8C8';
@@ -113,23 +113,23 @@ const PASTEL_COLORS = [
 
 // Exploded offsets along z-axis (front to back)
 const EXPLODED_OFFSETS = [
-    1.8,   // Fan
-    1.8,   // Fan Case
-    1.0,   // LP Compressor
-    0.3,   // HP Compressor
+    1.8, // Fan
+    1.8, // Fan Case
+    1.0, // LP Compressor
+    0.3, // HP Compressor
     -0.35, // Combustion Chamber
     -0.95, // HP Turbine
     -1.35, // LP Turbine
     -1.85, // Exhaust Nozzle
-    -0.1,  // Central Shaft (centered)
+    -0.1, // Central Shaft (centered)
 ];
 
 // Assembled offsets — parts packed together along shaft
 const ASSEMBLED_OFFSETS = [
-    0.55,  // Fan
-    0.55,  // Fan Case
-    0.30,  // LP Compressor
-    0.05,  // HP Compressor
+    0.55, // Fan
+    0.55, // Fan Case
+    0.30, // LP Compressor
+    0.05, // HP Compressor
     -0.25, // Combustion Chamber
     -0.55, // HP Turbine
     -0.70, // LP Turbine
@@ -165,7 +165,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promi
             reason => {
                 clearTimeout(timer);
                 reject(reason);
-            },
+            }
         );
     });
 }
@@ -178,7 +178,10 @@ const hoveredPart = ref<string | null>(null);
 const rotating = ref(true);
 const exploded = ref(true);
 const supported = ref(true);
-const mousePos = reactive({ x: 0, y: 0 });
+const mousePos = reactive({
+    x: 0,
+    y: 0,
+});
 
 const tooltipStyle = computed(() => ({
     left: `${mousePos.x + 16}px`,
@@ -192,7 +195,9 @@ const partEntries = reactive<PartEntry[]>([]);
 
 function createParts(): PartEntry[] {
     const offsets = exploded.value ? EXPLODED_OFFSETS : ASSEMBLED_OFFSETS;
-    const parts: { name: string; element: Shape3D; hoverColor: string }[] = [
+    const parts: { name: string;
+        element: Shape3D;
+        hoverColor: string; }[] = [
         {
             name: 'Fan',
             element: createFan({
@@ -314,7 +319,7 @@ onMounted(async () => {
         context = await withTimeout(
             createContext(viewport.value),
             WEBGPU_TIMEOUT_MS,
-            'WebGPU initialisation timed out.',
+            'WebGPU initialisation timed out.'
         );
     } catch {
         supported.value = false;
@@ -359,8 +364,8 @@ onMounted(async () => {
         autoStart: true,
         autoStop: false,
         debug: {
-            fps: true
-        }
+            fps: true,
+        },
     });
 
     renderer.on('tick', (event) => {

--- a/app/src/demos/jet-engine/jet-engine.vue
+++ b/app/src/demos/jet-engine/jet-engine.vue
@@ -35,11 +35,11 @@
 
 <script lang="ts" setup>
 import {
-    ref,
-    reactive,
     computed,
     onMounted,
     onUnmounted,
+    reactive,
+    ref,
 } from 'vue';
 
 import RiplSwitch from '../../.vitepress/components/ripl-switch.vue';
@@ -50,8 +50,8 @@ import {
 } from '@ripl/3d';
 
 import {
-    createScene,
     createRenderer,
+    createScene,
     easeInOutCubic,
 } from '@ripl/web';
 
@@ -60,8 +60,8 @@ import type {
 } from '@ripl/3d';
 
 import type {
-    Scene,
     Renderer,
+    Scene,
 } from '@ripl/web';
 
 import type {
@@ -69,15 +69,15 @@ import type {
 } from '@ripl/3d';
 
 import {
+    createCentralShaft,
+    createCombustionChamber,
+    createExhaustNozzle,
     createFan,
     createFanCase,
-    createLPCompressor,
     createHPCompressor,
-    createCombustionChamber,
     createHPTurbine,
+    createLPCompressor,
     createLPTurbine,
-    createExhaustNozzle,
-    createCentralShaft,
 } from './elements';
 
 const DEFAULT_COLOR = '#C8C8C8';
@@ -105,23 +105,23 @@ const PASTEL_COLORS = [
 
 // Exploded offsets along z-axis (front to back)
 const EXPLODED_OFFSETS = [
-    1.8,   // Fan
-    1.8,   // Fan Case
-    1.0,   // LP Compressor
-    0.3,   // HP Compressor
+    1.8, // Fan
+    1.8, // Fan Case
+    1.0, // LP Compressor
+    0.3, // HP Compressor
     -0.35, // Combustion Chamber
     -0.95, // HP Turbine
     -1.35, // LP Turbine
     -1.85, // Exhaust Nozzle
-    -0.1,  // Central Shaft (centered)
+    -0.1, // Central Shaft (centered)
 ];
 
 // Assembled offsets — parts packed together along shaft
 const ASSEMBLED_OFFSETS = [
-    0.55,  // Fan
-    0.55,  // Fan Case
-    0.30,  // LP Compressor
-    0.05,  // HP Compressor
+    0.55, // Fan
+    0.55, // Fan Case
+    0.30, // LP Compressor
+    0.05, // HP Compressor
     -0.25, // Combustion Chamber
     -0.55, // HP Turbine
     -0.70, // LP Turbine
@@ -148,7 +148,10 @@ const viewport = ref<HTMLElement>();
 const hoveredPart = ref<string | null>(null);
 const rotating = ref(true);
 const exploded = ref(true);
-const mousePos = reactive({ x: 0, y: 0 });
+const mousePos = reactive({
+    x: 0,
+    y: 0,
+});
 
 const tooltipStyle = computed(() => ({
     left: `${mousePos.x + 16}px`,
@@ -162,7 +165,9 @@ const partEntries = reactive<PartEntry[]>([]);
 
 function createParts(): PartEntry[] {
     const offsets = exploded.value ? EXPLODED_OFFSETS : ASSEMBLED_OFFSETS;
-    const parts: { name: string; element: Shape3D; hoverColor: string }[] = [
+    const parts: { name: string;
+        element: Shape3D;
+        hoverColor: string; }[] = [
         {
             name: 'Fan',
             element: createFan({
@@ -331,8 +336,8 @@ onMounted(() => {
         autoStart: true,
         autoStop: false,
         debug: {
-            fps: true
-        }
+            fps: true,
+        },
     });
 
     renderer.on('tick', (event) => {

--- a/app/src/demos/mermaid-diagram/mermaid-diagram.vue
+++ b/app/src/demos/mermaid-diagram/mermaid-diagram.vue
@@ -21,25 +21,34 @@
 
 <script lang="ts" setup>
 import {
-    ref,
     onMounted,
     onUnmounted,
+    ref,
 } from 'vue';
 
 import {
     createContext,
-    createScene,
     createRenderer,
-    Scene,
+    createScene,
 } from '@ripl/web';
 
 import type {
     Renderer,
+
+    Scene,
 } from '@ripl/web';
 
-import { parseMermaid } from './parser';
-import { computeLayout } from './layout';
-import { renderDiagram } from './renderer';
+import {
+    parseMermaid,
+} from './parser';
+
+import {
+    computeLayout,
+} from './layout';
+
+import {
+    renderDiagram,
+} from './renderer';
 
 const EXAMPLE_SOURCE = `graph TD
     A[Start] --> B{Is it working?}
@@ -66,8 +75,8 @@ function renderFromSource() {
         const ir = parseMermaid(source.value);
         const layout = computeLayout(ir);
         renderDiagram(scene, renderer, layout);
-    } catch (e) {
-        console.warn('Mermaid parse error:', e);
+    } catch (error) {
+        console.warn('Mermaid parse error:', error);
     }
 }
 

--- a/app/src/demos/piston-mechanism/piston-mechanism.vue
+++ b/app/src/demos/piston-mechanism/piston-mechanism.vue
@@ -80,9 +80,18 @@ const THROW_RADIUS = 0.15;
 const CON_ROD_LENGTH = 0.4;
 const CRANKSHAFT_SPEED = 1.5;
 
-const CRANKSHAFT_COLOR = { default: '#EF9A9A', hover: '#E57373' };
-const CON_ROD_COLOR = { default: '#A5D6A7', hover: '#81C784' };
-const PISTON_COLOR = { default: '#FFCC80', hover: '#FFB74D' };
+const CRANKSHAFT_COLOR = {
+    default: '#EF9A9A',
+    hover: '#E57373',
+};
+const CON_ROD_COLOR = {
+    default: '#A5D6A7',
+    hover: '#81C784',
+};
+const PISTON_COLOR = {
+    default: '#FFCC80',
+    hover: '#FFB74D',
+};
 
 interface PartColors {
     default: string;
@@ -99,7 +108,10 @@ interface PartEntry {
 const viewport = ref<HTMLElement>();
 const hoveredPart = ref<string | null>(null);
 const animating = ref(true);
-const mousePos = reactive({ x: 0, y: 0 });
+const mousePos = reactive({
+    x: 0,
+    y: 0,
+});
 const partEntries = reactive<PartEntry[]>([]);
 
 const tooltipStyle = computed(() => ({

--- a/app/src/demos/product-analytics/components/active-users-chart.vue
+++ b/app/src/demos/product-analytics/components/active-users-chart.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { DailyActiveUsersPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    DailyActiveUsersPoint,
+} from '../data/mock';
 
 type ActiveUsersDatum = DailyActiveUsersPoint & { ma: number };
 
@@ -39,7 +48,10 @@ function withMovingAverage(data: DailyActiveUsersPoint[], window = 7): ActiveUse
     return data.map((item, index) => {
         const slice = data.slice(Math.max(0, index - window + 1), index + 1);
         const avg = slice.reduce((sum, entry) => sum + entry.users, 0) / slice.length;
-        return { ...item, ma: Math.round(avg) };
+        return {
+            ...item,
+            ma: Math.round(avg),
+        };
     });
 }
 

--- a/app/src/demos/product-analytics/components/browser-share-chart.vue
+++ b/app/src/demos/product-analytics/components/browser-share-chart.vue
@@ -16,9 +16,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { BrowserSharePoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    BrowserSharePoint,
+} from '../data/mock';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/demos/product-analytics/components/conversion-funnel.vue
+++ b/app/src/demos/product-analytics/components/conversion-funnel.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { FunnelStagePoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    FunnelStagePoint,
+} from '../data/mock';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/demos/product-analytics/components/error-rate-gauge.vue
+++ b/app/src/demos/product-analytics/components/error-rate-gauge.vue
@@ -16,8 +16,14 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();
@@ -26,6 +32,18 @@ let chart: ReturnType<typeof createGaugeChart> | undefined;
 
 const DEFAULT_READOUT = 'Hover the gauge for the current rate';
 const readout = ref(DEFAULT_READOUT);
+
+function errorColor(rate: number): string {
+    if (rate > 3) {
+        return '#dc2626';
+    }
+
+    if (rate > 1.5) {
+        return '#f59e0b';
+    }
+
+    return '#16a34a';
+}
 
 function buildChart() {
     const value = store.errorRate;
@@ -36,7 +54,7 @@ function buildChart() {
         min: 0,
         max: 5,
         label: 'Error Rate',
-        color: value > 3 ? '#dc2626' : value > 1.5 ? '#f59e0b' : '#16a34a',
+        color: errorColor(value),
         formatValue: (v: number) => `${v.toFixed(2)}%`,
         tickCount: 5,
         showTickLabels: true,
@@ -70,7 +88,7 @@ watch(() => store.errorRate, () => {
         const value = store.errorRate;
         chart.update({
             value,
-            color: value > 3 ? '#dc2626' : value > 1.5 ? '#f59e0b' : '#16a34a',
+            color: errorColor(value),
         });
     } else {
         buildChart();

--- a/app/src/demos/product-analytics/components/feature-adoption-chart.vue
+++ b/app/src/demos/product-analytics/components/feature-adoption-chart.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { FeatureAdoptionPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    FeatureAdoptionPoint,
+} from '../data/mock';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/demos/product-analytics/components/page-load-scatter.vue
+++ b/app/src/demos/product-analytics/components/page-load-scatter.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { PageLoadPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    PageLoadPoint,
+} from '../data/mock';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();
@@ -46,8 +55,14 @@ function buildChart() {
         crosshair: true,
         format: 'number' as const,
         axis: {
-            x: { title: 'Load Time (ms)', format: (v: number) => `${Math.round(v)}ms` },
-            y: { title: 'Page Views', format: (v: number) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v)) },
+            x: {
+                title: 'Load Time (ms)',
+                format: (v: number) => `${Math.round(v)}ms`,
+            },
+            y: {
+                title: 'Page Views',
+                format: (v: number) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v)),
+            },
         },
         padding: {
             top: 16,

--- a/app/src/demos/product-analytics/components/retention-heatmap.vue
+++ b/app/src/demos/product-analytics/components/retention-heatmap.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
-import type { RetentionPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
+
+import type {
+    RetentionPoint,
+} from '../data/mock';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/demos/product-analytics/components/user-journey-sankey.vue
+++ b/app/src/demos/product-analytics/components/user-journey-sankey.vue
@@ -17,8 +17,14 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useAnalyticsStore } from '../store/analytics';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useAnalyticsStore,
+} from '../store/analytics';
 
 const store = useAnalyticsStore();
 const chartEl = ref<HTMLElement>();
@@ -75,7 +81,10 @@ watch(context, () => buildChart());
 watch(() => store.sankeyData, () => {
     if (chart) {
         const { nodes, links } = store.sankeyData;
-        chart.update({ nodes, links });
+        chart.update({
+            nodes,
+            links,
+        });
     } else {
         buildChart();
     }

--- a/app/src/demos/product-analytics/product-analytics.vue
+++ b/app/src/demos/product-analytics/product-analytics.vue
@@ -43,8 +43,13 @@
 </template>
 
 <script lang="ts" setup>
-import { PERIODS } from './data/mock';
-import { useAnalyticsStore } from './store/analytics';
+import {
+    PERIODS,
+} from './data/mock';
+
+import {
+    useAnalyticsStore,
+} from './store/analytics';
 
 import ActiveUsersChart from './components/active-users-chart.vue';
 import BrowserShareChart from './components/browser-share-chart.vue';

--- a/app/src/demos/trading-dashboard/components/commodity-chart.vue
+++ b/app/src/demos/trading-dashboard/components/commodity-chart.vue
@@ -27,9 +27,18 @@ import {
 import RiplSelect from '../../../.vitepress/components/ripl-select.vue';
 import RiplButtonGroup from '../../../.vitepress/components/ripl-button-group.vue';
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useDashboardStore } from '../store/dashboard';
-import type { MockCommodityPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useDashboardStore,
+} from '../store/dashboard';
+
+import type {
+    MockCommodityPoint,
+} from '../data/mock';
 
 import type {
     CommodityType,
@@ -37,7 +46,10 @@ import type {
 } from '../store/dashboard';
 
 const ranges: TimeRange[] = ['1M', '3M', '6M', '1Y'];
-const rangeOptions = ranges.map(r => ({ label: r, value: r }));
+const rangeOptions = ranges.map(r => ({
+    label: r,
+    value: r,
+}));
 const store = useDashboardStore();
 const chartEl = ref<HTMLElement>();
 const context = useChartContext(chartEl);
@@ -60,7 +72,10 @@ function buildChart() {
     ];
 
     if (chart) {
-        chart.update({ data, series });
+        chart.update({
+            data,
+            series,
+        });
         return;
     }
 

--- a/app/src/demos/trading-dashboard/components/market-overview-chart.vue
+++ b/app/src/demos/trading-dashboard/components/market-overview-chart.vue
@@ -28,10 +28,22 @@ import {
 import RiplSelect from '../../../.vitepress/components/ripl-select.vue';
 import RiplButtonGroup from '../../../.vitepress/components/ripl-button-group.vue';
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useDashboardStore } from '../store/dashboard';
-import { withMovingAverage } from '../data/mock';
-import type { MockDailyPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useDashboardStore,
+} from '../store/dashboard';
+
+import {
+    withMovingAverage,
+} from '../data/mock';
+
+import type {
+    MockDailyPoint,
+} from '../data/mock';
 
 import type {
     TimeRange,
@@ -40,7 +52,10 @@ import type {
 type MarketDatum = MockDailyPoint & { ma: number };
 
 const ranges: TimeRange[] = ['7D', '1M', '3M', '6M', '1Y'];
-const rangeOptions = ranges.map(r => ({ label: r, value: r }));
+const rangeOptions = ranges.map(r => ({
+    label: r,
+    value: r,
+}));
 const store = useDashboardStore();
 const chartEl = ref<HTMLElement>();
 const context = useChartContext(chartEl);

--- a/app/src/demos/trading-dashboard/components/stock-candlestick.vue
+++ b/app/src/demos/trading-dashboard/components/stock-candlestick.vue
@@ -15,9 +15,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useDashboardStore } from '../store/dashboard';
-import type { MockIntradayPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useDashboardStore,
+} from '../store/dashboard';
+
+import type {
+    MockIntradayPoint,
+} from '../data/mock';
 
 const store = useDashboardStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/demos/trading-dashboard/components/stock-history-chart.vue
+++ b/app/src/demos/trading-dashboard/components/stock-history-chart.vue
@@ -21,10 +21,22 @@ import {
 
 import RiplButtonGroup from '../../../.vitepress/components/ripl-button-group.vue';
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useDashboardStore } from '../store/dashboard';
-import { withMovingAverage } from '../data/mock';
-import type { MockDailyPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useDashboardStore,
+} from '../store/dashboard';
+
+import {
+    withMovingAverage,
+} from '../data/mock';
+
+import type {
+    MockDailyPoint,
+} from '../data/mock';
 
 import type {
     TimeRange,
@@ -33,7 +45,10 @@ import type {
 type StockDatum = MockDailyPoint & { ma: number };
 
 const ranges: TimeRange[] = ['1M', '3M', '6M', '1Y'];
-const rangeOptions = ranges.map(r => ({ label: r, value: r }));
+const rangeOptions = ranges.map(r => ({
+    label: r,
+    value: r,
+}));
 const store = useDashboardStore();
 const chartEl = ref<HTMLElement>();
 const context = useChartContext(chartEl);

--- a/app/src/demos/trading-dashboard/components/stock-volume-chart.vue
+++ b/app/src/demos/trading-dashboard/components/stock-volume-chart.vue
@@ -17,9 +17,18 @@ import {
 } from '@ripl/charts';
 
 import DashboardCard from './dashboard-card.vue';
-import { useChartContext } from '../composables/use-chart-context';
-import { useDashboardStore } from '../store/dashboard';
-import type { MockDailyPoint } from '../data/mock';
+
+import {
+    useChartContext,
+} from '../composables/use-chart-context';
+
+import {
+    useDashboardStore,
+} from '../store/dashboard';
+
+import type {
+    MockDailyPoint,
+} from '../data/mock';
 
 const store = useDashboardStore();
 const chartEl = ref<HTMLElement>();

--- a/app/src/docs/core/essentials/renderer.md
+++ b/app/src/docs/core/essentials/renderer.md
@@ -60,7 +60,7 @@ const scene = createScene('.mount-element', {
 
 const renderer = createRenderer(scene);
 
-await renderer.transition(scene, (el, i) => ({
+await renderer.transition(scene.graph(false), (el, i) => ({
     duration: 600,
     delay: i * 150,
     ease: easeOutCubic,
@@ -255,7 +255,7 @@ await renderer.transition(circle, {
 
 ### Animating Multiple Elements
 
-Pass an array of elements or a group to animate them all with the same options:
+Pass an array of elements to animate them all with the same options:
 
 ```ts
 await renderer.transition([circle, rect], {
@@ -270,13 +270,17 @@ await renderer.transition([circle, rect], {
 Pass a function instead of an options object to customize the transition per element. This is useful for staggered animations:
 
 ```ts
-await renderer.transition(group, (element, index, total) => ({
+await renderer.transition(group.graph(false), (element, index, total) => ({
     duration: 500,
     delay: index * 100, // stagger by 100ms
     ease: easeOutCubic,
     state: { fill: '#ff006e' },
 }));
 ```
+
+Passing a **group** directly to `transition` animates the group itself as a single unit — its own
+transform and opacity, composited at the group boundary — not its children. To animate a group's
+descendants (for example, to stagger across them), flatten it first with `group.graph(false)`.
 
 ## Manual Control
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -411,6 +411,59 @@ export default tseslint.config(
         },
     },
 
+    // Lint <script> blocks in Vue single-file components (demos + app SFCs)
+    {
+        name: 'ripl/vue-sfc',
+        files: ['**/*.vue'],
+        plugins: {
+            vue,
+            'ripl': riplPlugin,
+        },
+        languageOptions: {
+            parser: vueParser,
+            parserOptions: {
+                parser: tseslint.parser,
+                ecmaVersion: 2021,
+                sourceType: 'module',
+                extraFileExtensions: ['.vue'],
+            },
+        },
+        rules: {
+            // Relax rules that don't apply cleanly to SFC <script setup> (template-only refs, auto-imports)
+            'no-console': 'off',
+            'no-undef': 'off',
+            'no-unused-vars': 'off',
+            '@typescript-eslint/no-unused-vars': 'off',
+            '@typescript-eslint/no-explicit-any': 'off',
+
+            // Enforce stylistic rules
+            '@stylistic/indent': ['error', INDENT],
+            '@stylistic/semi': ['error', 'always'],
+            '@stylistic/quotes': ['error', 'single', { 'avoidEscape': true }],
+            '@stylistic/comma-dangle': ['error', {
+                'arrays': 'always-multiline',
+                'objects': 'always-multiline',
+                'imports': 'always-multiline',
+                'exports': 'always-multiline',
+                'functions': 'never',
+            }],
+            '@stylistic/object-curly-spacing': ['error', 'always'],
+            '@stylistic/object-curly-newline': ['error', {
+                'ObjectExpression': {
+                    'minProperties': 2,
+                    'multiline': true,
+                    'consistent': true,
+                },
+                'ImportDeclaration': 'always',
+                'ExportDeclaration': {
+                    'minProperties': 2,
+                },
+            }],
+            '@stylistic/member-delimiter-style': 'error',
+            'ripl/import-export-spacing': 'error',
+        },
+    },
+
     // Playground examples run inside the docs editor with `context`, `scene` and
     // `renderer` injected into scope, so treat them as read-only globals.
     {

--- a/packages/3d/src/core/shape.ts
+++ b/packages/3d/src/core/shape.ts
@@ -215,7 +215,7 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
         return context.project([this.x, this.y, this.z])[2];
     }
 
-    public getLocalBoundingBox(): Box {
+    public _getLocalBoundingBox(): Box {
         const context = this.context as Context3D | undefined;
 
         if (!context) {

--- a/packages/3d/src/core/shape.ts
+++ b/packages/3d/src/core/shape.ts
@@ -215,7 +215,7 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
         return context.project([this.x, this.y, this.z])[2];
     }
 
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const context = this.context as Context3D | undefined;
 
         if (!context) {

--- a/packages/canvas/src/context.ts
+++ b/packages/canvas/src/context.ts
@@ -129,7 +129,7 @@ export class CanvasContext extends DOMContext<HTMLCanvasElement> {
         // Fast path: plain colours skip bounding-box resolution and gradient parsing entirely,
         // which otherwise ran for every element on every frame.
         if (isGradientString(value)) {
-            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getBoundingBox?.(), this.width, this.height);
+            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getLocalBoundingBox?.(), this.width, this.height);
             setCanvasFill(this.context, value, bounds);
         } else {
             this.context.fillStyle = value;
@@ -290,7 +290,7 @@ export class CanvasContext extends DOMContext<HTMLCanvasElement> {
 
         // Fast path: plain colours skip bounding-box resolution and gradient parsing entirely.
         if (isGradientString(value)) {
-            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getBoundingBox?.(), this.width, this.height);
+            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getLocalBoundingBox?.(), this.width, this.height);
             setCanvasStroke(this.context, value, bounds);
         } else {
             this.context.strokeStyle = value;

--- a/packages/canvas/src/context.ts
+++ b/packages/canvas/src/context.ts
@@ -129,7 +129,7 @@ export class CanvasContext extends DOMContext<HTMLCanvasElement> {
         // Fast path: plain colours skip bounding-box resolution and gradient parsing entirely,
         // which otherwise ran for every element on every frame.
         if (isGradientString(value)) {
-            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getLocalBoundingBox?.(), this.width, this.height);
+            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
             setCanvasFill(this.context, value, bounds);
         } else {
             this.context.fillStyle = value;
@@ -290,7 +290,7 @@ export class CanvasContext extends DOMContext<HTMLCanvasElement> {
 
         // Fast path: plain colours skip bounding-box resolution and gradient parsing entirely.
         if (isGradientString(value)) {
-            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getLocalBoundingBox?.(), this.width, this.height);
+            const bounds = getCanvasGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
             setCanvasStroke(this.context, value, bounds);
         } else {
             this.context.strokeStyle = value;

--- a/packages/canvas/test/context.test.ts
+++ b/packages/canvas/test/context.test.ts
@@ -24,7 +24,7 @@ const GRADIENT = 'linear-gradient(90deg, #ff0000, #0000ff)';
 
 function createFakeRenderElement() {
     return {
-        getLocalBoundingBox: vi.fn(() => ({
+        getBoundingBox: vi.fn(() => ({
             left: 0,
             top: 0,
             right: 10,
@@ -70,7 +70,7 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.fill = '#ff0000';
 
-        expect(element.getLocalBoundingBox).not.toHaveBeenCalled();
+        expect(element.getBoundingBox).not.toHaveBeenCalled();
         expect(ctx.fill).toBe('#ff0000');
     });
 
@@ -81,7 +81,7 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.stroke = '#00ff00';
 
-        expect(element.getLocalBoundingBox).not.toHaveBeenCalled();
+        expect(element.getBoundingBox).not.toHaveBeenCalled();
         expect(ctx.stroke).toBe('#00ff00');
     });
 
@@ -92,7 +92,8 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.fill = GRADIENT;
 
-        expect(element.getLocalBoundingBox).toHaveBeenCalled();
+        // Gradient bounds are the element's local (untransformed) box.
+        expect(element.getBoundingBox).toHaveBeenCalledWith(true);
     });
 
     test('createPath returns a CanvasPath', () => {

--- a/packages/canvas/test/context.test.ts
+++ b/packages/canvas/test/context.test.ts
@@ -24,7 +24,7 @@ const GRADIENT = 'linear-gradient(90deg, #ff0000, #0000ff)';
 
 function createFakeRenderElement() {
     return {
-        getBoundingBox: vi.fn(() => ({
+        getLocalBoundingBox: vi.fn(() => ({
             left: 0,
             top: 0,
             right: 10,
@@ -70,7 +70,7 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.fill = '#ff0000';
 
-        expect(element.getBoundingBox).not.toHaveBeenCalled();
+        expect(element.getLocalBoundingBox).not.toHaveBeenCalled();
         expect(ctx.fill).toBe('#ff0000');
     });
 
@@ -81,7 +81,7 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.stroke = '#00ff00';
 
-        expect(element.getBoundingBox).not.toHaveBeenCalled();
+        expect(element.getLocalBoundingBox).not.toHaveBeenCalled();
         expect(ctx.stroke).toBe('#00ff00');
     });
 
@@ -92,7 +92,7 @@ describe('CanvasContext', () => {
         (ctx as { currentRenderElement: unknown }).currentRenderElement = element;
         ctx.fill = GRADIENT;
 
-        expect(element.getBoundingBox).toHaveBeenCalled();
+        expect(element.getLocalBoundingBox).toHaveBeenCalled();
     });
 
     test('createPath returns a CanvasPath', () => {

--- a/packages/charts/src/charts/arc-diagram.ts
+++ b/packages/charts/src/charts/arc-diagram.ts
@@ -185,7 +185,6 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
     }
 
     private _attachNodeHover(circle: Circle, node: ArcDiagramNode<TData>, color: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): ArcDiagramNodeEvent<TData> => ({
@@ -198,8 +197,7 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
 
         applyHoverHighlight(circle, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: circle.cx,
@@ -215,7 +213,6 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
     }
 
     private _attachLinkHover(arc: Polyline, link: ArcDiagramLink, content: string, color: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): ArcDiagramLinkEvent => ({
@@ -228,8 +225,7 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
 
         applyHoverHighlight(arc, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const points = arc.points;

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -224,7 +224,6 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
     }
 
     private _attachMarkerHover(marker: Circle, srs: AreaChartSeriesOptions<TData>, key: string, value: number, color: string, x: number, y: number) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -238,8 +237,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
 
         applyHoverHighlight(marker, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor: () => ({
                 x,

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -201,7 +201,6 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
     private _attachBarHover(bar: Rect, srs: BarChartSeriesOptions<TData>, key: string, value: number, anchor: () => { x: number;
         y: number; }) {
         const restFill = bar.fill as string;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -215,8 +214,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
         applyHoverHighlight(bar, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor,
             content: () => `${srs.label}: ${formatValue(value)}`,

--- a/packages/charts/src/charts/box-plot.ts
+++ b/packages/charts/src/charts/box-plot.ts
@@ -140,7 +140,6 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
 
     private _attachBoxHover(rect: Rect, category: string, stats: BoxplotStats): void {
         const restFill = rect.fill as string;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: {
@@ -155,8 +154,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor: () => ({
                 x: rect.x + rect.width / 2,

--- a/packages/charts/src/charts/chord.ts
+++ b/packages/charts/src/charts/chord.ts
@@ -511,7 +511,6 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
     }
 
     private _attachArcHover(segment: Arc, arc: ChordArc) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -525,8 +524,7 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
 
         applyHoverHighlight(segment, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const [x, y] = segment.getCentroid(segment.data as Partial<ArcState>);
@@ -545,7 +543,6 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
     }
 
     private _attachRibbonHover(ribbonEl: Ribbon, ribbon: ChordRibbon, cx: number, cy: number) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -560,8 +557,7 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
 
         applyHoverHighlight(ribbonEl, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: cx,

--- a/packages/charts/src/charts/force-directed.ts
+++ b/packages/charts/src/charts/force-directed.ts
@@ -204,7 +204,6 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
     }
 
     private _attachNodeHover(circle: Circle, node: PlacedNode, content: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): ForceDirectedNodeEvent<TData> => ({
@@ -218,8 +217,7 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
 
         applyHoverHighlight(circle, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: circle.cx,
@@ -235,7 +233,6 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
     }
 
     private _attachLinkHover(line: Line, link: ForceNetworkLink, content: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): ForceDirectedLinkEvent => ({
@@ -248,8 +245,7 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
 
         applyHoverHighlight(line, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: (line.x1 + line.x2) / 2,

--- a/packages/charts/src/charts/funnel.ts
+++ b/packages/charts/src/charts/funnel.ts
@@ -332,7 +332,6 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
         x: number;
         y: number;
         width: number; }, color: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -346,8 +345,7 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: item.x + item.width / 2,

--- a/packages/charts/src/charts/gantt.ts
+++ b/packages/charts/src/charts/gantt.ts
@@ -596,7 +596,6 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
         color: string;
         progress?: number;
         state: RectState; }) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const progressStr = task.progress !== undefined ? ` (${Math.round(task.progress * 100)}%)` : '';
         const tooltipText = `${task.label}: ${this._formatDate(task.start)} – ${this._formatDate(task.end)}${progressStr}`;
 
@@ -610,8 +609,7 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
 
         applyHoverHighlight(bar, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: (task.state.x as number) + (task.state.width as number) / 2,

--- a/packages/charts/src/charts/gauge.ts
+++ b/packages/charts/src/charts/gauge.ts
@@ -481,7 +481,6 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
     }
 
     private _attachValueHover(arc: Arc, value: number, color: string, formatDisplay: (value: number) => string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): GaugeChartValueEvent => ({
@@ -492,8 +491,7 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
 
         applyHoverHighlight(arc, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const [x, y] = arc.getCentroid(arc.data as Partial<ArcState>);

--- a/packages/charts/src/charts/heatmap.ts
+++ b/packages/charts/src/charts/heatmap.ts
@@ -430,7 +430,6 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
         value: number;
         xLabel: string;
         yLabel: string; }) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): HeatmapChartCellEvent => ({
@@ -443,8 +442,7 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: cell.x + cell.width / 2,

--- a/packages/charts/src/charts/histogram.ts
+++ b/packages/charts/src/charts/histogram.ts
@@ -140,7 +140,6 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
     /** Wires hover highlight + tooltip + interaction events onto a bin bar. */
     private _attachBinHover(rect: Rect, current: Bin): void {
         const restFill = rect.fill as string;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: {
@@ -156,8 +155,7 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor: () => ({
                 x: rect.x + rect.width / 2,

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -223,7 +223,6 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
         }
 
         const radius = series.markerRadius ?? 3;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -237,8 +236,7 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
         applyHoverHighlight(marker, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor: () => ({
                 x: marker.cx,

--- a/packages/charts/src/charts/packed-circle.ts
+++ b/packages/charts/src/charts/packed-circle.ts
@@ -146,7 +146,6 @@ export class PackedCircleChart<TData = unknown> extends Chart<PackedCircleChartO
     }
 
     private _attachCellHover(circle: Circle, node: PackedNode, content: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): PackedCircleChartCellEvent => ({
@@ -159,8 +158,7 @@ export class PackedCircleChart<TData = unknown> extends Chart<PackedCircleChartO
 
         applyHoverHighlight(circle, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: node.x,

--- a/packages/charts/src/charts/pie.ts
+++ b/packages/charts/src/charts/pie.ts
@@ -449,18 +449,25 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 }));
             };
 
-            const transitionUpdates = async () => renderer.transition(updates, element => ({
+            // Segments are grouped, but transitions animate their own state — so drive the leaf
+            // children (arc/label/connector) to their stashed `.data`, not the inert group.
+            const transitionUpdates = async () => renderer.transition(updates.flatMap(group => group.children), element => ({
                 duration: update.duration,
                 ease: update.ease,
                 state: element.data as Partial<BaseElementState>,
             }));
 
-            const transitionExits = async () => renderer.transition(exits, element => ({
-                duration: exit.duration,
-                ease: exit.ease,
-                state: element.data as Partial<BaseElementState>,
-                onComplete: el => el.destroy(),
-            }));
+            const transitionExits = async () => {
+                await renderer.transition(exits.flatMap(group => group.children), element => ({
+                    duration: exit.duration,
+                    ease: exit.ease,
+                    state: element.data as Partial<BaseElementState>,
+                }));
+
+                // Destroy the whole segment group once its leaves have collapsed (destroying leaves
+                // individually would leave empty group nodes behind).
+                exits.forEach(group => group.destroy());
+            };
 
             return Promise.all([
                 transitionEntries(),
@@ -475,7 +482,6 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
         label: string;
         key: string; }) {
         const { color, value, label, key } = segment;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -489,8 +495,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
 
         applyHoverHighlight(arc, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const [x, y] = arc.getCentroid(arc.data as Partial<ArcState>);

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -674,7 +674,9 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             }
 
             async function transitionUpdates() {
-                return renderer.transition(updates, element => ({
+                // Segments are grouped, but transitions animate their own state — drive the leaf
+                // children (arc/label/connector) to their stashed `.data`, not the inert group.
+                return renderer.transition(updates.flatMap(group => group.children), element => ({
                     duration: animDuration * 0.8,
                     ease: easeOutQuint,
                     state: element.data as Partial<BaseElementState>,
@@ -682,12 +684,15 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             }
 
             async function transitionExits() {
-                return renderer.transition(exits, element => ({
+                await renderer.transition(exits.flatMap(group => group.children), element => ({
                     duration: animDuration * 0.8,
                     ease: easeOutQuint,
                     state: element.data as Partial<BaseElementState>,
-                    onComplete: element => element.destroy(),
                 }));
+
+                // Destroy the whole segment group once its leaves have collapsed (destroying leaves
+                // individually would leave empty group nodes behind).
+                exits.forEach(group => group.destroy());
             }
 
             return Promise.all([
@@ -704,7 +709,6 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
         label: string;
         key: string; }) {
         const { color, value, label, key } = segment;
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -718,8 +722,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
 
         applyHoverHighlight(arc, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const [x, y] = arc.getCentroid(arc.data as Partial<ArcState>);

--- a/packages/charts/src/charts/polar-scatter.ts
+++ b/packages/charts/src/charts/polar-scatter.ts
@@ -329,7 +329,6 @@ export class PolarScatterChart<TData = unknown> extends Chart<PolarScatterChartO
     }
 
     private _attachMarkerHover(marker: Circle, values: PolarScatterMarkerEvent, content: string, restFill: string, stroke: string, radius: number) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): PolarScatterMarkerEvent => ({
@@ -340,8 +339,7 @@ export class PolarScatterChart<TData = unknown> extends Chart<PolarScatterChartO
 
         applyHoverHighlight(marker, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: marker.cx,

--- a/packages/charts/src/charts/radar.ts
+++ b/packages/charts/src/charts/radar.ts
@@ -606,7 +606,6 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
     private _attachPointHover(marker: Circle, pd: { point: Point;
         axisLabel: string;
         value: number; }, seriesId: string, color: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -620,8 +619,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
 
         applyHoverHighlight(marker, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: marker.cx,

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -147,7 +147,6 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
     }
 
     private _attachBarHover(arc: Arc, values: RadialBarChartBarEvent, color: string, content: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): RadialBarChartBarEvent => ({
@@ -158,8 +157,7 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
 
         applyHoverHighlight(arc, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 // Bars are stroked open arcs (no inner radius), so `getCentroid` (which assumes an

--- a/packages/charts/src/charts/sankey.ts
+++ b/packages/charts/src/charts/sankey.ts
@@ -613,7 +613,6 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
     }
 
     private _attachLinkHover(linkEl: SankeyLinkPath, link: LayoutLink, anchorX: number, anchorY: number) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): SankeyChartLinkEvent => ({
@@ -627,8 +626,7 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
 
         applyHoverHighlight(linkEl, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: anchorX,
@@ -644,7 +642,6 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
     }
 
     private _attachNodeHover(rect: Rect, node: LayoutNode, anchorX: number, anchorY: number) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         const payload = (point: { x: number;
             y: number; }): SankeyChartNodeEvent<TData> => ({
@@ -658,8 +655,7 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: anchorX,

--- a/packages/charts/src/charts/scatter.ts
+++ b/packages/charts/src/charts/scatter.ts
@@ -259,7 +259,6 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
         xValue: number;
         yValue: number;
         sizeValue: number; }, content: string, state: CircleState) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const stroke = state.stroke as string;
 
         const payload = (point: { x: number;
@@ -274,8 +273,7 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
 
         applyHoverHighlight(bubble, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
             anchor: () => ({
                 x: bubble.cx,

--- a/packages/charts/src/charts/stock.ts
+++ b/packages/charts/src/charts/stock.ts
@@ -273,8 +273,10 @@ export class StockChart<TData = unknown> extends Chart<StockChartOptions<TData>,
 
         applyHoverHighlight(body, {
             renderer: this.renderer,
-            duration: this.getAnimationDuration(200),
-            ease: easeOutQuart,
+            animation: () => ({
+                duration: this.getAnimationDuration(200),
+                ease: easeOutQuart,
+            }),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: anchorX,

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -342,7 +342,6 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
     }
 
     private _attachSegmentHover(segment: Arc, arc: FlattenedArc<TData>) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -357,8 +356,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
 
         applyHoverHighlight(segment, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => {
                 const [x, y] = segment.getCentroid(segment.data as Partial<ArcState>);

--- a/packages/charts/src/charts/treemap.ts
+++ b/packages/charts/src/charts/treemap.ts
@@ -428,7 +428,6 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
     }
 
     private _attachCellHover(rect: Rect, node: TreemapNode, color: string) {
-        const hover = this.resolveAnimation(ANIMATION_REFERENCE.hover);
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -442,8 +441,7 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
 
         applyHoverHighlight(rect, {
             renderer: this.renderer,
-            duration: hover.duration,
-            ease: hover.ease,
+            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: node.x + node.width / 2,

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -276,8 +276,10 @@ export class TrendChart<TData = unknown> extends Chart<TrendChartOptions<TData>,
 
         applyHoverHighlight(marker, {
             renderer: this.renderer,
-            duration: this.getAnimationDuration(300),
-            ease: easeOutQuart,
+            animation: () => ({
+                duration: this.getAnimationDuration(300),
+                ease: easeOutQuart,
+            }),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: marker.cx,
@@ -312,8 +314,10 @@ export class TrendChart<TData = unknown> extends Chart<TrendChartOptions<TData>,
 
         applyHoverHighlight(bar, {
             renderer: this.renderer,
-            duration: this.getAnimationDuration(300),
-            ease: easeOutQuart,
+            animation: () => ({
+                duration: this.getAnimationDuration(300),
+                ease: easeOutQuart,
+            }),
             tooltip: this._tooltip,
             anchor: () => ({
                 x: bar.x + bar.width / 2,

--- a/packages/charts/src/core/interaction.ts
+++ b/packages/charts/src/core/interaction.ts
@@ -36,10 +36,17 @@ export interface InteractionPoint {
 export interface HoverHighlightOptions<TElement extends Element> {
     /** Renderer used to run the highlight/restore transitions. */
     renderer: Renderer;
-    /** Duration of the highlight/restore transition, in milliseconds. */
-    duration: number;
-    /** Easing applied to the highlight/restore transition. */
-    ease: Ease;
+    /**
+     * Resolves the highlight/restore transition timing lazily, at hover time. Resolving on each
+     * hover (rather than baking a value in when the handler is bound) keeps navigator-driven
+     * animation suppression from freezing the hover into an instant snap.
+     */
+    animation: () => {
+        /** Duration of the highlight/restore transition, in milliseconds. */
+        duration: number;
+        /** Easing applied to the highlight/restore transition. */
+        ease: Ease;
+    };
     /** Target state applied while hovered. */
     highlight: StateOf<TElement>;
     /** Target state applied when the pointer leaves. */
@@ -84,8 +91,7 @@ export function applyHoverHighlight<TElement extends Element>(
 
     const {
         renderer,
-        duration,
-        ease,
+        animation,
         highlight,
         restore,
         tooltip,
@@ -125,6 +131,8 @@ export function applyHoverHighlight<TElement extends Element>(
 
         onEnter?.({ ...pointer });
 
+        const { duration, ease } = animation();
+
         renderer.transition(element, {
             duration,
             ease,
@@ -136,6 +144,8 @@ export function applyHoverHighlight<TElement extends Element>(
         tooltip?.hide();
 
         onLeave?.({ ...pointer });
+
+        const { duration, ease } = animation();
 
         renderer.transition(element, {
             duration,

--- a/packages/charts/src/elements/ribbon.ts
+++ b/packages/charts/src/elements/ribbon.ts
@@ -100,7 +100,7 @@ export class Ribbon extends Shape2D<RibbonState> {
         super('ribbon', options);
     }
 
-    public getLocalBoundingBox(): Box {
+    public _getLocalBoundingBox(): Box {
         const {
             cx,
             cy,

--- a/packages/charts/src/elements/ribbon.ts
+++ b/packages/charts/src/elements/ribbon.ts
@@ -100,7 +100,7 @@ export class Ribbon extends Shape2D<RibbonState> {
         super('ribbon', options);
     }
 
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const {
             cx,
             cy,

--- a/packages/charts/src/elements/sankey-link.ts
+++ b/packages/charts/src/elements/sankey-link.ts
@@ -69,7 +69,7 @@ export class SankeyLinkPath extends Shape2D<SankeyLinkState> {
         });
     }
 
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const {
             sx,
             sy,

--- a/packages/charts/src/elements/sankey-link.ts
+++ b/packages/charts/src/elements/sankey-link.ts
@@ -69,7 +69,7 @@ export class SankeyLinkPath extends Shape2D<SankeyLinkState> {
         });
     }
 
-    public getLocalBoundingBox(): Box {
+    public _getLocalBoundingBox(): Box {
         const {
             sx,
             sy,

--- a/packages/charts/test/interaction.test.ts
+++ b/packages/charts/test/interaction.test.ts
@@ -1,0 +1,75 @@
+import {
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    applyHoverHighlight,
+} from '../src/core/interaction';
+
+/**
+ * The hover animation is resolved through a thunk on every enter/leave rather than baked in when
+ * the handlers are bound. This keeps a navigator-driven re-render (which resolves animation to a
+ * zero duration while a gesture is in flight) from freezing the persistent hover into an instant snap.
+ */
+describe('applyHoverHighlight', () => {
+
+    function bind(animation: () => { duration: number;
+        ease: (t: number) => number; }) {
+        const handlers: Record<string, () => void> = {};
+        const transition = vi.fn();
+
+        const element = {
+            on: (event: string, handler: () => void) => {
+                handlers[event] = handler;
+                return { dispose: vi.fn() };
+            },
+        };
+
+        applyHoverHighlight(element as never, {
+            renderer: { transition } as never,
+            animation,
+            highlight: { radius: 12 } as never,
+            restore: { radius: 10 } as never,
+        });
+
+        return {
+            handlers,
+            transition,
+            element,
+        };
+    }
+
+    test('resolves the transition timing at hover time, not when the handlers are bound', () => {
+        // Simulate binding during a navigator gesture, when the resolver would report a zero duration.
+        let duration = 0;
+        const { handlers, transition } = bind(() => ({
+            duration,
+            ease: t => t,
+        }));
+
+        // The gesture ends; a later hover must animate with the real duration.
+        duration = 300;
+        handlers.mouseenter();
+
+        expect(transition).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ duration: 300 }));
+    });
+
+    test('re-resolves on every enter and leave', () => {
+        const durations = [120, 340];
+        let call = 0;
+        const { handlers, transition } = bind(() => ({
+            duration: durations[call++],
+            ease: t => t,
+        }));
+
+        handlers.mouseenter();
+        handlers.mouseleave();
+
+        expect(transition).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({ duration: 120 }));
+        expect(transition).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({ duration: 340 }));
+    });
+
+});

--- a/packages/charts/test/pie-transition.test.ts
+++ b/packages/charts/test/pie-transition.test.ts
@@ -1,0 +1,139 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    elementIsArc,
+    isGroup,
+} from '@ripl/core';
+
+import {
+    valueOneOrMore,
+} from '@ripl/utilities';
+
+import {
+    createPieChart,
+    createPolarAreaChart,
+} from '../src';
+
+polyfillPath2D();
+
+interface Slice {
+    label: string;
+    value: number;
+}
+
+const INITIAL: Slice[] = [
+    {
+        label: 'a',
+        value: 1,
+    },
+    {
+        label: 'b',
+        value: 2,
+    },
+    {
+        label: 'c',
+        value: 3,
+    },
+];
+
+// Shared keys 'a'/'b' become updates; 'c' exits; 'd' enters.
+const UPDATED: Slice[] = [
+    {
+        label: 'a',
+        value: 5,
+    },
+    {
+        label: 'b',
+        value: 1,
+    },
+    {
+        label: 'd',
+        value: 4,
+    },
+];
+
+/**
+ * A segment's arc/label/connector live under a per-segment group, but `transition()` animates a
+ * target's OWN state — a group's own `.data` is undefined, so passing groups freezes the update.
+ * These tests assert the update/exit passes target the leaf children (arcs), never the groups.
+ */
+describe('Pie / polar-area slice transitions target leaves', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    async function transitionTargetsAfterUpdate(chart: { render(): Promise<unknown>;
+        update(o: unknown): Promise<unknown>;
+        destroy(): void; }) {
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        const spy = vi.spyOn((chart as unknown as { renderer: { transition: (...args: unknown[]) => unknown } }).renderer, 'transition');
+
+        // autoRender is off, so re-render explicitly to diff the new data against the old.
+        chart.update({ data: UPDATED });
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        // Flatten every target passed to transition() across the update's enter/update/exit passes.
+        return spy.mock.calls.flatMap(call => valueOneOrMore(call[0]));
+    }
+
+    test('pie update animates leaf arcs, not segment groups', async () => {
+        const chart = createPieChart<Slice>(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL,
+            key: 'label',
+            value: 'value',
+            label: 'label',
+        });
+
+        const targets = await transitionTargetsAfterUpdate(chart);
+
+        expect(targets.length).toBeGreaterThan(0);
+        // The update reaches the leaf arcs...
+        expect(targets.some(target => elementIsArc(target))).toBe(true);
+        // ...and never hands a bare group to transition() (which would silently no-op).
+        expect(targets.some(target => isGroup(target))).toBe(false);
+
+        chart.destroy();
+    });
+
+    test('polar-area update animates leaf arcs, not segment groups', async () => {
+        const chart = createPolarAreaChart<Slice>(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL,
+            key: 'label',
+            value: 'value',
+            label: 'label',
+        });
+
+        const targets = await transitionTargetsAfterUpdate(chart);
+
+        expect(targets.length).toBeGreaterThan(0);
+        expect(targets.some(target => elementIsArc(target))).toBe(true);
+        expect(targets.some(target => isGroup(target))).toBe(false);
+
+        chart.destroy();
+    });
+
+});

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -49,6 +49,10 @@ import type {
 } from '../core/element';
 
 import {
+    CONTEXT_OPERATIONS,
+} from '../core/constants';
+
+import {
     scaleContinuous,
 } from '../scales';
 
@@ -59,6 +63,8 @@ import type {
 import {
     arrayDedupe,
     functionMemoize,
+    objectForEach,
+    typeIsNil,
     typeIsNumber,
 } from '@ripl/utilities';
 
@@ -439,10 +445,14 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         return { ...factory.getDefaultState() };
     }
 
-    /** Pushes the current state onto the stack and resets to defaults. */
+    /**
+     * Pushes the current state onto the stack and continues with a copy of it, so nested scopes
+     * inherit the enclosing drawing state (matching native canvas). This is what lets a group's
+     * paint, applied once at its boundary via {@link Context.pushGroup}, cascade to descendants.
+     */
     public save(): void {
         this.states.push(this.currentState);
-        this.currentState = this.getDefaultState();
+        this.currentState = { ...this.currentState };
         this.saveDepth += 1;
     }
 
@@ -516,11 +526,12 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
 
     /**
      * Opens a group boundary: saves the current drawing state and applies the group's own
-     * transform, so that descendant elements render within the group's coordinate system
-     * and any group-scoped clip is confined to the group. Every {@link Context.pushGroup}
-     * must be balanced by a matching {@link Context.popGroup}. Backends that render
-     * hierarchy structurally (such as SVG) override this to nest descendants under a
-     * group node.
+     * transform, inherited paint, and opacity, so that descendant elements render within the
+     * group's coordinate system, inherit its paint through the copied state (the render-tree
+     * cascade), and composite under its opacity. Any group-scoped clip is confined to the group.
+     * Every {@link Context.pushGroup} must be balanced by a matching {@link Context.popGroup}.
+     * Backends that render hierarchy structurally (such as SVG) override this to nest descendants
+     * under a group node.
      *
      * @param group - The group element whose boundary is being entered.
      */
@@ -528,6 +539,34 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         this._groupDepthStack.push(this.saveDepth);
         this.save();
         applyElementTransform(this, group);
+        this.applyGroupPaint(group);
+
+        // Opacity composites the group as a unit (multiplicative), rather than inheriting as a
+        // per-element value. Nested groups compound because each `save()` re-copies the state.
+        const opacity = group.opacity;
+
+        if (!typeIsNil(opacity) && opacity !== 1) {
+            this.opacity *= opacity;
+        }
+    }
+
+    /**
+     * Applies a group's own inherited paint (fill, stroke, font, line, shadow, text) to the
+     * context so descendants pick it up from the copied state. Transforms are applied separately
+     * and opacity is composited at the boundary, so both are skipped here.
+     */
+    protected applyGroupPaint(group: RiplElement): void {
+        objectForEach(CONTEXT_OPERATIONS, (key, operation) => {
+            if (key === 'opacity') {
+                return;
+            }
+
+            const value = (group as unknown as Record<string, unknown>)[key];
+
+            if (!typeIsNil(value)) {
+                (operation as (context: Context, val: unknown) => void)(this, value);
+            }
+        });
     }
 
     /**

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -54,8 +54,10 @@ export interface RenderElement {
     pointerEvents: RenderElementPointerEvents;
     /** Stacking order used when sorting hit-test results; higher values are prioritised. */
     zIndex: number;
-    /** Returns the element's axis-aligned bounding box, when one is defined. */
+    /** Returns the element's on-screen (transformed) axis-aligned bounding box, when one is defined. */
     getBoundingBox?(): Box;
+    /** Returns the element's untransformed, local-space bounding box, when one is defined. */
+    getLocalBoundingBox?(): Box;
     /** Returns whether the element has any listeners registered for the given event. */
     has(event: string): boolean;
     /** Tests whether the point `(x, y)` lies within the element, honouring its pointer-event region. */

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -54,10 +54,8 @@ export interface RenderElement {
     pointerEvents: RenderElementPointerEvents;
     /** Stacking order used when sorting hit-test results; higher values are prioritised. */
     zIndex: number;
-    /** Returns the element's on-screen (transformed) axis-aligned bounding box, when one is defined. */
-    getBoundingBox?(): Box;
-    /** Returns the element's untransformed, local-space bounding box, when one is defined. */
-    getLocalBoundingBox?(): Box;
+    /** Returns the element's bounding box: the on-screen (world) box, or the raw local box when `local` is `true`. */
+    getBoundingBox?(local?: boolean): Box;
     /** Returns whether the element has any listeners registered for the given event. */
     has(event: string): boolean;
     /** Tests whether the point `(x, y)` lies within the element, honouring its pointer-event region. */

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -331,7 +331,7 @@ export function applyElementTransform(target: TransformTarget, element: Element)
     if (hasOrigin) {
         const needsBBox = typeIsString(rawOriginX) || typeIsString(rawOriginY);
         // Origins resolve against the element's own (pre-transform) geometry, not its on-screen box.
-        const box = needsBBox ? element.getLocalBoundingBox() : null;
+        const box = needsBBox ? element._getLocalBoundingBox() : null;
 
         originX = resolveTransformOrigin(rawOriginX, box?.width ?? 0);
         originY = resolveTransformOrigin(rawOriginY, box?.height ?? 0);
@@ -777,18 +777,27 @@ export class Element<
         return closest<TElement>(this, selector);
     }
 
-    /** Returns the element's untransformed, authored bounding box in its own local coordinate space. Override in subclasses for accurate geometry. */
-    public getLocalBoundingBox(): Box {
+    /**
+     * @internal Raw local-space geometry hook. Override per element to return the untransformed,
+     * authored bounding box in the element's own coordinate space. Consumers should call
+     * {@link Element.getBoundingBox} instead.
+     */
+    public _getLocalBoundingBox(): Box {
         return new Box(0, 0, 0, 0);
     }
 
     /**
-     * Returns the element's on-screen bounding box — its {@link Element.getLocalBoundingBox} with
-     * its own and every ancestor group's transform applied (mirroring the DOM's
-     * `getBoundingClientRect`). A rotated element yields a conservative axis-aligned box.
+     * Returns this element's bounding box: the on-screen (world) box by default, or the raw local
+     * box when `local` is `true`. The world box applies this element's own and every ancestor
+     * group's transform (mirroring the DOM's `getBoundingClientRect`); a rotated element yields a
+     * conservative axis-aligned box.
+     * @param local - when `true`, returns the untransformed authored geometry instead of the world box.
      */
-    public getBoundingBox(): Box {
-        return transformBox(this.getLocalBoundingBox(), getWorldTransform(this as unknown as Element));
+    public getBoundingBox(local = false): Box {
+        const box = this._getLocalBoundingBox();
+        return local
+            ? box
+            : transformBox(box, getWorldTransform(this as unknown as Element));
     }
 
     /** Tests whether a point intersects this element’s bounding box. Override for custom hit testing. */

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -24,6 +24,7 @@ import {
     matrixRotate,
     matrixScale,
     matrixTranslate,
+    transformBox,
 } from '../math';
 
 import type {
@@ -329,7 +330,8 @@ export function applyElementTransform(target: TransformTarget, element: Element)
 
     if (hasOrigin) {
         const needsBBox = typeIsString(rawOriginX) || typeIsString(rawOriginY);
-        const box = needsBBox ? element.getBoundingBox() : null;
+        // Origins resolve against the element's own (pre-transform) geometry, not its on-screen box.
+        const box = needsBBox ? element.getLocalBoundingBox() : null;
 
         originX = resolveTransformOrigin(rawOriginX, box?.width ?? 0);
         originY = resolveTransformOrigin(rawOriginY, box?.height ?? 0);
@@ -692,9 +694,31 @@ export class Element<
         } as unknown as TState;
     }
 
-    /** Reads a state value, falling back to the parent’s value if the local value is nil (property inheritance). */
+    /**
+     * Reads this element's own state value (no inheritance). Inherited paint now cascades through
+     * the render tree — a group applies its paint at its boundary ({@link Context.pushGroup}) and
+     * descendants pick it up from the context's copied state — so property getters return own
+     * values only, mirroring how the browser resolves computed style at paint time. Use
+     * {@link Element.getComputedStateValue} when the effective (inheritance-resolved) value is
+     * required outside a render pass (e.g. animation start values).
+     */
     protected getStateValue<TKey extends keyof TState>(key: TKey) {
-        return this.state[key] ?? (this.parent as unknown as TState)?.[key];
+        return this.state[key];
+    }
+
+    /**
+     * Resolves a state value against the parent chain (own value, else the nearest ancestor's) —
+     * the effective value an element renders with. Used where the resolved value is needed without
+     * a live context, such as computing a transition's start value.
+     */
+    protected getComputedStateValue<TKey extends keyof TState>(key: TKey): TState[TKey] {
+        const own = this.state[key];
+
+        if (own !== undefined && own !== null) {
+            return own;
+        }
+
+        return (this.parent as unknown as Element<TState> | undefined)?.getComputedStateValue(key) as TState[TKey];
     }
 
     /** Sets a state value and emits an `updated` event. */
@@ -753,9 +777,18 @@ export class Element<
         return closest<TElement>(this, selector);
     }
 
-    /** Returns the axis-aligned bounding box for this element. Override in subclasses for accurate geometry. */
-    public getBoundingBox() {
+    /** Returns the element's untransformed, authored bounding box in its own local coordinate space. Override in subclasses for accurate geometry. */
+    public getLocalBoundingBox(): Box {
         return new Box(0, 0, 0, 0);
+    }
+
+    /**
+     * Returns the element's on-screen bounding box — its {@link Element.getLocalBoundingBox} with
+     * its own and every ancestor group's transform applied (mirroring the DOM's
+     * `getBoundingClientRect`). A rotated element yields a conservative axis-aligned box.
+     */
+    public getBoundingBox(): Box {
+        return transformBox(this.getLocalBoundingBox(), getWorldTransform(this as unknown as Element));
     }
 
     /** Tests whether a point intersects this element’s bounding box. Override for custom hit testing. */
@@ -767,7 +800,9 @@ export class Element<
     /** Creates an interpolator that transitions from the current state towards the target state, supporting keyframes and custom interpolator overrides. */
     public interpolate(newState: Partial<ElementInterpolationState<TState>>, interpolators: Partial<ElementInterpolators<TState>> = {}): Interpolator<void> {
         const mappedIntpls = objectReduce(newState, (output, key, value) => {
-            const currentValue = this.getStateValue(key);
+            // Start from the element's *effective* value (own, else inherited) so a transition on
+            // an inherited property animates from what's actually on screen.
+            const currentValue = this.getComputedStateValue(key);
 
             if (typeIsNil(currentValue)) {
                 return output;

--- a/packages/core/src/core/group.ts
+++ b/packages/core/src/core/group.ts
@@ -162,14 +162,18 @@ export class Group<TEventMap extends ElementEventMap = ElementEventMap> extends 
         return this.graph(true).filter(element => classList.every(cls => element.classList.has(cls))) as TElement[];
     }
 
-    /** Returns the composite on-screen bounding box enclosing all children (each child's world box). */
-    public getBoundingBox() {
-        return getContainingBox(this.children, element => element.getBoundingBox());
+    /**
+     * Returns the composite bounding box enclosing all children: their on-screen (world) boxes by
+     * default, or their raw local boxes when `local` is `true`.
+     * @param local - when `true`, unions the children's untransformed local geometry instead of their world boxes.
+     */
+    public getBoundingBox(local = false) {
+        return getContainingBox(this.children, element => element.getBoundingBox(local));
     }
 
-    /** Returns the composite untransformed bounding box enclosing all children's local geometry. */
-    public getLocalBoundingBox() {
-        return getContainingBox(this.children, element => element.getLocalBoundingBox());
+    /** @internal Composite raw local-space box enclosing all children's untransformed geometry. */
+    public _getLocalBoundingBox() {
+        return getContainingBox(this.children, element => element._getLocalBoundingBox());
     }
 
     /** Detaches all children (clearing their parent), then destroys this group. */

--- a/packages/core/src/core/group.ts
+++ b/packages/core/src/core/group.ts
@@ -162,9 +162,14 @@ export class Group<TEventMap extends ElementEventMap = ElementEventMap> extends 
         return this.graph(true).filter(element => classList.every(cls => element.classList.has(cls))) as TElement[];
     }
 
-    /** Returns the composite bounding box enclosing all children. */
+    /** Returns the composite on-screen bounding box enclosing all children (each child's world box). */
     public getBoundingBox() {
         return getContainingBox(this.children, element => element.getBoundingBox());
+    }
+
+    /** Returns the composite untransformed bounding box enclosing all children's local geometry. */
+    public getLocalBoundingBox() {
+        return getContainingBox(this.children, element => element.getLocalBoundingBox());
     }
 
     /** Detaches all children (clearing their parent), then destroys this group. */

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -14,10 +14,6 @@ import type {
     Group,
 } from './group';
 
-import {
-    isGroup,
-} from './group';
-
 import type {
     Interpolator,
 } from '../interpolators';
@@ -258,7 +254,8 @@ export class Renderer extends EventBus<RendererEventMap> {
     }
 
     private _renderBoundingBoxes(element: Element) {
-        const box = element.getBoundingBox();
+        // Drawn within the element's current transform context, so use the local (untransformed) box.
+        const box = element.getLocalBoundingBox();
         const context = this._scene.context;
         const path = context.createPath();
 
@@ -483,9 +480,10 @@ export class Renderer extends EventBus<RendererEventMap> {
         };
 
         const instance = new Transition((resolve, _reject, onAbort) => {
-            const elements = valueOneOrMore(element).flatMap(element => {
-                return isGroup(element) ? element.graph(false) : [element];
-            });
+            // Targets animate their own state — including groups, which the render loop advances at
+            // their `push` op so a group transitions as a unit (transform about its origin, opacity
+            // composited at the boundary) rather than fanning out to per-leaf animations.
+            const elements = valueOneOrMore(element);
 
             if (!elements.length) {
                 resolve();

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -255,7 +255,7 @@ export class Renderer extends EventBus<RendererEventMap> {
 
     private _renderBoundingBoxes(element: Element) {
         // Drawn within the element's current transform context, so use the local (untransformed) box.
-        const box = element.getLocalBoundingBox();
+        const box = element._getLocalBoundingBox();
         const context = this._scene.context;
         const path = context.createPath();
 

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -90,7 +90,14 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
             const inverse = worldTransform && matrixInvert(worldTransform);
 
             if (inverse) {
-                [x, y] = matrixApplyToPoint(inverse, [x, y]);
+                // The point arrives in device pixels (scaled by the device pixel ratio) but the world
+                // transform is composed in logical space. Map device → logical, apply the inverse, then
+                // map back to device so the native path test (which works in device pixels) stays correct.
+                const dpr = this.context.scaleDPR(1);
+                const [localX, localY] = matrixApplyToPoint(inverse, [x / dpr, y / dpr]);
+
+                x = localX * dpr;
+                y = localY * dpr;
             }
         }
 

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -126,11 +126,14 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
                 return;
             }
 
-            if (this.path && this.autoFill && this.fill) {
+            // Paint if a fill/stroke is set on this shape *or inherited* from a group — the context
+            // already holds the resolved value (own, applied by the base render; inherited, applied
+            // at the group boundary), so autoFill/autoStroke fire whenever the effective paint is set.
+            if (this.path && this.autoFill && this.getComputedStateValue('fill')) {
                 context.applyFill(this.path);
             }
 
-            if (this.path && this.autoStroke && this.stroke) {
+            if (this.path && this.autoStroke && this.getComputedStateValue('stroke')) {
                 context.applyStroke(this.path);
             }
         }, this.clip);

--- a/packages/core/src/elements/arc.ts
+++ b/packages/core/src/elements/arc.ts
@@ -146,8 +146,8 @@ export class Arc extends Shape2D<ArcState> {
         return getThetaPoint(angle, distance, cx, cy);
     }
 
-    /** Returns the axis-aligned bounding box of the arc. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the arc. */
+    public _getLocalBoundingBox(): Box {
         const {
             cx,
             cy,

--- a/packages/core/src/elements/arc.ts
+++ b/packages/core/src/elements/arc.ts
@@ -147,7 +147,7 @@ export class Arc extends Shape2D<ArcState> {
     }
 
     /** Returns the axis-aligned bounding box of the arc. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const {
             cx,
             cy,

--- a/packages/core/src/elements/circle.ts
+++ b/packages/core/src/elements/circle.ts
@@ -60,7 +60,7 @@ export class Circle extends Shape2D<CircleState> {
     }
 
     /** Returns the axis-aligned bounding box of the circle. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radius,
             this.cx - this.radius,

--- a/packages/core/src/elements/circle.ts
+++ b/packages/core/src/elements/circle.ts
@@ -59,8 +59,8 @@ export class Circle extends Shape2D<CircleState> {
         super('circle', options);
     }
 
-    /** Returns the axis-aligned bounding box of the circle. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the circle. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radius,
             this.cx - this.radius,

--- a/packages/core/src/elements/ellipse.ts
+++ b/packages/core/src/elements/ellipse.ts
@@ -103,8 +103,8 @@ export class Ellipse extends Shape2D<EllipseState> {
         super('ellipse', options);
     }
 
-    /** Returns the axis-aligned bounding box of the ellipse. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the ellipse. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radiusY,
             this.cx - this.radiusX,

--- a/packages/core/src/elements/ellipse.ts
+++ b/packages/core/src/elements/ellipse.ts
@@ -104,7 +104,7 @@ export class Ellipse extends Shape2D<EllipseState> {
     }
 
     /** Returns the axis-aligned bounding box of the ellipse. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radiusY,
             this.cx - this.radiusX,

--- a/packages/core/src/elements/image.ts
+++ b/packages/core/src/elements/image.ts
@@ -155,8 +155,8 @@ export class ImageElement extends Element<ImageState> {
         super('image', options);
     }
 
-    /** Returns the axis-aligned bounding box of the image. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the image. */
+    public _getLocalBoundingBox(): Box {
         const [sourceWidth, sourceHeight] = getSourceSize(this.image);
 
         return new Box(

--- a/packages/core/src/elements/image.ts
+++ b/packages/core/src/elements/image.ts
@@ -156,7 +156,7 @@ export class ImageElement extends Element<ImageState> {
     }
 
     /** Returns the axis-aligned bounding box of the image. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const [sourceWidth, sourceHeight] = getSourceSize(this.image);
 
         return new Box(

--- a/packages/core/src/elements/line.ts
+++ b/packages/core/src/elements/line.ts
@@ -72,8 +72,8 @@ export class Line extends Shape2D<LineState> {
         super('line', options);
     }
 
-    /** Returns the axis-aligned bounding box of the line. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the line. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             min(this.y1, this.y2),
             min(this.x1, this.x2),

--- a/packages/core/src/elements/line.ts
+++ b/packages/core/src/elements/line.ts
@@ -73,7 +73,7 @@ export class Line extends Shape2D<LineState> {
     }
 
     /** Returns the axis-aligned bounding box of the line. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             min(this.y1, this.y2),
             min(this.x1, this.x2),

--- a/packages/core/src/elements/path.ts
+++ b/packages/core/src/elements/path.ts
@@ -88,8 +88,8 @@ export class Path extends Shape2D<PathState> {
         this._pathRenderer = renderer;
     }
 
-    /** Returns the axis-aligned bounding box of the path. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the path. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.y,
             this.x,

--- a/packages/core/src/elements/path.ts
+++ b/packages/core/src/elements/path.ts
@@ -89,7 +89,7 @@ export class Path extends Shape2D<PathState> {
     }
 
     /** Returns the axis-aligned bounding box of the path. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             this.y,
             this.x,

--- a/packages/core/src/elements/polygon.ts
+++ b/packages/core/src/elements/polygon.ts
@@ -72,8 +72,8 @@ export class Polygon extends Shape2D<PolygonState> {
         super('polygon', options);
     }
 
-    /** Returns the axis-aligned bounding box of the polygon. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the polygon. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radius,
             this.cx - this.radius,

--- a/packages/core/src/elements/polygon.ts
+++ b/packages/core/src/elements/polygon.ts
@@ -73,7 +73,7 @@ export class Polygon extends Shape2D<PolygonState> {
     }
 
     /** Returns the axis-aligned bounding box of the polygon. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             this.cy - this.radius,
             this.cx - this.radius,

--- a/packages/core/src/elements/polyline.ts
+++ b/packages/core/src/elements/polyline.ts
@@ -532,7 +532,7 @@ export class Polyline extends Shape2D<PolylineState> {
     }
 
     /** Returns the axis-aligned bounding box of the polyline. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const [left, right] = getExtent(this.points, point => point[0]);
         const [top, bottom] = getExtent(this.points, point => point[1]);
 

--- a/packages/core/src/elements/polyline.ts
+++ b/packages/core/src/elements/polyline.ts
@@ -531,8 +531,8 @@ export class Polyline extends Shape2D<PolylineState> {
         super('polyline', options);
     }
 
-    /** Returns the axis-aligned bounding box of the polyline. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the polyline. */
+    public _getLocalBoundingBox(): Box {
         const [left, right] = getExtent(this.points, point => point[0]);
         const [top, bottom] = getExtent(this.points, point => point[1]);
 

--- a/packages/core/src/elements/rect.ts
+++ b/packages/core/src/elements/rect.ts
@@ -87,7 +87,7 @@ export class Rect extends Shape2D<RectState> {
     }
 
     /** Returns the axis-aligned bounding box of the rectangle. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         return new Box(
             this.y,
             this.x,

--- a/packages/core/src/elements/rect.ts
+++ b/packages/core/src/elements/rect.ts
@@ -86,8 +86,8 @@ export class Rect extends Shape2D<RectState> {
         super('rect', options);
     }
 
-    /** Returns the axis-aligned bounding box of the rectangle. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the rectangle. */
+    public _getLocalBoundingBox(): Box {
         return new Box(
             this.y,
             this.x,

--- a/packages/core/src/elements/text.ts
+++ b/packages/core/src/elements/text.ts
@@ -85,8 +85,8 @@ export class Text extends Element<TextState> {
         super('text', options);
     }
 
-    /** Returns the axis-aligned bounding box of the text, measured with its current alignment. */
-    public getLocalBoundingBox(): Box {
+    /** @internal Local-space bounding box of the text, measured with its current alignment. */
+    public _getLocalBoundingBox(): Box {
         const text = this.content.toString();
 
         // Measure with the element's alignment so the anchor-relative `actualBoundingBox*` metrics

--- a/packages/core/src/elements/text.ts
+++ b/packages/core/src/elements/text.ts
@@ -86,7 +86,7 @@ export class Text extends Element<TextState> {
     }
 
     /** Returns the axis-aligned bounding box of the text, measured with its current alignment. */
-    public getBoundingBox(): Box {
+    public getLocalBoundingBox(): Box {
         const text = this.content.toString();
 
         // Measure with the element's alignment so the anchor-relative `actualBoundingBox*` metrics

--- a/packages/core/src/math/geometry.ts
+++ b/packages/core/src/math/geometry.ts
@@ -7,6 +7,14 @@ import {
 } from './structs';
 
 import {
+    matrixApplyToPoint,
+} from './matrix';
+
+import type {
+    Matrix,
+} from './matrix';
+
+import {
     factory,
 } from '../core/factory';
 
@@ -101,6 +109,40 @@ export function getContainingBox<TValue>(value: TValue[], identity: (value: TVal
         left = Math.min(left, box.left);
         bottom = Math.max(bottom, box.bottom);
         right = Math.max(right, box.right);
+    });
+
+    return new Box(top, left, bottom, right);
+}
+
+/**
+ * Transforms a box by an affine matrix and returns the axis-aligned bounding box of the result.
+ * Returns the box unchanged when `matrix` is `null` (the identity case). Because it re-fits an AABB
+ * around the transformed corners, a rotated box yields a conservative (enlarged) bounding box.
+ */
+export function transformBox(box: Box, matrix: Matrix | null): Box {
+    if (!matrix) {
+        return box;
+    }
+
+    const corners: Point[] = [
+        [box.left, box.top],
+        [box.right, box.top],
+        [box.right, box.bottom],
+        [box.left, box.bottom],
+    ];
+
+    let top = Infinity,
+        left = Infinity,
+        bottom = -Infinity,
+        right = -Infinity;
+
+    corners.forEach(corner => {
+        const [x, y] = matrixApplyToPoint(matrix, corner);
+
+        top = Math.min(top, y);
+        left = Math.min(left, x);
+        bottom = Math.max(bottom, y);
+        right = Math.max(right, x);
     });
 
     return new Box(top, left, bottom, right);

--- a/packages/core/test/core/cascade-bounds.test.ts
+++ b/packages/core/test/core/cascade-bounds.test.ts
@@ -53,14 +53,14 @@ describe('Transform-aware bounding boxes', () => {
             height: 40,
         });
 
-        const local = rect.getLocalBoundingBox();
+        const local = rect.getBoundingBox(true);
         const world = rect.getBoundingBox();
 
         expect([local.left, local.top, local.right, local.bottom]).toEqual([10, 20, 40, 60]);
         expect([world.left, world.top, world.right, world.bottom]).toEqual([10, 20, 40, 60]);
     });
 
-    test('getBoundingBox reflects the element\'s own translation; getLocalBoundingBox stays raw', () => {
+    test('getBoundingBox reflects the element\'s own translation; getBoundingBox(true) stays raw', () => {
         const rect = createRect({
             x: 10,
             y: 20,
@@ -70,7 +70,7 @@ describe('Transform-aware bounding boxes', () => {
         rect.translateX = 100;
         rect.translateY = 5;
 
-        expect(rect.getLocalBoundingBox().left).toBe(10);
+        expect(rect.getBoundingBox(true).left).toBe(10);
         expect(rect.getBoundingBox().left).toBe(110);
         expect(rect.getBoundingBox().top).toBe(25);
     });
@@ -91,7 +91,9 @@ describe('Transform-aware bounding boxes', () => {
         expect(world.left).toBe(70);
         expect(world.right).toBe(130);
         // Local is untouched by ancestor transforms.
-        expect(rect.getLocalBoundingBox().left).toBe(10);
+        expect(rect.getBoundingBox(true).left).toBe(10);
+        // The group's own local box unions the children's untransformed geometry.
+        expect(group.getBoundingBox(true).left).toBe(10);
     });
 
     test('a group\'s bounding box encloses its children on screen', () => {

--- a/packages/core/test/core/cascade-bounds.test.ts
+++ b/packages/core/test/core/cascade-bounds.test.ts
@@ -1,0 +1,110 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    createGroup,
+    createRect,
+} from '../../src';
+
+describe('Own-only state cascade', () => {
+
+    test('a property getter returns the element\'s own value, not an inherited one', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        const group = createGroup({ children: [rect] });
+        group.fill = '#ff0000';
+
+        // Inheritance now happens through the render tree (the group applies its paint at its
+        // boundary), so the getter itself is own-only.
+        expect(rect.fill).toBeUndefined();
+        expect(group.fill).toBe('#ff0000');
+    });
+
+    test('opacity is own-only (composited at the group boundary, not inherited as a value)', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+        const group = createGroup({ children: [rect] });
+        group.opacity = 0.5;
+
+        expect(rect.opacity).toBeUndefined();
+        expect(group.opacity).toBe(0.5);
+    });
+
+});
+
+describe('Transform-aware bounding boxes', () => {
+
+    test('getBoundingBox equals the local box when there is no transform', () => {
+        const rect = createRect({
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        });
+
+        const local = rect.getLocalBoundingBox();
+        const world = rect.getBoundingBox();
+
+        expect([local.left, local.top, local.right, local.bottom]).toEqual([10, 20, 40, 60]);
+        expect([world.left, world.top, world.right, world.bottom]).toEqual([10, 20, 40, 60]);
+    });
+
+    test('getBoundingBox reflects the element\'s own translation; getLocalBoundingBox stays raw', () => {
+        const rect = createRect({
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        });
+        rect.translateX = 100;
+        rect.translateY = 5;
+
+        expect(rect.getLocalBoundingBox().left).toBe(10);
+        expect(rect.getBoundingBox().left).toBe(110);
+        expect(rect.getBoundingBox().top).toBe(25);
+    });
+
+    test('getBoundingBox reflects an ancestor group\'s transform', () => {
+        const rect = createRect({
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        });
+        const group = createGroup({ children: [rect] });
+        group.translateX = 50;
+        group.transformScaleX = 2;
+
+        // Group scales x by 2 (about origin) then the rect sits at x=10 → 20, plus the group's +50.
+        const world = rect.getBoundingBox();
+        expect(world.left).toBe(70);
+        expect(world.right).toBe(130);
+        // Local is untouched by ancestor transforms.
+        expect(rect.getLocalBoundingBox().left).toBe(10);
+    });
+
+    test('a group\'s bounding box encloses its children on screen', () => {
+        const rect = createRect({
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        });
+        const group = createGroup({ children: [rect] });
+        group.translateX = 100;
+
+        expect(group.getBoundingBox().left).toBe(110);
+    });
+
+});

--- a/packages/core/test/core/renderer.test.ts
+++ b/packages/core/test/core/renderer.test.ts
@@ -9,6 +9,8 @@ import {
 
 import {
     createElement,
+    createGroup,
+    isGroup,
     Renderer,
     TaskAbortError,
 } from '../../src';
@@ -36,12 +38,20 @@ function createMockScene() {
     const scene = {
         context: mockContext,
         buffer: elements,
-        // Leaf-only mock: every element renders as a `draw` instruction (no group boundaries).
+        // Groups bracket their subtree with push/pop; leaves are bare draw instructions.
         get instructions() {
-            return elements.map(element => ({
-                type: 'draw' as const,
-                element,
-            }));
+            return elements.flatMap(element => isGroup(element)
+                ? [{
+                    type: 'push' as const,
+                    element,
+                }, {
+                    type: 'pop' as const,
+                    element,
+                }]
+                : [{
+                    type: 'draw' as const,
+                    element,
+                }]);
         },
         on: vi.fn().mockReturnValue({ dispose: vi.fn() }),
         once: vi.fn().mockReturnValue({ dispose: vi.fn() }),
@@ -240,6 +250,33 @@ describe('Renderer', () => {
 
         expect(el1.opacity).toBeCloseTo(1, 1);
         expect(el2.opacity).toBeCloseTo(1, 1);
+
+        renderer.destroy();
+    });
+
+    test('Should animate a group\'s own state as a unit (no fan-out to leaves)', async () => {
+        const { scene } = createMockScene();
+        const renderer = new Renderer(scene, {
+            autoStart: false,
+            autoStop: false,
+        });
+
+        const child = createElement('rect', {});
+        const group = createGroup({ children: [child] });
+        scene.add(group);
+
+        const t = renderer.transition(group, {
+            duration: 100,
+            state: { transformScaleX: 2 },
+        });
+
+        await vi.advanceTimersByTimeAsync(200);
+        await t;
+
+        // The group's OWN state animated (advanced at its push op)...
+        expect(group.transformScaleX).toBeCloseTo(2, 1);
+        // ...and the leaf child was never touched (proving no fan-out).
+        expect(child.transformScaleX).toBe(1);
 
         renderer.destroy();
     });

--- a/packages/core/test/core/shape.test.ts
+++ b/packages/core/test/core/shape.test.ts
@@ -69,6 +69,39 @@ describe('Shape2D', () => {
         expect(rect.intersectsWith(200, 200)).toBe(false);
     });
 
+    test('Should map a device-space hit point into local space using the device pixel ratio', () => {
+        const rect = createRect({
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        });
+
+        rect.translateX = 50; // logical-space world transform
+
+        const recorded: [number, number][] = [];
+
+        // dpr = 2: scaleDPR maps logical → device (×2); invert maps device → logical (÷2).
+        const scaleDPR = Object.assign((value: number) => value * 2, { invert: (value: number) => value / 2 });
+
+        (rect as unknown as { context: unknown }).context = {
+            hitTestHonoursTransform: false,
+            scaleDPR,
+            isPointInStroke: () => false,
+            isPointInPath: (_path: unknown, x: number, y: number) => {
+                recorded.push([x, y]);
+                return true;
+            },
+        };
+        (rect as unknown as { path: unknown }).path = {};
+
+        // Device point for logical (60, 20) at dpr 2 → (120, 40).
+        rect.intersectsWith(120, 40);
+
+        // device (120,40) → logical (60,20) → inverse translate(-50) → local (10,20) → device (20,40).
+        expect(recorded.at(-1)).toEqual([20, 40]);
+    });
+
     test('Should return false for pointerEvents "none" with isPointer', () => {
         const rect = createRect({
             x: 0,

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -850,6 +850,18 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             groupElement.definition.attributes.transform = transform;
         }
 
+        // Opacity composites the subtree as a unit: stamp it on the <g> and reset the inheritable
+        // state so descendants don't also stamp it (which would double-apply). Paint (fill, stroke,
+        // …) stays in the state so leaves inherit and stamp their resolved value.
+        const opacity = this.currentState.opacity;
+
+        if (opacity !== 1) {
+            groupElement.definition.styles.opacity = opacity.toString();
+        }
+
+        this.currentState.opacity = 1;
+
+        // Children carry only their own transform; the native <g> supplies the group transform once.
         this._currentTransforms = [];
     }
 


### PR DESCRIPTION
Builds on the group-aware render buffer (#32) with three browser-aligned refactors. **Stacked on #32** — this PR targets that branch so the diff shows only the changes below; retarget to `main` once #32 merges.

## Group-targetable transitions
`transition()` no longer fans a group out to its leaves — a group animates its **own** state, which the render loop advances at the group's `push` op. A group now scales/rotates about its origin and fades as a unit, instead of animating each leaf independently. The only caller that passed a group (the tooltip) now fades correctly as a unit; hover-highlight (which does its own leaf-level fan-out) and legend targets (leaves) are unaffected.

## Own-only state cascade (paint applied at group boundaries)
Inherited paint (fill, stroke, font, line, shadow, text) now cascades through the render tree the way the browser resolves computed style, instead of via per-element parent-chain lookups:

- A group applies its paint **once** at its boundary (`pushGroup`); descendants pick it up from the context's copied state.
- Property getters (`getStateValue`) are therefore **own-only**; `save()` copies the current state so nested scopes inherit it; `getComputedStateValue` resolves the effective value off the hot path (transition start values), and `Shape2D`'s auto-fill/stroke gate on it.
- **Opacity** composites at the boundary (canvas `globalAlpha`; SVG `<g opacity>`) rather than inheriting as a value, so group fades compound and don't double-apply.

Net effect on the hot path: a leaf render drops from ~22 parent-chain walks (one per drawing-state prop) to zero, with inheritance carried by the context's save/restore stack.

## Transform-aware bounding boxes
`getBoundingBox()` now returns the **on-screen (world)** box — the element's local geometry with its own and every ancestor group's transform applied, like `getBoundingClientRect`. A new `getLocalBoundingBox()` exposes the raw authored geometry for internal use (transform-origin resolution, gradient bounds, debug boxes); each shape overrides that, and the base composes the world box via `getWorldTransform`.

## Known limitations (documented, follow-ups)
- Canvas group opacity is per-primitive `globalAlpha` (overlaps within a translucent group blend); true offscreen isolation is a separate follow-up. SVG gets true group opacity via nested `<g opacity>`.
- A group with a **gradient** fill inherited by leaves resolves per-element on SVG (objectBoundingBox) but uses the boundary's bounds on canvas.

## Verification
- Full suite green (1388 tests) incl. new unit tests: group transition animates own state (no fan-out), own-only getters, world vs local bounds.
- Lint clean; TypeDoc `notDocumented` clean for core/svg/canvas.
- Real-browser (Chromium) checks: canvas & SVG leaves inherit a group fill; group opacity composites on the `<g>` / via `globalAlpha` with no leaf double-stamp; group transform & clip still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdPBehCPZeP7kuGjcJUimb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdPBehCPZeP7kuGjcJUimb)_