### PR TITLE
Extract series renderers and add TrendChart with navigator

### DIFF
--- a/app/src/.vitepress/data/charts.ts
+++ b/app/src/.vitepress/data/charts.ts
@@ -23,7 +23,7 @@ export const charts: ChartMeta[] = [
     {
         text: 'Trend',
         link: '/charts/trend',
-        description: 'Combine x/y series such as bar, line, or area into a single composite chart.',
+        description: 'Mix line, bar, and area series on shared axes with stacking and a windowing navigator strip.',
     },
     {
         text: 'Pie/Donut',

--- a/app/src/charts/area.md
+++ b/app/src/charts/area.md
@@ -1,6 +1,6 @@
 # Area Chart
 
-The **Area Chart** renders filled areas beneath lines, making it easy to compare cumulative totals or show how individual series contribute to a whole. It supports stacked mode (areas stacked on top of each other), per-series opacity and line interpolation, and includes crosshair, grid, tooltips, and a legend. On entry the area is revealed left-to-right as the line draws on, and it transitions smoothly between data states on update.
+The **Area Chart** renders filled areas beneath lines, making it easy to compare cumulative totals or show how individual series contribute to a whole. It supports stacked mode (areas stacked on top of each other), per-series opacity and line interpolation, and includes crosshair, grid, tooltips, and a legend. When areas overlap (unstacked), they are painted largest-first so a smaller area is never hidden behind a larger one. On entry the area is revealed left-to-right as the line draws on, and it transitions smoothly between data states on update.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/app/src/charts/area.md
+++ b/app/src/charts/area.md
@@ -47,6 +47,9 @@ The **Area Chart** renders filled areas beneath lines, making it easy to compare
             <RiplField label="Markers" inline>
                 <RiplSwitch v-model="markers" />
             </RiplField>
+            <RiplField label="Navigator" inline>
+                <RiplSwitch v-model="overview" />
+            </RiplField>
         </RiplChartConfig>
     </template>
 </ripl-example>
@@ -86,9 +89,10 @@ const stacked = ref(false);
 const lineType = ref<PolylineRenderer>('monotoneX');
 const lineStyle = ref<'solid' | 'dashed' | 'dotted'>('solid');
 const markers = ref(false);
+const overview = ref(false);
 
 const config = useChartConfig({
-    features: { title: true, legend: true, axes: true, grid: true, animation: true, navigator: true },
+    features: { title: true, legend: true, axes: true, grid: true, animation: true },
     title: 'Traffic by Device',
     axisX: 'Month',
     axisY: 'Sessions',
@@ -125,6 +129,7 @@ const { contextChanged, chart } = useRiplChart(context => {
         stacked: stacked.value,
         padding: { top: 30, right: 20, bottom: 30, left: 20 },
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 });
@@ -133,12 +138,13 @@ function apply() {
     chart.value?.update({
         stacked: stacked.value,
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 }
 
 watch(config, apply, { deep: true });
-watch([stacked, lineType, lineStyle, markers], apply);
+watch([stacked, lineType, lineStyle, markers, overview], apply);
 
 function randomize() {
     data = generateData(data.length);
@@ -252,3 +258,4 @@ createAreaChart('#container', {
 - **`tooltip`** — `boolean | ChartTooltipOptions` — Show/configure tooltips (default `true`)
 - **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend
 - **`axis`** — `boolean | ChartAxisOptions` — Configure x/y axes
+- **`overview`** — `boolean | { size }` — Show the navigator scrub bar beneath the plot; enabling it also turns on category-axis (horizontal) pan/zoom on the plot

--- a/app/src/charts/bar.md
+++ b/app/src/charts/bar.md
@@ -23,6 +23,9 @@ The **Bar Chart** is one of the most versatile chart types in Ripl. It supports 
             <RiplField label="Horizontal" inline>
                 <RiplSwitch v-model="horizontal" />
             </RiplField>
+            <RiplField label="Navigator" inline>
+                <RiplSwitch v-model="overview" />
+            </RiplField>
         </RiplChartConfig>
     </template>
 </ripl-example>
@@ -58,10 +61,11 @@ const seriesMeta = [
 
 const stacked = ref(false);
 const horizontal = ref(false);
+const overview = ref(false);
 let monthCount = 6;
 
 const config = useChartConfig({
-    features: { title: true, legend: true, axes: true, grid: true, animation: true, navigator: true },
+    features: { title: true, legend: true, axes: true, grid: true, animation: true },
     title: 'Monthly Breakdown',
     axisX: 'Month',
     axisY: 'Amount ($)',
@@ -101,6 +105,7 @@ const { contextChanged, chart } = useRiplChart(context => {
         orientation: horizontal.value ? 'horizontal' : 'vertical',
         padding: { top: 30, right: 20, bottom: 30, left: 20 },
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 });
@@ -110,12 +115,13 @@ function apply() {
         mode: stacked.value ? 'stacked' : 'grouped',
         orientation: horizontal.value ? 'horizontal' : 'vertical',
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 }
 
 watch(config, apply, { deep: true });
-watch([stacked, horizontal], apply);
+watch([stacked, horizontal, overview], apply);
 
 function randomize() {
     data = generateData();
@@ -248,4 +254,5 @@ createBarChart('#container', {
 - **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend
 - **`tooltip`** — `boolean | ChartTooltipOptions` — Show/configure tooltips (default `true`)
 - **`axis`** — `boolean | ChartAxisOptions` — Configure x/y axes
+- **`overview`** — `boolean | { size }` — Show the navigator scrub bar (beneath the plot for vertical bars, alongside it for horizontal bars); enabling it also turns on category-axis pan/zoom on the plot
 - **`borderRadius`** — Bar corner radius (default `2`)

--- a/app/src/charts/getting-started.md
+++ b/app/src/charts/getting-started.md
@@ -172,7 +172,7 @@ chart.destroy();
 | [Sankey](/charts/sankey) | `createSankeyChart` | Flow diagrams |
 | [Chord](/charts/chord) | `createChordChart` | Relationship matrices |
 | [Sunburst](/charts/sunburst) | `createSunburstChart` | Hierarchical rings |
-| [Trend](/charts/trend) | `createTrendChart` | Sparkline-style |
+| [Trend](/charts/trend) | `createTrendChart` | Mixed line/bar/area, stacking, navigator |
 | [Stock](/charts/stock) | `createStockChart` | OHLC candlesticks, volume |
 | [Gantt](/charts/gantt) | `createGanttChart` | Tasks over a time axis |
 | [Realtime](/charts/realtime) | `createRealtimeChart` | Streaming sliding window |

--- a/app/src/charts/line.md
+++ b/app/src/charts/line.md
@@ -44,6 +44,9 @@ The **Line Chart** renders one or more data series as smooth or straight lines w
             <RiplField label="Markers" inline>
                 <RiplSwitch v-model="markers" />
             </RiplField>
+            <RiplField label="Navigator" inline>
+                <RiplSwitch v-model="overview" />
+            </RiplField>
         </RiplChartConfig>
     </template>
 </ripl-example>
@@ -83,9 +86,10 @@ const seriesMeta = [
 const lineType = ref<PolylineRenderer>('monotoneX');
 const lineStyle = ref<'solid' | 'dashed' | 'dotted'>('solid');
 const markers = ref(true);
+const overview = ref(false);
 
 const config = useChartConfig({
-    features: { title: true, legend: true, axes: true, grid: true, animation: true, navigator: true },
+    features: { title: true, legend: true, axes: true, grid: true, animation: true },
     title: 'Monthly Performance',
     axisX: 'Month',
     axisY: 'Amount ($)',
@@ -121,6 +125,7 @@ const { contextChanged, chart } = useRiplChart(context => {
         key: 'month',
         padding: { top: 30, right: 20, bottom: 30, left: 20 },
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 });
@@ -128,12 +133,13 @@ const { contextChanged, chart } = useRiplChart(context => {
 function apply() {
     chart.value?.update({
         series: getSeries(),
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 }
 
 watch(config, apply, { deep: true });
-watch([lineType, lineStyle, markers], apply);
+watch([lineType, lineStyle, markers, overview], apply);
 
 function randomize() {
     data = generateData(data.length);
@@ -251,4 +257,5 @@ createLineChart('#container', {
 - **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend (shown by default for multiple series, at the bottom)
 - **`tooltip`** — `boolean | ChartTooltipOptions` — Show/configure tooltips (default `true`)
 - **`axis`** — `boolean | ChartAxisOptions` — Configure x/y axes
+- **`overview`** — `boolean | { size }` — Show the navigator scrub bar beneath the plot; enabling it also turns on category-axis (horizontal) pan/zoom on the plot
 - **`padding`** — Chart padding

--- a/app/src/charts/trend.md
+++ b/app/src/charts/trend.md
@@ -257,7 +257,7 @@ createTrendChart('#container', {
 - **`key`** — Key accessor for the categorical x-axis
 - **`stacked`** — Stack same-type series (default `false`)
 - **`borderRadius`** — Corner radius applied to bars (default `2`)
-- **`overview`** — `boolean | { height }` — Show the navigator strip; enabling it also turns on in-plot pan/zoom
+- **`overview`** — `boolean | { size }` — Show the navigator strip; enabling it also turns on in-plot pan/zoom
 - **`navigator`** — `boolean | NavigatorInteractions` — Configure in-plot pan/zoom/brush directly
 - **`labels`** — `boolean | anchor` — Show value labels next to marks
 - **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines

--- a/app/src/charts/trend.md
+++ b/app/src/charts/trend.md
@@ -63,16 +63,12 @@ import type {
 } from '@ripl/web';
 
 import {
-    stringUniqueId,
-} from '@ripl/utilities';
-
-import {
     ref,
     watch,
 } from 'vue';
 
 interface SalesRow {
-    id: string;
+    month: string;
     revenue: number;
     expenses: number;
     orders: number;
@@ -109,14 +105,16 @@ function getSeries(): TrendChartSeriesOptions<SalesRow>[] {
     })) as TrendChartSeriesOptions<SalesRow>[];
 }
 
-let data = Array.from({ length: 12 }, getDataItem);
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+let data = Array.from({ length: MONTHS.length }, (_, index) => getDataItem(index));
 
 const {
     chart,
     contextChanged,
 } = useRiplChart(context => createTrendChart(context, {
     data,
-    key: 'id',
+    key: 'month',
     series: getSeries(),
     stacked: stacked.value,
     overview: overview.value,
@@ -135,13 +133,17 @@ function apply() {
 watch(config, apply, { deep: true });
 watch([stacked, overview, lineType], apply);
 
+function monthLabel(index: number): string {
+    const year = 24 + Math.floor(index / MONTHS.length);
+    return `${MONTHS[index % MONTHS.length]} '${year}`;
+}
+
 function getValue(min: number, max: number) {
     return Math.round(min + Math.random() * (max - min));
 }
 
-function getDataItem(): SalesRow {
+function rollValues() {
     return {
-        id: stringUniqueId(),
         revenue: getValue(400, 1000),
         expenses: getValue(120, 420),
         orders: getValue(60, 320),
@@ -149,15 +151,22 @@ function getDataItem(): SalesRow {
     };
 }
 
+function getDataItem(index: number): SalesRow {
+    return {
+        month: monthLabel(index),
+        ...rollValues(),
+    };
+}
+
 function addData() {
-    data.push(getDataItem());
+    data.push(getDataItem(data.length));
     chart.value?.update({ data });
 }
 
 function randomise() {
     data = data.map(item => ({
-        ...getDataItem(),
-        id: item.id,
+        month: item.month,
+        ...rollValues(),
     }));
 
     chart.value?.update({ data });

--- a/app/src/charts/trend.md
+++ b/app/src/charts/trend.md
@@ -1,9 +1,11 @@
 # Trend Chart
 
-The **Trend Chart** is a composite chart that lets you mix bar, line, and area series on the same axes. This makes it ideal for dashboards where you want to overlay a trend line on top of bar data, or combine multiple visualization types in a single view. Each series specifies its `type` (`'bar'`, `'line'`, or `'area'`), and all share common features like grid, legend, and animated transitions.
+The **Trend Chart** is a true mixed cartesian chart that combines line, bar, and area series on shared axes. Each series declares its `type` (`'line'`, `'bar'`, or `'area'`) plus the options specific to that type, and the chart reuses the same renderers as the standalone line, bar, and area charts. Series paint back-to-front as **area → bar → line** so lines never hide behind fills or bars, and overlaid areas are drawn largest-first so smaller areas stay visible. Same-type series can be stacked, and an optional **navigator** strip beneath the plot lets you window the visible x-range (with wheel/drag pan-zoom on the plot itself).
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
+
+## Example
 
 <ripl-example @context-changed="contextChanged">
     <template #footer>
@@ -14,28 +16,30 @@ The **Trend Chart** is a composite chart that lets you mix bar, line, and area s
     </template>
     <template #config>
         <RiplChartConfig :config="config" :series="seriesMeta" extra-title="Trend">
+            <RiplField label="Stacked" inline>
+                <RiplSwitch v-model="stacked" />
+            </RiplField>
+            <RiplField label="Navigator" inline>
+                <RiplSwitch v-model="overview" />
+            </RiplField>
             <RiplField label="Line type">
-                <RiplSelect v-model="lineRenderer">
+                <RiplSelect v-model="lineType">
                     <option value="linear">Linear</option>
                     <option value="spline">Spline</option>
                     <option value="basis">Basis</option>
                     <option value="bumpX">Bump X</option>
-                    <option value="bumpY">Bump Y</option>
                     <option value="cardinal">Cardinal</option>
                     <option value="catmullRom">Catmull-Rom</option>
                     <option value="monotoneX">Monotone X</option>
-                    <option value="monotoneY">Monotone Y</option>
                     <option value="natural">Natural</option>
                     <option value="step">Step</option>
-                    <option value="stepBefore">Step Before</option>
-                    <option value="stepAfter">Step After</option>
                 </RiplSelect>
             </RiplField>
         </RiplChartConfig>
     </template>
 </ripl-example>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import {
     useRiplChart,
 } from '../.vitepress/compositions/example';
@@ -50,8 +54,12 @@ import {
     createTrendChart,
 } from '@ripl/charts';
 
-import {
-    scaleContinuous,
+import type {
+    TrendChartSeriesOptions,
+} from '@ripl/charts';
+
+import type {
+    PolylineRenderer,
 } from '@ripl/web';
 
 import {
@@ -63,70 +71,82 @@ import {
     watch,
 } from 'vue';
 
-const dataScale = scaleContinuous([0, 1], [-500, 1200]);
-const lineRenderer = ref('linear');
+interface SalesRow {
+    id: string;
+    revenue: number;
+    expenses: number;
+    orders: number;
+    target: number;
+}
 
 const seriesMeta = [
-    { type: 'bar', id: 'australia', label: 'Australia', value: 'australia' },
-    { type: 'bar', id: 'new-zealand', label: 'New Zealand', value: 'newZealand' },
-    { type: 'bar', id: 'sweden', label: 'Sweden', value: 'sweden' },
-    { type: 'bar', id: 'united-states', label: 'United States', value: 'unitedStates' },
-    { type: 'line', id: 'great-britain', label: 'Great Britain', value: 'greatBritain' },
+    { type: 'area' as const, id: 'revenue', label: 'Revenue', value: 'revenue' },
+    { type: 'area' as const, id: 'expenses', label: 'Expenses', value: 'expenses' },
+    { type: 'bar' as const, id: 'orders', label: 'Orders', value: 'orders' },
+    { type: 'line' as const, id: 'target', label: 'Target', value: 'target' },
 ];
+
+const stacked = ref(false);
+const overview = ref(false);
+const lineType = ref<PolylineRenderer>('monotoneX');
 
 const config = useChartConfig({
     features: { title: true, legend: true, axes: true, grid: true, animation: true },
-    title: 'Medal Trend',
-    axisY: 'Count',
+    title: 'Sales Trend',
+    axisY: 'Value',
     colors: seedColors(seriesMeta.map(s => s.id)),
 });
 
-function getSeries() {
+function getSeries(): TrendChartSeriesOptions<SalesRow>[] {
     return seriesMeta.map(s => ({
         type: s.type,
         id: s.id,
         label: s.label,
         value: s.value,
         color: config.colors[s.id],
-        ...(s.type === 'line' ? { lineType: lineRenderer.value } : {}),
-    }));
+        ...(s.type === 'area' ? { opacity: 0.25 } : {}),
+        ...(s.type === 'bar' ? {} : { lineType: lineType.value }),
+    })) as TrendChartSeriesOptions<SalesRow>[];
 }
 
-let data = Array.from({ length: 15 }, getDataItem);
+let data = Array.from({ length: 12 }, getDataItem);
 
 const {
     chart,
-    contextChanged
+    contextChanged,
 } = useRiplChart(context => createTrendChart(context, {
     data,
     key: 'id',
     series: getSeries(),
+    stacked: stacked.value,
+    overview: overview.value,
     ...buildCommonOptions(config),
 }));
 
 function apply() {
     chart.value?.update({
         series: getSeries(),
+        stacked: stacked.value,
+        overview: overview.value,
         ...buildCommonOptions(config),
     });
 }
 
 watch(config, apply, { deep: true });
-watch(lineRenderer, apply);
+watch([stacked, overview, lineType], apply);
 
-function getDataItem() {
-    return {
-        id: stringUniqueId(),
-        australia: getValue(),
-        newZealand: getValue(),
-        sweden: getValue(),
-        unitedStates: getValue(),
-        greatBritain: getValue(),
-    }
+function getValue(min: number, max: number) {
+    return Math.round(min + Math.random() * (max - min));
 }
 
-function getValue() {
-    return Math.round(dataScale(Math.random()));
+function getDataItem(): SalesRow {
+    return {
+        id: stringUniqueId(),
+        revenue: getValue(400, 1000),
+        expenses: getValue(120, 420),
+        orders: getValue(60, 320),
+        target: getValue(520, 900),
+    };
 }
 
 function addData() {
@@ -135,44 +155,116 @@ function addData() {
 }
 
 function randomise() {
-    data = data.map(value => ({
+    data = data.map(item => ({
         ...getDataItem(),
-        id: value.id
+        id: item.id,
     }));
 
     chart.value?.update({ data });
 }
 </script>
 
-```typescript
-const chart = createTrendChart(context, {
-    data,
-    key: 'id',
+## Usage
+
+```ts
+import {
+    createTrendChart,
+} from '@ripl/charts';
+
+const chart = createTrendChart('#container', {
+    data: [/* ... */],
+    key: 'month',
     series: [
-        {
-            type: 'bar',
-            id: 'australia',
-            label: 'Australia',
-            value: 'australia',
-        },
-        {
-            type: 'bar',
-            id: 'new-zealand',
-            label: 'New Zealand',
-            value: 'newZealand',
-        },
-        {
-            type: 'bar',
-            id: 'sweden',
-            label: 'Sweden',
-            value: 'sweden',
-        },
-        {
-            type: 'line',
-            id: 'united-states',
-            label: 'United States',
-            value: 'unitedStates',
-        },
+        { type: 'area', id: 'revenue', label: 'Revenue', value: 'revenue' },
+        { type: 'bar', id: 'orders', label: 'Orders', value: 'orders' },
+        { type: 'line', id: 'target', label: 'Target', value: 'target' },
     ],
+});
+```
+
+## Data Format
+
+A single flat dataset is shared by every series; each series reads its own numeric field via `value`, and `key` gives the category plotted along the x axis:
+
+```ts
+const data = [
+    { month: 'Jan',
+        revenue: 620,
+        orders: 140,
+        target: 700 },
+    { month: 'Feb',
+        revenue: 780,
+        orders: 190,
+        target: 720 },
+    { month: 'Mar',
+        revenue: 550,
+        orders: 120,
+        target: 680 },
+];
+```
+
+## Variants
+
+### Stacked
+
+Same-type series stack independently — bars stack among bar series, areas among area series:
+
+```ts
+createTrendChart('#container', {
+    data,
+    key: 'month',
+    stacked: true,
+    series: [
+        { type: 'area', id: 'revenue', label: 'Revenue', value: 'revenue' },
+        { type: 'area', id: 'expenses', label: 'Expenses', value: 'expenses' },
+        { type: 'line', id: 'target', label: 'Target', value: 'target' },
+    ],
+});
+```
+
+### Navigator
+
+Enable the overview strip to window the visible x-range (and pan/zoom on the plot):
+
+```ts
+createTrendChart('#container', {
+    data,
+    key: 'month',
+    overview: true,
+    series: [
+        { type: 'bar', id: 'orders', label: 'Orders', value: 'orders' },
+        { type: 'line', id: 'target', label: 'Target', value: 'target' },
+    ],
+});
+```
+
+## Options
+
+- **`data`** — The data array shared by all series
+- **`series`** — Array of series, each a discriminated union on `type`:
+  - **`type: 'line'`** — `id`, `value`, `label`, optional `color`, `lineType`, `lineWidth`, `lineStyle` (`'solid'` \| `'dashed'` \| `'dotted'` \| custom dash array), `markers`, `markerRadius`
+  - **`type: 'area'`** — as line, plus `opacity` (fill opacity, default `0.3`); unstacked areas paint largest-first
+  - **`type: 'bar'`** — `id`, `value`, `label`, optional `color`
+- **`key`** — Key accessor for the categorical x-axis
+- **`stacked`** — Stack same-type series (default `false`)
+- **`borderRadius`** — Corner radius applied to bars (default `2`)
+- **`overview`** — `boolean | { height }` — Show the navigator strip; enabling it also turns on in-plot pan/zoom
+- **`navigator`** — `boolean | NavigatorInteractions` — Configure in-plot pan/zoom/brush directly
+- **`labels`** — `boolean | anchor` — Show value labels next to marks
+- **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines
+- **`crosshair`** — `boolean | ChartCrosshairOptions` — Show/configure crosshair
+- **`tooltip`** — `boolean | ChartTooltipOptions` — Show/configure tooltips
+- **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend
+- **`axis`** — `boolean | ChartAxisOptions` — Configure x/y axes
+- **`format`** — Format applied to values in tooltips and labels
+
+## Events
+
+Bar series emit `barclick` / `barenter` / `barleave`, and line/area markers emit `markerclick` / `markerenter` / `markerleave`. Each payload carries `{ x, y, xValue, yValue, seriesId }`:
+
+```ts
+chart.on('markerclick', event => {
+    const { seriesId, xValue, yValue } = event.data;
+    console.log(`${seriesId} @ ${xValue}: ${yValue}`);
 });
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -285,6 +285,13 @@ export default tseslint.config(
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
             '@typescript-eslint/no-empty-function': 'warn',
+            // Allow `_`-prefixed arguments (and caught errors) that are intentionally unused — e.g. a
+            // base hook whose default ignores a parameter that overrides consume. Unused local
+            // variables are still reported (delete them rather than prefixing).
+            '@typescript-eslint/no-unused-vars': ['error', {
+                'argsIgnorePattern': '^_',
+                'caughtErrorsIgnorePattern': '^_',
+            }],
             // Enforce `import type` for type-only imports so the codebase stays compatible with
             // `verbatimModuleSyntax` and the future TypeScript 7 compiler.
             '@typescript-eslint/consistent-type-imports': ['error', {

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -22,7 +22,6 @@ import type {
 
 import {
     normalizeDataLabels,
-    resolveLineDash,
     resolveValueFormat,
 } from '../core/options';
 
@@ -31,93 +30,50 @@ import type {
 } from '../core/options';
 
 import {
-    createDataLabel,
-    resolveDataLabelLayout,
-} from '../core/labels';
-
-import {
-    ANIMATION_REFERENCE,
-    exitElement,
-} from '../core/animation';
-
-import {
-    applyHoverHighlight,
-} from '../core/interaction';
-
-import {
     resolveAccessor,
 } from '../core/data';
+
+import {
+    AreaSeriesRenderer,
+} from '../core/series/area-series';
+
+import type {
+    AreaSeriesContext,
+    SeriesEventPhase,
+    SeriesInteractionEvent,
+} from '../core/series/context';
+
+import type {
+    ChartArea,
+} from '../core/layout';
 
 import type {
     LegendItem,
 } from '../components/legend';
 
 import type {
-    Circle,
-    CircleState,
     Context,
     EventMap,
-    Group,
-    Interpolator,
-    Point,
-    Polyline,
     PolylineRenderer,
-    PolylineState,
     Scale,
-    Text,
-    TextState,
 } from '@ripl/core';
 
 import {
     Box,
-    createCircle,
-    createGroup,
-    createPolyline,
     getExtent,
-    interpolatePath,
-    interpolatePoints,
-    interpolateWaypoint,
     scaleContinuous,
-    setColorAlpha,
 } from '@ripl/core';
 
 import {
-    correspondence,
-    keysDiffer,
-} from '../core/morph';
-
-import {
-    areaBandRenderer,
-} from '../core/fill';
-
-import {
-    arrayJoin,
     functionIdentity,
 } from '@ripl/utilities';
 
-/**
- * Builds an interpolator that reveals a filled area band left→right. At each position it grows a
- * closed polygon from the left edge to a moving front, following the real top boundary and closing
- * back along the lower boundary — a true wipe, unlike `interpolatePath` on the closed polygon
- * (which would trace the outline) or a horizontal scale (which stretches the series).
- */
-function interpolateAreaReveal(top: Point[], bottom: Point[]): Interpolator<Point[]> {
-    const lastIndex = top.length - 1;
-    const topAt = interpolateWaypoint(top);
-    const bottomAt = interpolateWaypoint(bottom);
-
-    return position => {
-        if (position >= 1) {
-            return [...top, ...bottom.slice().reverse()];
-        }
-
-        const count = Math.ceil(lastIndex * position);
-        const revealedTop = top.slice(0, count).concat([topAt(position)]);
-        const revealedBottom = bottom.slice(0, count).concat([bottomAt(position)]);
-
-        return [...revealedTop, ...revealedBottom.reverse()];
-    };
-}
+/** Maps a pointer interaction phase to the corresponding area-chart marker event name. */
+const MARKER_EVENTS = {
+    enter: 'markerenter',
+    leave: 'markerleave',
+    click: 'markerclick',
+} as const;
 
 /** Configuration for an individual area chart series. */
 export interface AreaChartSeriesOptions<TData> {
@@ -196,15 +152,14 @@ export interface AreaChartEventMap extends EventMap {
  *
  * Supports stacked and unstacked modes with optional markers, crosshair, tooltips, legend, chart
  * title, and grid. On entry the line draws on and the fill is revealed left-to-right (a true wipe,
- * not a horizontal stretch); areas transition smoothly on update and fade out on exit.
+ * not a horizontal stretch); areas transition smoothly on update and fade out on exit. Unstacked
+ * areas are painted largest-first so smaller areas are never hidden behind larger ones.
  *
  * @typeParam TData - The type of each data item in the dataset.
  */
 export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<TData>, TData, AreaChartEventMap> {
 
-    private _areaGroups: Group[] = [];
-    /** Previous ordered data keys per series, used to key-reconcile the line/fill morph across add/remove. */
-    private _morphKeys = new Map<string, string[]>();
+    private _series = new AreaSeriesRenderer<TData>();
     private _yScale!: Scale;
     private _xScale!: Scale<string>;
 
@@ -223,480 +178,28 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
         return resolveAccessor<TData, number>(series.value)(item);
     }
 
-    private _attachMarkerHover(marker: Circle, srs: AreaChartSeriesOptions<TData>, key: string, value: number, color: string, x: number, y: number) {
-        const formatValue = resolveValueFormat(this.options.format);
-
-        const payload = (point: { x: number;
-            y: number; }): AreaChartMarkerEvent => ({
-            x: point.x,
-            y: point.y,
-            xValue: key,
-            yValue: value,
-            seriesId: srs.id,
-        });
-
-        applyHoverHighlight(marker, {
-            renderer: this.renderer,
-            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
-            tooltip: this.tooltip,
-            anchor: () => ({
-                x,
-                y,
-            }),
-            content: () => `${srs.label}: ${formatValue(value)}`,
-            highlight: {
-                fill: color,
-                radius: 5,
-            },
-            restore: {
-                fill: '#FFFFFF',
-                radius: 3,
-            },
-            onEnter: point => this.emit('markerenter', payload(point)),
-            onLeave: point => this.emit('markerleave', payload(point)),
-            onClick: point => this.emit('markerclick', payload(point)),
-        });
+    private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
+        this.emit(MARKER_EVENTS[phase], event);
     }
 
-    private async _drawAreas(baseline: number, plot: { x: number;
-        y: number;
-        width: number;
-        height: number; }) {
-        const { data, series, key, stacked } = this.options;
-
-        const getKey = resolveAccessor<TData, string>(key);
-        const exitAnimation = this.resolveAnimation(ANIMATION_REFERENCE.exit);
-        const dataLabels = normalizeDataLabels(this.options.labels, { anchor: 'top' });
-        const formatValue = resolveValueFormat(this.options.format);
-
-        const {
-            left: seriesEntries,
-            inner: seriesUpdates,
-            right: seriesExits,
-        } = arrayJoin(series, this._areaGroups, 'id');
-
-        const enteringLabels: Text[] = [];
-        const updatingLabels: Text[] = [];
-
-        // Builds/updates the value label for a marker, positioned at its data point.
-        const buildLabel = (srs: AreaChartSeriesOptions<TData>) => (item: TData, dataIndex: number) => {
-            const x = this._xScale(getKey(item));
-            const y = this._yScale(getSeriesValue(srs, item, dataIndex));
-
-            return createDataLabel({
-                id: `${srs.id}-marker-${getKey(item)}-label`,
-                x,
-                y,
-                anchor: dataLabels.anchor,
-                content: formatValue(this._seriesValue(srs, item)),
-                font: dataLabels.font,
-                fill: dataLabels.fontColor,
-                offset: 7,
-            });
+    private _seriesContext(plot: ChartArea): AreaSeriesContext<TData> {
+        return {
+            data: this.options.data,
+            getKey: resolveAccessor<TData, string>(this.options.key),
+            yScale: this._yScale,
+            xScale: this._xScale,
+            stacked: this.options.stacked ?? false,
+            plot,
+            baseline: this._yScale(0),
+            renderer: this.renderer,
+            tooltip: this.tooltip,
+            getColor: id => this.getSeriesColor(id),
+            resolveAnimation: reference => this.resolveAnimation(reference),
+            formatValue: resolveValueFormat(this.options.format),
+            dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
+            addContent: elements => this.addPlotContent(elements),
+            emit: (phase, event) => this._emitMarker(phase, event),
         };
-
-        const updateLabel = (srs: AreaChartSeriesOptions<TData>, item: TData, dataIndex: number, label: Text) => {
-            const x = this._xScale(getKey(item));
-            const y = this._yScale(getSeriesValue(srs, item, dataIndex));
-            const layout = resolveDataLabelLayout({
-                x,
-                y,
-                anchor: dataLabels.anchor,
-                offset: 7,
-            });
-
-            label.content = formatValue(this._seriesValue(srs, item));
-            label.data = {
-                x: layout.x,
-                y: layout.y,
-                opacity: 1,
-            } as Partial<TextState>;
-        };
-
-        seriesExits.forEach(group => {
-            const exits = group.graph(false).map(element => exitElement(this.renderer, element, exitAnimation));
-            void Promise.all(exits).then(() => group.destroy());
-        });
-
-        // Precompute cumulative stacked values per data point.
-        const stackedValues: number[][] = [];
-
-        if (stacked) {
-            data.forEach((item, dataIndex) => {
-                stackedValues[dataIndex] = [];
-                let cumulative = 0;
-
-                series.forEach((srs, seriesIndex) => {
-                    cumulative += this._seriesValue(srs, item);
-                    stackedValues[dataIndex][seriesIndex] = cumulative;
-                });
-            });
-        }
-
-        const getSeriesValue = (srs: AreaChartSeriesOptions<TData>, item: TData, dataIndex: number) => {
-            const rawValue = this._seriesValue(srs, item);
-            const seriesIndex = series.indexOf(srs);
-
-            if (stacked && seriesIndex >= 0) {
-                return stackedValues[dataIndex]?.[seriesIndex] ?? rawValue;
-            }
-
-            return rawValue;
-        };
-
-        const getPrevSeriesValue = (srs: AreaChartSeriesOptions<TData>, dataIndex: number) => {
-            const seriesIndex = series.indexOf(srs);
-
-            if (stacked && seriesIndex > 0) {
-                return stackedValues[dataIndex]?.[seriesIndex - 1] ?? 0;
-            }
-
-            return 0;
-        };
-
-        const buildPoints = (srs: AreaChartSeriesOptions<TData>) => {
-            const linePoints: Point[] = [];
-            const bottomPoints: Point[] = [];
-
-            data.forEach((item, dataIndex) => {
-                const x = this._xScale(getKey(item));
-                const y = this._yScale(getSeriesValue(srs, item, dataIndex));
-                // Lower boundary: the previous series' cumulative top when stacked, else the baseline.
-                const bottomY = stacked ? this._yScale(getPrevSeriesValue(srs, dataIndex)) : baseline;
-
-                linePoints.push([x, y]);
-                bottomPoints.push([x, bottomY]);
-            });
-
-            // Closed band polygon: top edge left→right, then the lower boundary right→left.
-            const areaPoints: Point[] = [
-                ...linePoints,
-                ...bottomPoints.slice().reverse(),
-            ];
-
-            return {
-                linePoints,
-                bottomPoints,
-                areaPoints,
-            };
-        };
-
-        // Builds a marker circle for a data item (radius animates from 0 up to its rest size).
-        const buildMarker = (srs: AreaChartSeriesOptions<TData>) => {
-            const color = this.getSeriesColor(srs.id);
-
-            return (item: TData, dataIndex: number) => {
-                const x = this._xScale(getKey(item));
-                const y = this._yScale(getSeriesValue(srs, item, dataIndex));
-
-                const state: CircleState = {
-                    fill: '#FFFFFF',
-                    stroke: color,
-                    lineWidth: 2,
-                    cx: x,
-                    cy: y,
-                    radius: 3,
-                };
-
-                const marker = createCircle({
-                    id: `${srs.id}-marker-${getKey(item)}`,
-                    ...state,
-                    radius: 0,
-                    data: state,
-                });
-
-                this._attachMarkerHover(marker, srs, getKey(item), this._seriesValue(srs, item), color, x, y);
-
-                return marker;
-            };
-        };
-
-        // Top/bottom boundaries per entering series, used to drive the left→right reveal.
-        const entryReveal = new Map<string, { linePoints: Point[];
-            bottomPoints: Point[]; }>();
-
-        const seriesEntryGroups = seriesEntries.map(srs => {
-            const color = this.getSeriesColor(srs.id);
-            const opacity = srs.opacity ?? 0.3;
-            const showMarkers = srs.markers !== false;
-            const { linePoints, bottomPoints, areaPoints } = buildPoints(srs);
-            const makeMarker = buildMarker(srs);
-
-            entryReveal.set(srs.id, {
-                linePoints,
-                bottomPoints,
-            });
-
-            const markerElements: Circle[] = showMarkers
-                ? data.map((item, dataIndex) => makeMarker(item, dataIndex))
-                : [];
-
-            // Areas/lines are created at their final geometry; the entry transition reveals them
-            // left→right by progressively drawing their points (see the entry transitions below).
-            const areaFill = createPolyline({
-                id: `${srs.id}-area`,
-                fill: setColorAlpha(color, opacity),
-                stroke: undefined,
-                points: areaPoints,
-                // Curve only the top edge (matching the line) and straight-close the baseline; a
-                // plain curve renderer would smooth through the corners and gap away from the line.
-                renderer: areaBandRenderer(srs.lineType),
-                data: {
-                    points: areaPoints,
-                } as PolylineState,
-            });
-
-            areaFill.autoStroke = false;
-
-            const line = createPolyline({
-                id: `${srs.id}-line`,
-                lineWidth: srs.lineWidth ?? 2,
-                stroke: color,
-                lineDash: resolveLineDash(srs.lineStyle),
-                points: linePoints,
-                renderer: srs.lineType,
-                data: {
-                    points: linePoints,
-                } as PolylineState,
-            });
-
-            this._morphKeys.set(srs.id, data.map(getKey));
-
-            return createGroup({
-                id: srs.id,
-                children: [
-                    areaFill,
-                    line,
-                    ...markerElements,
-                    ...(dataLabels.visible ? data.map((item, dataIndex) => buildLabel(srs)(item, dataIndex)) : []),
-                ],
-            });
-        });
-
-        const seriesUpdateGroups = seriesUpdates.map(([srs, group]) => {
-            const color = this.getSeriesColor(srs.id);
-            const polylines = group.getElementsByType('polyline') as Polyline[];
-            const areaFill = polylines[0];
-            const line = polylines[1];
-            const markers = group.getElementsByType('circle') as Circle[];
-            const { linePoints, areaPoints } = buildPoints(srs);
-
-            const newKeys = data.map(getKey);
-            const prevKeys = this._morphKeys.get(srs.id);
-            const keyed = !!prevKeys && keysDiffer(prevKeys, newKeys);
-
-            // Apply the renderer directly (not via the transition, which would snap it at t=0.5) and
-            // key-reconcile the morph so curved lines/fills stay curved across add/remove. The fill is
-            // a closed [top, reversed-bottom] polygon, so its keys are disambiguated per run (t:/b:)
-            // to keep top matched to top and bottom to bottom.
-            line.renderer = srs.lineType;
-            areaFill.renderer = areaBandRenderer(srs.lineType);
-            // Dash pattern is a static style (not tweened) — apply it directly.
-            line.lineDash = resolveLineDash(srs.lineStyle);
-
-            const fillKeys = (keys: string[]): string[] => [
-                ...keys.map(key => `t:${key}`),
-                ...keys.slice().reverse().map(key => `b:${key}`),
-            ];
-
-            line.data = {
-                points: keyed
-                    ? interpolatePoints(line.points, linePoints, {
-                        resolveKeys: () => correspondence(prevKeys!, newKeys),
-                    })
-                    : linePoints,
-            };
-
-            areaFill.data = {
-                points: keyed
-                    ? interpolatePoints(areaFill.points, areaPoints, {
-                        resolveKeys: () => correspondence(fillKeys(prevKeys!), fillKeys(newKeys)),
-                    })
-                    : areaPoints,
-            };
-
-            this._morphKeys.set(srs.id, newKeys);
-
-            // Diff markers by key so new data points add markers and removed ones exit,
-            // instead of the previous index-based update that ignored points beyond the
-            // original marker count.
-            const makeMarker = buildMarker(srs);
-
-            const {
-                left: markerEntries,
-                inner: markerUpdates,
-                right: markerExits,
-            } = arrayJoin(data, markers, (item, marker) => marker.id === `${srs.id}-marker-${getKey(item)}`);
-
-            markerExits.forEach(marker => exitElement(this.renderer, marker, exitAnimation, {
-                radius: 0,
-                opacity: 0,
-            }));
-
-            if (srs.markers !== false) {
-                markerEntries.forEach(item => group.add(makeMarker(item, data.indexOf(item))));
-            }
-
-            markerUpdates.forEach(([item, marker]) => {
-                const dataIndex = data.indexOf(item);
-                const x = this._xScale(getKey(item));
-                const y = this._yScale(getSeriesValue(srs, item, dataIndex));
-
-                marker.data = {
-                    fill: '#FFFFFF',
-                    stroke: color,
-                    lineWidth: 2,
-                    cx: x,
-                    cy: y,
-                    radius: 3,
-                } as CircleState;
-
-                this._attachMarkerHover(marker, srs, getKey(item), this._seriesValue(srs, item), color, x, y);
-            });
-
-            // Reconcile value labels alongside the markers.
-            const labels = group.getElementsByType('text') as Text[];
-
-            if (dataLabels.visible) {
-                const {
-                    left: labelEntries,
-                    inner: labelUpdates,
-                    right: labelExits,
-                } = arrayJoin(data, labels, (item, label) => label.id === `${srs.id}-marker-${getKey(item)}-label`);
-
-                labelExits.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-
-                labelEntries.forEach(item => {
-                    const label = buildLabel(srs)(item, data.indexOf(item));
-                    group.add(label);
-                    enteringLabels.push(label);
-                });
-
-                labelUpdates.forEach(([item, label]) => {
-                    updateLabel(srs, item, data.indexOf(item), label);
-                    updatingLabels.push(label);
-                });
-            } else {
-                labels.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-            }
-
-            return group;
-        });
-
-        this.addPlotContent(seriesEntryGroups);
-
-        this._areaGroups = [
-            ...seriesEntryGroups,
-            ...seriesUpdateGroups,
-        ];
-
-        // Series groups map 1:1 to legend items (by id); register them for legend hover-highlight.
-        this.registerHighlightGroups(this._areaGroups);
-
-        const enter = this.resolveAnimation(ANIMATION_REFERENCE.enter);
-        const update = this.resolveAnimation(ANIMATION_REFERENCE.update);
-
-        // Updates morph polylines/markers to their new data in place.
-        const updateTransitions = seriesUpdateGroups.flatMap(group => {
-            const markers = group.getElementsByType('circle') as Circle[];
-            const polylines = group.getElementsByType('polyline') as Polyline[];
-
-            return [
-                ...polylines.map(polyline => this.renderer.transition(polyline, {
-                    duration: update.duration,
-                    ease: update.ease,
-                    state: polyline.data as PolylineState,
-                })),
-                ...(markers.length > 0
-                    ? [this.renderer.transition(markers, element => ({
-                        duration: update.duration,
-                        ease: update.ease,
-                        state: element.data as CircleState,
-                    }))]
-                    : []),
-            ];
-        });
-
-        // Entry: progressively draw the line and fill in from the left (a true left→right wipe,
-        // not a horizontal stretch) while each marker pops in as the reveal front passes its x.
-        const entryTransitions = seriesEntryGroups.flatMap(group => {
-            const markers = group.getElementsByType('circle') as Circle[];
-            const reveal = entryReveal.get(group.id);
-            // Group children are created as [areaFill, line, ...markers].
-            const polylines = group.getElementsByType('polyline') as Polyline[];
-            const areaFill = polylines[0];
-            const line = polylines[1];
-
-            const polylineTransitions = [];
-
-            if (line && reveal) {
-                polylineTransitions.push(this.renderer.transition(line, {
-                    duration: enter.duration,
-                    ease: enter.ease,
-                    state: { points: interpolatePath(reveal.linePoints) },
-                }));
-            }
-
-            if (areaFill && reveal) {
-                polylineTransitions.push(this.renderer.transition(areaFill, {
-                    duration: enter.duration,
-                    ease: enter.ease,
-                    state: { points: interpolateAreaReveal(reveal.linePoints, reveal.bottomPoints) },
-                }));
-            }
-
-            return [
-                ...polylineTransitions,
-                ...(markers.length > 0
-                    ? [this.renderer.transition(markers, element => {
-                        const fraction = plot.width > 0
-                            ? Math.min(Math.max(((element as Circle).cx - plot.x) / plot.width, 0), 1)
-                            : 0;
-
-                        return {
-                            duration: enter.duration * 0.4,
-                            delay: fraction * enter.duration,
-                            ease: enter.ease,
-                            state: element.data as CircleState,
-                        };
-                    })]
-                    : []),
-            ];
-        });
-
-        // Value labels: entry labels fade in; updated labels animate to their refreshed position.
-        const entryLabels = seriesEntryGroups.flatMap(group => group.getElementsByType('text') as Text[]);
-        const labelTransitions: Promise<unknown>[] = [];
-
-        if (entryLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(entryLabels, {
-                duration: enter.duration,
-                ease: enter.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (enteringLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(enteringLabels, {
-                duration: update.duration,
-                ease: update.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (updatingLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(updatingLabels, element => ({
-                duration: update.duration,
-                ease: update.ease,
-                state: element.data as Partial<TextState>,
-            })));
-        }
-
-        return Promise.all([
-            ...entryTransitions,
-            ...updateTransitions,
-            ...labelTransitions,
-        ]);
     }
 
     public async render() {
@@ -782,7 +285,6 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             this.xAxis.scale = this._xScale;
             this.yAxis.scale = this._yScale;
 
-            const baseline = this._yScale(0);
             const plot = {
                 x: yAxisBox.right,
                 y: top,
@@ -794,10 +296,13 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             this.renderGrid([], this._yScale.ticks(10).map(tick => this._yScale(tick)), plot);
             this.setupCrosshair(plot);
 
+            const seriesRender = this._series.render(series, this._seriesContext(plot));
+            this.registerHighlightGroups(this._series.groups);
+
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
                 this.yAxis.visible ? this.yAxis.render() : Promise.resolve(),
-                this._drawAreas(baseline, plot),
+                seriesRender,
             ]);
         });
     }

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -44,6 +44,10 @@ import type {
 } from '../core/series/context';
 
 import type {
+    ChartNavigatorSeries,
+} from '../components/navigator';
+
+import type {
     ChartArea,
 } from '../core/layout';
 
@@ -174,12 +178,29 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
         this.init();
     }
 
+    /** Area charts are category-on-x, so the navigator windows the x axis (bottom scrub bar). */
+    protected override navigationAxis(): 'x' {
+        return 'x';
+    }
+
     private _seriesValue(series: AreaChartSeriesOptions<TData>, item: TData): number {
         return resolveAccessor<TData, number>(series.value)(item);
     }
 
     private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
         this.emit(MARKER_EVENTS[phase], event);
+    }
+
+    /** Builds the per-series overview data (id, colour, type, values) for the navigator strip. */
+    private _overviewSeries(): ChartNavigatorSeries[] {
+        const { data, series } = this.options;
+
+        return series.map(srs => ({
+            id: srs.id,
+            color: this.getSeriesColor(srs.id),
+            type: 'area' as const,
+            values: data.map(item => this._seriesValue(srs, item)),
+        }));
     }
 
     private _seriesContext(plot: ChartArea): AreaSeriesContext<TData> {
@@ -256,6 +277,9 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
 
             this.reserveLegend(layout, legendItems);
 
+            // Reserve the overview strip band from the bottom before the axes are measured.
+            const navBand = this.reserveNavigatorBand(layout);
+
             const area = layout.area;
             const left = area.x;
             const top = area.y;
@@ -278,12 +302,10 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds.bottom = xAxisBox.top;
 
-            // Rescale to the navigator's view (no-op at rest): continuous y via domain rescale,
-            // categorical x via a pixel-space transform, so geometry and axes track together.
-            this._yScale = this.applyView(this._yScale, 'y');
+            // The navigator windows the x (category) axis only — the value axis stays at the full
+            // extent, so the strip scrubs horizontally without rescaling the y domain.
             this._xScale = this.applyViewToScale(this._xScale, 'x');
             this.xAxis.scale = this._xScale;
-            this.yAxis.scale = this._yScale;
 
             const plot = {
                 x: yAxisBox.right,
@@ -298,6 +320,8 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
 
             const seriesRender = this._series.render(series, this._seriesContext(plot));
             this.registerHighlightGroups(this._series.groups);
+
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -321,7 +321,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             const seriesRender = this._series.render(series, this._seriesContext(plot));
             this.registerHighlightGroups(this._series.groups);
 
-            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]], stacked ?? false);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -30,6 +30,7 @@ import type {
 } from '../core/options';
 
 import {
+    cumulativeExtent,
     resolveAccessor,
 } from '../core/data';
 
@@ -195,12 +196,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
     private _overviewSeries(): ChartNavigatorSeries[] {
         const { data, series } = this.options;
 
-        return series.map(srs => ({
-            id: srs.id,
-            color: this.getSeriesColor(srs.id),
-            type: 'area' as const,
-            values: data.map(item => this._seriesValue(srs, item)),
-        }));
+        return this.buildOverviewSeries(series, data, () => 'area', (srs, item) => this._seriesValue(srs, item));
     }
 
     private _seriesContext(plot: ChartArea): AreaSeriesContext<TData> {
@@ -236,25 +232,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             let dataExtent: number[];
 
             if (stacked) {
-                let stackedMax = 0;
-                let stackedMin = 0;
-
-                data.forEach(item => {
-                    let cumulative = 0;
-                    let cumulativeMax = 0;
-                    let cumulativeMin = 0;
-
-                    series.forEach(srs => {
-                        cumulative += this._seriesValue(srs, item);
-                        cumulativeMax = Math.max(cumulativeMax, cumulative);
-                        cumulativeMin = Math.min(cumulativeMin, cumulative);
-                    });
-
-                    stackedMax = Math.max(stackedMax, cumulativeMax);
-                    stackedMin = Math.min(stackedMin, cumulativeMin);
-                });
-
-                dataExtent = [stackedMin, stackedMax];
+                dataExtent = cumulativeExtent(series, data, (srs, item) => this._seriesValue(srs, item));
             } else {
                 const seriesExtents = series
                     .flatMap(srs => getExtent(data, item => this._seriesValue(srs, item)))

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -185,6 +185,11 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
         return this._isHorizontal ? 'y' : 'x';
     }
 
+    /** Bars are laid out in padded category bands, so the overview strip mirrors that band placement. */
+    protected override navigatorCategoryLayout(): 'band' {
+        return 'band';
+    }
+
     private _seriesValue(series: BarChartSeriesOptions<TData>, item: TData): number {
         return resolveAccessor<TData, number>(series.value)(item);
     }
@@ -337,7 +342,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, adjustedValueScale, horizontalPlot));
                 this.registerHighlightGroups(this._series.groups);
 
-                this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
+                this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]], this._isStacked);
 
                 return Promise.all([
                     this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
@@ -391,7 +396,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, adjustedValueScale, verticalPlot));
             this.registerHighlightGroups(this._series.groups);
 
-            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]], this._isStacked);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -39,6 +39,10 @@ import type {
 } from '../core/series/context';
 
 import type {
+    ChartNavigatorSeries,
+} from '../components/navigator';
+
+import type {
     ChartArea,
 } from '../core/layout';
 
@@ -176,12 +180,29 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
         return this.options.mode === 'stacked';
     }
 
+    /** Bar charts window their category axis: y when horizontal (side strip), x otherwise (bottom strip). */
+    protected override navigationAxis(): 'x' | 'y' {
+        return this._isHorizontal ? 'y' : 'x';
+    }
+
     private _seriesValue(series: BarChartSeriesOptions<TData>, item: TData): number {
         return resolveAccessor<TData, number>(series.value)(item);
     }
 
     private _emitBar(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
         this.emit(BAR_EVENTS[phase], event);
+    }
+
+    /** Builds the per-series overview data (id, colour, type, values) for the navigator strip. */
+    private _overviewSeries(): ChartNavigatorSeries[] {
+        const { data, series } = this.options;
+
+        return series.map(srs => ({
+            id: srs.id,
+            color: this.getSeriesColor(srs.id),
+            type: 'bar' as const,
+            values: data.map(item => this._seriesValue(srs, item)),
+        }));
     }
 
     private _seriesContext(categoryScale: BandScale<string>, valueScale: Scale, plot: ChartArea): BarSeriesContext<TData> {
@@ -260,6 +281,10 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
             this.reserveLegend(layout, legendItems);
 
+            // Reserve the overview strip band before the axes are measured (a side band for a horizontal
+            // bar chart, a bottom band for a vertical one).
+            const navBand = this.reserveNavigatorBand(layout);
+
             const area = layout.area;
             const left = area.x;
             const top = area.y;
@@ -289,11 +314,9 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 this.xAxis.scale = adjustedValueScale;
                 this.xAxis.bounds = new Box(top, yAxisBox.right, bottom, right);
 
-                // Apply the navigator view (no-op at rest): values (x) via domain rescale, categories
-                // (y) via a pixel-space transform, so bars and both axes track the pan/zoom together.
-                const viewedValueScale = this.applyView(adjustedValueScale, 'x');
+                // The navigator windows the y (category) axis only — the value axis (x) stays at the full
+                // extent, so the side strip scrubs vertically without rescaling the value domain.
                 const viewedCategoryScale = this.applyViewToScale(categoryScale, 'y');
-                this.xAxis.scale = viewedValueScale;
                 this.yAxis.scale = this.bandCenterScale(viewedCategoryScale, keys);
 
                 const horizontalPlot = {
@@ -306,13 +329,15 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 this.clipPlot(horizontalPlot);
 
                 this.renderGrid(
-                    viewedValueScale.ticks(10).map(tick => viewedValueScale(tick)),
+                    adjustedValueScale.ticks(10).map(tick => adjustedValueScale(tick)),
                     [],
                     horizontalPlot
                 );
 
-                const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, viewedValueScale, horizontalPlot));
+                const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, adjustedValueScale, horizontalPlot));
                 this.registerHighlightGroups(this._series.groups);
+
+                this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
 
                 return Promise.all([
                     this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
@@ -343,11 +368,9 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             this.yAxis.scale = adjustedValueScale;
             this.yAxis.bounds = new Box(top, left, xAxisBox.top, right);
 
-            // Apply the navigator view (no-op at rest): values (y) via domain rescale, categories (x)
-            // via a pixel-space transform, so bars and both axes track the pan/zoom together.
-            const viewedValueScale = this.applyView(adjustedValueScale, 'y');
+            // The navigator windows the x (category) axis only — the value axis (y) stays at the full
+            // extent, so the bottom strip scrubs horizontally without rescaling the value domain.
             const viewedCategoryScale = this.applyViewToScale(categoryScale, 'x');
-            this.yAxis.scale = viewedValueScale;
             this.xAxis.scale = this.bandCenterScale(viewedCategoryScale, keys);
 
             const verticalPlot = {
@@ -361,12 +384,14 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
             this.renderGrid(
                 [],
-                viewedValueScale.ticks(10).map(tick => viewedValueScale(tick)),
+                adjustedValueScale.ticks(10).map(tick => adjustedValueScale(tick)),
                 verticalPlot
             );
 
-            const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, viewedValueScale, verticalPlot));
+            const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, adjustedValueScale, verticalPlot));
             this.registerHighlightGroups(this._series.groups);
+
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -25,6 +25,7 @@ import {
 } from '../core/options';
 
 import {
+    positiveNegativeExtent,
     resolveAccessor,
 } from '../core/data';
 
@@ -202,12 +203,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
     private _overviewSeries(): ChartNavigatorSeries[] {
         const { data, series } = this.options;
 
-        return series.map(srs => ({
-            id: srs.id,
-            color: this.getSeriesColor(srs.id),
-            type: 'bar' as const,
-            values: data.map(item => this._seriesValue(srs, item)),
-        }));
+        return this.buildOverviewSeries(series, data, () => 'bar', (srs, item) => this._seriesValue(srs, item));
     }
 
     private _seriesContext(categoryScale: BandScale<string>, valueScale: Scale, plot: ChartArea): BarSeriesContext<TData> {
@@ -247,28 +243,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             let dataExtent = getExtent(seriesExtents, functionIdentity);
 
             if (this._isStacked) {
-                let stackedMax = 0;
-                let stackedMin = 0;
-
-                data.forEach(item => {
-                    let positiveTotal = 0;
-                    let negativeTotal = 0;
-
-                    series.forEach(srs => {
-                        const value = this._seriesValue(srs, item);
-
-                        if (value >= 0) {
-                            positiveTotal += value;
-                        } else {
-                            negativeTotal += value;
-                        }
-                    });
-
-                    stackedMax = Math.max(stackedMax, positiveTotal);
-                    stackedMin = Math.min(stackedMin, negativeTotal);
-                });
-
-                dataExtent = [stackedMin, stackedMax];
+                dataExtent = positiveNegativeExtent(series, data, (srs, item) => this._seriesValue(srs, item));
             }
 
             // Shared layout pass: title and legend reserve their bands first.

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -25,24 +25,22 @@ import {
 } from '../core/options';
 
 import {
-    createDataLabel,
-    resolveDataLabelLayout,
-} from '../core/labels';
-
-import {
-    ANIMATION_REFERENCE,
-    exitElement,
-    stagger,
-} from '../core/animation';
-
-import {
-    applyHoverHighlight,
-} from '../core/interaction';
-
-import {
-    computeStackOffset,
     resolveAccessor,
 } from '../core/data';
+
+import {
+    BarSeriesRenderer,
+} from '../core/series/bar-series';
+
+import type {
+    BarSeriesContext,
+    SeriesEventPhase,
+    SeriesInteractionEvent,
+} from '../core/series/context';
+
+import type {
+    ChartArea,
+} from '../core/layout';
 
 import type {
     LegendItem,
@@ -50,30 +48,19 @@ import type {
 
 import type {
     BandScale,
-    BorderRadius,
     Context,
     EventMap,
-    Group,
-    Rect,
-    RectState,
-    Text,
-    TextState,
+    Scale,
 } from '@ripl/core';
 
 import {
     Box,
-    createGroup,
-    createRect,
     getExtent,
-    max,
-    queryAll,
     scaleBand,
     scaleContinuous,
-    setColorAlpha,
 } from '@ripl/core';
 
 import {
-    arrayJoin,
     functionIdentity,
 } from '@ripl/utilities';
 
@@ -82,8 +69,12 @@ export type BarChartOrientation = 'vertical' | 'horizontal';
 /** Whether multiple series are drawn side by side (`grouped`) or accumulated into one column (`stacked`). */
 export type BarChartMode = 'grouped' | 'stacked';
 
-/** The opacity applied to a bar's fill at rest (full opacity is used on hover). */
-const REST_ALPHA = 0.78;
+/** Maps a pointer interaction phase to the corresponding bar-chart event name. */
+const BAR_EVENTS = {
+    enter: 'barenter',
+    leave: 'barleave',
+    click: 'barclick',
+} as const;
 
 /** Configuration for an individual bar chart series. */
 export interface BarChartSeriesOptions<TData> {
@@ -162,7 +153,7 @@ export interface BarChartEventMap extends EventMap {
  */
 export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TData>, TData, BarChartEventMap> {
 
-    private _barGroups: Group[] = [];
+    private _series = new BarSeriesRenderer<TData>();
 
     constructor(target: string | HTMLElement | Context, options: BarChartOptions<TData>) {
         super(target, options);
@@ -189,456 +180,31 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
         return resolveAccessor<TData, number>(series.value)(item);
     }
 
-    private _stackOffset(series: BarChartSeriesOptions<TData>[], current: BarChartSeriesOptions<TData>, item: TData): number {
-        if (!this._isStacked) {
-            return 0;
-        }
-
-        return computeStackOffset(series, current, item, (s, i) => this._seriesValue(s, i));
+    private _emitBar(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
+        this.emit(BAR_EVENTS[phase], event);
     }
 
-    /** Wires consistent hover highlight + tooltip + interaction events onto a bar. */
-    private _attachBarHover(bar: Rect, srs: BarChartSeriesOptions<TData>, key: string, value: number, anchor: () => { x: number;
-        y: number; }) {
-        const restFill = bar.fill as string;
-        const formatValue = resolveValueFormat(this.options.format);
-
-        const payload = (point: { x: number;
-            y: number; }): BarChartBarEvent => ({
-            x: point.x,
-            y: point.y,
-            xValue: key,
-            yValue: value,
-            seriesId: srs.id,
-        });
-
-        applyHoverHighlight(bar, {
+    private _seriesContext(categoryScale: BandScale<string>, valueScale: Scale, plot: ChartArea): BarSeriesContext<TData> {
+        return {
+            data: this.options.data,
+            getKey: resolveAccessor<TData, string>(this.options.key),
+            yScale: valueScale,
+            valueScale,
+            categoryScale,
+            orientation: this._isHorizontal ? 'horizontal' : 'vertical',
+            stacked: this._isStacked,
+            borderRadius: this.options.borderRadius ?? 2,
+            plot,
+            baseline: valueScale(0),
             renderer: this.renderer,
-            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
-            anchor,
-            content: () => `${srs.label}: ${formatValue(value)}`,
-            highlight: { fill: setColorAlpha(restFill, 1) },
-            restore: { fill: restFill },
-            onEnter: point => this.emit('barenter', payload(point)),
-            onLeave: point => this.emit('barleave', payload(point)),
-            onClick: point => this.emit('barclick', payload(point)),
-        });
-    }
-
-    private async _drawBars(
-        categoryScale: BandScale<string>,
-        valueScale: ReturnType<typeof scaleContinuous>,
-        getKey: (item: TData) => string
-    ) {
-        const { data, series } = this.options;
-        const horizontal = this._isHorizontal;
-        const baseline = valueScale(0);
-        const cornerRadius = this.options.borderRadius ?? 2;
-        const dataLabels = normalizeDataLabels(this.options.labels, { anchor: horizontal ? 'right' : 'top' });
-        const formatValue = resolveValueFormat(this.options.format);
-
-        let seriesScale: BandScale<string> | undefined;
-
-        if (!this._isStacked) {
-            seriesScale = scaleBand(series.map(s => s.id), [0, categoryScale.bandwidth], {
-                innerPadding: 0.1,
-            });
-        }
-
-        // Per-column totals (by sign) and category order — used to round only the outermost
-        // segment of a stack and to time the stacked entry as a single rising fill.
-        const keyIndex = new Map<string, number>(data.map((item, index) => [getKey(item), index]));
-        const columnTotals = new Map<string, { pos: number;
-            neg: number; }>();
-
-        data.forEach(item => {
-            let pos = 0;
-            let neg = 0;
-
-            series.forEach(srs => {
-                const value = this._seriesValue(srs, item);
-
-                if (value >= 0) {
-                    pos += value;
-                } else {
-                    neg += -value;
-                }
-            });
-
-            columnTotals.set(getKey(item), {
-                pos,
-                neg,
-            });
-        });
-
-        // The index of the last same-sign series contributing to a column (its outermost segment).
-        const outermostStackIndex = (item: TData, positive: boolean) => {
-            let outer = -1;
-
-            series.forEach((srs, index) => {
-                const value = this._seriesValue(srs, item);
-
-                if (value === 0) {
-                    return;
-                }
-
-                if ((value >= 0) === positive) {
-                    outer = index;
-                }
-            });
-
-            return outer;
+            getColor: id => this.getSeriesColor(id),
+            resolveAnimation: reference => this.resolveAnimation(reference),
+            formatValue: resolveValueFormat(this.options.format),
+            dataLabels: normalizeDataLabels(this.options.labels, { anchor: this._isHorizontal ? 'right' : 'top' }),
+            addContent: elements => this.addPlotContent(elements),
+            emit: (phase, event) => this._emitBar(phase, event),
         };
-
-        const stackedBorderRadius = (srs: BarChartSeriesOptions<TData>, item: TData, value: number): number | BorderRadius => {
-            const positive = value >= 0;
-
-            if (series.indexOf(srs) !== outermostStackIndex(item, positive)) {
-                return 0;
-            }
-
-            if (horizontal) {
-                return positive
-                    ? [0, cornerRadius, cornerRadius, 0]
-                    : [cornerRadius, 0, 0, cornerRadius];
-            }
-
-            return positive
-                ? [cornerRadius, cornerRadius, 0, 0]
-                : [0, 0, cornerRadius, cornerRadius];
-        };
-
-        const entryTiming = new Map<string, { delayFraction: number;
-            durationFraction: number;
-            columnIndex: number; }>();
-
-        const getBarState = (srs: BarChartSeriesOptions<TData>, item: TData) => {
-            const value = this._seriesValue(srs, item);
-            const key = getKey(item);
-            const color = this.getSeriesColor(srs.id);
-            const stackOffset = this._stackOffset(series, srs, item);
-
-            let x: number;
-            let y: number;
-            let width: number;
-            let height: number;
-
-            if (horizontal) {
-                if (this._isStacked) {
-                    y = categoryScale(key);
-                    height = categoryScale.bandwidth;
-                    x = valueScale(value >= 0 ? stackOffset : value + stackOffset);
-                    width = Math.abs(valueScale(0) - valueScale(Math.abs(value)));
-                } else {
-                    y = categoryScale(key) + (seriesScale ? seriesScale(srs.id) : 0);
-                    height = seriesScale ? seriesScale.bandwidth : categoryScale.bandwidth;
-                    x = Math.min(baseline, valueScale(value));
-                    width = Math.abs(valueScale(value) - baseline);
-                }
-            } else if (this._isStacked) {
-                x = categoryScale(key);
-                width = categoryScale.bandwidth;
-                y = valueScale(value >= 0 ? value + stackOffset : stackOffset);
-                height = Math.abs(valueScale(0) - valueScale(Math.abs(value)));
-            } else {
-                x = categoryScale(key) + (seriesScale ? seriesScale(srs.id) : 0);
-                width = seriesScale ? seriesScale.bandwidth : categoryScale.bandwidth;
-                y = valueScale(max(0, value));
-                height = Math.abs(baseline - valueScale(value));
-            }
-
-            const borderRadius = this._isStacked ? stackedBorderRadius(srs, item, value) : cornerRadius;
-
-            if (this._isStacked) {
-                const totals = columnTotals.get(key);
-                const columnTotal = value >= 0 ? (totals?.pos ?? 0) : (totals?.neg ?? 0);
-
-                entryTiming.set(`${srs.id}-${key}`, {
-                    delayFraction: columnTotal > 0 ? Math.abs(stackOffset) / columnTotal : 0,
-                    durationFraction: columnTotal > 0 ? Math.abs(value) / columnTotal : 1,
-                    columnIndex: keyIndex.get(key) ?? 0,
-                });
-            }
-
-            return {
-                id: `${srs.id}-${key}`,
-                value,
-                state: {
-                    fill: color,
-                    x,
-                    y,
-                    width,
-                    height,
-                    borderRadius,
-                } as RectState,
-            };
-        };
-
-        const anchorFor = (state: RectState) => () => (horizontal
-            ? {
-                x: state.x + state.width,
-                y: state.y + state.height / 2,
-            }
-            : {
-                x: state.x + state.width / 2,
-                y: state.y,
-            });
-
-        // The collapsed initial geometry an entering/exiting bar grows from (chart baseline).
-        const collapsed = (): Partial<RectState> => (horizontal
-            ? {
-                x: baseline,
-                width: 0,
-            }
-            : {
-                y: baseline,
-                height: 0,
-            });
-
-        // A stacked segment collapses to its own lower edge so the column reveals as one rising
-        // fill rather than every segment growing from the chart baseline.
-        const collapsedEntry = (srs: BarChartSeriesOptions<TData>, item: TData): Partial<RectState> => {
-            if (!this._isStacked) {
-                return collapsed();
-            }
-
-            const stackOffset = this._stackOffset(series, srs, item);
-
-            return horizontal
-                ? {
-                    x: valueScale(stackOffset),
-                    width: 0,
-                }
-                : {
-                    y: valueScale(stackOffset),
-                    height: 0,
-                };
-        };
-
-        const createBar = (srs: BarChartSeriesOptions<TData>) => (item: TData) => {
-            const { id, value, state } = getBarState(srs, item);
-            const restFill = setColorAlpha(state.fill as string, REST_ALPHA);
-
-            const bar = createRect({
-                id,
-                ...state,
-                ...collapsedEntry(srs, item),
-                fill: restFill,
-                data: {
-                    ...state,
-                    fill: restFill,
-                },
-            });
-
-            this._attachBarHover(bar, srs, getKey(item), value, anchorFor(state));
-
-            return bar;
-        };
-
-        // Builds the value label for a bar, positioned at the bar's outer-edge anchor.
-        const createBarLabel = (srs: BarChartSeriesOptions<TData>) => (item: TData) => {
-            const { id, value, state } = getBarState(srs, item);
-            const point = anchorFor(state)();
-
-            return createDataLabel({
-                id: `${id}-label`,
-                x: point.x,
-                y: point.y,
-                anchor: dataLabels.anchor,
-                content: formatValue(value),
-                font: dataLabels.font,
-                fill: dataLabels.fontColor,
-            });
-        };
-
-        // Repositions/refreshes an existing label for an updated bar (data drives the transition).
-        const updateBarLabel = (srs: BarChartSeriesOptions<TData>, item: TData, label: Text) => {
-            const { value, state } = getBarState(srs, item);
-            const point = anchorFor(state)();
-            const layout = resolveDataLabelLayout({
-                x: point.x,
-                y: point.y,
-                anchor: dataLabels.anchor,
-            });
-
-            label.content = formatValue(value);
-            label.data = {
-                x: layout.x,
-                y: layout.y,
-                opacity: 1,
-            } as Partial<TextState>;
-        };
-
-        const {
-            left: seriesEntries,
-            inner: seriesUpdates,
-            right: seriesExits,
-        } = arrayJoin(series, this._barGroups, 'id');
-
-        // Exit removed series.
-        const exitAnimation = this.resolveAnimation(ANIMATION_REFERENCE.exit);
-
-        seriesExits.forEach(group => {
-            const exits = (group.getElementsByType('rect') as Rect[]).map(bar => exitElement(this.renderer, bar, exitAnimation, {
-                ...collapsed(),
-                opacity: 0,
-            }));
-
-            void Promise.all(exits).then(() => group.destroy());
-        });
-
-        const seriesEntryGroups = seriesEntries.map(srs => createGroup({
-            id: srs.id,
-            children: [
-                ...data.map(createBar(srs)),
-                ...(dataLabels.visible ? data.map(createBarLabel(srs)) : []),
-            ],
-        }));
-
-        // Labels added/repositioned during the update pass, animated after the maps below.
-        const enteringLabels: Text[] = [];
-        const updatingLabels: Text[] = [];
-
-        const seriesUpdateGroups = seriesUpdates.map(([srs, group]) => {
-            const bars = group.getElementsByType('rect') as Rect[];
-
-            const {
-                left: barEntries,
-                inner: barUpdates,
-                right: barExits,
-            } = arrayJoin(data, bars, (item, bar) => bar.id === `${srs.id}-${getKey(item)}`);
-
-            barExits.forEach(bar => exitElement(this.renderer, bar, exitAnimation, {
-                ...collapsed(),
-                opacity: 0,
-            }));
-
-            barEntries.forEach(item => group.add(createBar(srs)(item)));
-
-            barUpdates.forEach(([item, bar]) => {
-                const { value, state } = getBarState(srs, item);
-                const restFill = setColorAlpha(state.fill as string, REST_ALPHA);
-
-                bar.data = {
-                    ...state,
-                    fill: restFill,
-                };
-
-                this._attachBarHover(bar, srs, getKey(item), value, anchorFor(state));
-            });
-
-            // Reconcile value labels alongside the bars.
-            const labels = group.getElementsByType('text') as Text[];
-
-            if (dataLabels.visible) {
-                const {
-                    left: labelEntries,
-                    inner: labelUpdates,
-                    right: labelExits,
-                } = arrayJoin(data, labels, (item, label) => label.id === `${srs.id}-${getKey(item)}-label`);
-
-                labelExits.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-
-                labelEntries.forEach(item => {
-                    const label = createBarLabel(srs)(item);
-                    group.add(label);
-                    enteringLabels.push(label);
-                });
-
-                labelUpdates.forEach(([item, label]) => {
-                    updateBarLabel(srs, item, label);
-                    updatingLabels.push(label);
-                });
-            } else {
-                labels.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-            }
-
-            return group;
-        });
-
-        this.addPlotContent(seriesEntryGroups);
-
-        this._barGroups = [
-            ...seriesEntryGroups,
-            ...seriesUpdateGroups,
-        ];
-
-        // Series groups map 1:1 to legend items (by id); register them for legend hover-highlight.
-        this.registerHighlightGroups(this._barGroups);
-
-        const enterAnimation = this.resolveAnimation(ANIMATION_REFERENCE.enter);
-        const updateAnimation = this.resolveAnimation(ANIMATION_REFERENCE.update);
-
-        const barEntries = (queryAll(seriesEntryGroups, 'rect') as Rect[])
-            .sort((a, b) => (horizontal ? a.y - b.y : a.x - b.x));
-
-        const categoryCount = Math.max(1, keyIndex.size);
-
-        const entriesTransition = this.renderer.transition(barEntries, (element, index, length) => {
-            // Stacked: each column fills as one rising unit — segments are timed by their position
-            // in the stack so the fill front sweeps the whole column once, in colour order.
-            if (this._isStacked) {
-                const timing = entryTiming.get(element.id);
-                const columnDelay = stagger(timing?.columnIndex ?? 0, categoryCount, enterAnimation.duration) * 0.4;
-
-                return {
-                    duration: Math.max((timing?.durationFraction ?? 1) * enterAnimation.duration, 80),
-                    delay: columnDelay + (timing?.delayFraction ?? 0) * enterAnimation.duration,
-                    ease: enterAnimation.ease,
-                    state: element.data as RectState,
-                };
-            }
-
-            return {
-                duration: enterAnimation.duration,
-                delay: stagger(index, length, enterAnimation.duration),
-                ease: enterAnimation.ease,
-                state: element.data as RectState,
-            };
-        });
-
-        const updatesTransition = this.renderer.transition(queryAll(seriesUpdateGroups, 'rect') as Rect[], element => ({
-            duration: updateAnimation.duration,
-            ease: updateAnimation.ease,
-            state: element.data as RectState,
-        }));
-
-        // Value labels: entry labels (on new series and new bars) fade in; updated labels
-        // animate to their refreshed position.
-        const entryLabels = queryAll(seriesEntryGroups, 'text') as Text[];
-
-        const labelTransitions: Promise<unknown>[] = [];
-
-        if (entryLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(entryLabels, {
-                duration: enterAnimation.duration,
-                ease: enterAnimation.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (enteringLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(enteringLabels, {
-                duration: updateAnimation.duration,
-                ease: updateAnimation.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (updatingLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(updatingLabels, element => ({
-                duration: updateAnimation.duration,
-                ease: updateAnimation.ease,
-                state: element.data as Partial<TextState>,
-            })));
-        }
-
-        return Promise.all([
-            entriesTransition,
-            updatesTransition,
-            ...labelTransitions,
-        ]);
     }
 
     public async render() {
@@ -714,7 +280,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                     innerPadding: 0.2,
                 });
 
-                this.yAxis.scale = this._bandAxisScale(categoryScale, keys);
+                this.yAxis.scale = this.bandCenterScale(categoryScale, keys);
                 this.yAxis.bounds = new Box(top, left, xAxisBox.top, right);
 
                 const yAxisBox = this.yAxis.getBoundingBox();
@@ -728,7 +294,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 const viewedValueScale = this.applyView(adjustedValueScale, 'x');
                 const viewedCategoryScale = this.applyViewToScale(categoryScale, 'y');
                 this.xAxis.scale = viewedValueScale;
-                this.yAxis.scale = this._bandAxisScale(viewedCategoryScale, keys);
+                this.yAxis.scale = this.bandCenterScale(viewedCategoryScale, keys);
 
                 const horizontalPlot = {
                     x: yAxisBox.right,
@@ -745,10 +311,13 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                     horizontalPlot
                 );
 
+                const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, viewedValueScale, horizontalPlot));
+                this.registerHighlightGroups(this._series.groups);
+
                 return Promise.all([
                     this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
                     this.yAxis.visible ? this.yAxis.render() : Promise.resolve(),
-                    this._drawBars(viewedCategoryScale, viewedValueScale, getKey),
+                    seriesRender,
                 ]);
             }
 
@@ -765,7 +334,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 innerPadding: 0.2,
             });
 
-            this.xAxis.scale = this._bandAxisScale(categoryScale, keys);
+            this.xAxis.scale = this.bandCenterScale(categoryScale, keys);
             this.xAxis.bounds = new Box(top, yAxisBox.right, bottom, right);
 
             const xAxisBox = this.xAxis.getBoundingBox();
@@ -779,7 +348,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             const viewedValueScale = this.applyView(adjustedValueScale, 'y');
             const viewedCategoryScale = this.applyViewToScale(categoryScale, 'x');
             this.yAxis.scale = viewedValueScale;
-            this.xAxis.scale = this._bandAxisScale(viewedCategoryScale, keys);
+            this.xAxis.scale = this.bandCenterScale(viewedCategoryScale, keys);
 
             const verticalPlot = {
                 x: yAxisBox.right,
@@ -796,26 +365,15 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 verticalPlot
             );
 
+            const seriesRender = this._series.render(series, this._seriesContext(viewedCategoryScale, viewedValueScale, verticalPlot));
+            this.registerHighlightGroups(this._series.groups);
+
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
                 this.yAxis.visible ? this.yAxis.render() : Promise.resolve(),
-                this._drawBars(viewedCategoryScale, viewedValueScale, getKey),
+                seriesRender,
             ]);
         });
-    }
-
-    /** Wraps a band scale so an axis renders one centred tick per category. */
-    private _bandAxisScale(categoryScale: BandScale<string>, keys: string[]) {
-        return Object.assign(
-            (value: string) => categoryScale(value) + categoryScale.bandwidth / 2,
-            {
-                domain: keys,
-                range: categoryScale.range,
-                inverse: categoryScale.inverse,
-                ticks: () => keys,
-                includes: (v: string) => keys.includes(v),
-            }
-        ) as unknown as typeof this.xAxis.scale;
     }
 
 }

--- a/packages/charts/src/charts/box-plot.ts
+++ b/packages/charts/src/charts/box-plot.ts
@@ -27,6 +27,10 @@ import {
     stagger,
 } from '../core/animation';
 
+import type {
+    ResolvedAnimation,
+} from '../core/animation';
+
 import {
     applyHoverHighlight,
 } from '../core/interaction';
@@ -45,10 +49,16 @@ import type {
 } from '../core/statistics';
 
 import type {
+    Circle,
+    CircleState,
     Context,
+    Ease,
     EventMap,
     Group,
+    Line,
+    LineState,
     Rect,
+    RectState,
     Scale,
 } from '@ripl/core';
 
@@ -173,79 +183,150 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
         });
     }
 
-    private _createBox(category: string, stats: BoxplotStats, centre: number, boxWidth: number, valueScale: Scale<number>, color: string): Group {
+    /** Computes the final geometry of every box element (the target the entry/update transitions animate to). */
+    private _boxTargets(stats: BoxplotStats, centre: number, boxWidth: number, valueScale: Scale<number>) {
         const left = centre - boxWidth / 2;
         const capWidth = boxWidth * 0.5;
+        const yQ3 = valueScale(stats.q3);
+        const yQ1 = valueScale(stats.q1);
+        const yMedian = valueScale(stats.median);
+        const yMax = valueScale(stats.max);
+        const yMin = valueScale(stats.min);
+
+        return {
+            centre,
+            yMedian,
+            box: {
+                x: left,
+                y: yQ3,
+                width: boxWidth,
+                height: Math.max(0, yQ1 - yQ3),
+            } as RectState,
+            median: {
+                x1: left,
+                y1: yMedian,
+                x2: left + boxWidth,
+                y2: yMedian,
+            } as LineState,
+            whiskerHigh: {
+                x1: centre,
+                y1: yQ3,
+                x2: centre,
+                y2: yMax,
+            } as LineState,
+            whiskerLow: {
+                x1: centre,
+                y1: yQ1,
+                x2: centre,
+                y2: yMin,
+            } as LineState,
+            capHigh: {
+                x1: centre - capWidth / 2,
+                y1: yMax,
+                x2: centre + capWidth / 2,
+                y2: yMax,
+            } as LineState,
+            capLow: {
+                x1: centre - capWidth / 2,
+                y1: yMin,
+                x2: centre + capWidth / 2,
+                y2: yMin,
+            } as LineState,
+        };
+    }
+
+    /**
+     * Builds a box group with every element **collapsed toward the median** (box height 0 at the
+     * median line, whiskers/caps collapsed at their box edge/centre, outliers at radius 0) and its
+     * final geometry stashed on `data`, so the entry transition grows it out like a candlestick.
+     */
+    private _createBox(category: string, stats: BoxplotStats, centre: number, boxWidth: number, valueScale: Scale<number>, color: string): Group {
+        const target = this._boxTargets(stats, centre, boxWidth, valueScale);
+        const restFill = setColorAlpha(color, REST_ALPHA);
 
         const box = createRect({
             id: `${category}-box`,
-            x: left,
-            y: valueScale(stats.q3),
-            width: boxWidth,
-            height: Math.max(0, valueScale(stats.q1) - valueScale(stats.q3)),
-            fill: setColorAlpha(color, REST_ALPHA),
+            x: target.box.x,
+            y: target.yMedian,
+            width: target.box.width,
+            height: 0,
+            fill: restFill,
             stroke: color,
             lineWidth: 1.5,
+            data: {
+                ...target.box,
+                fill: restFill,
+            } as RectState,
         });
 
         this._attachBoxHover(box, category, stats);
 
         const median = createLine({
             id: `${category}-median`,
-            x1: left,
-            y1: valueScale(stats.median),
-            x2: left + boxWidth,
-            y2: valueScale(stats.median),
+            x1: centre,
+            y1: target.yMedian,
+            x2: centre,
+            y2: target.yMedian,
             stroke: color,
             lineWidth: 2,
+            data: target.median,
         });
 
         const whiskerHigh = createLine({
             id: `${category}-whisker-high`,
             x1: centre,
-            y1: valueScale(stats.q3),
+            y1: target.whiskerHigh.y1,
             x2: centre,
-            y2: valueScale(stats.max),
+            y2: target.whiskerHigh.y1,
             stroke: color,
             lineWidth: 1,
+            data: target.whiskerHigh,
         });
 
         const whiskerLow = createLine({
             id: `${category}-whisker-low`,
             x1: centre,
-            y1: valueScale(stats.q1),
+            y1: target.whiskerLow.y1,
             x2: centre,
-            y2: valueScale(stats.min),
+            y2: target.whiskerLow.y1,
             stroke: color,
             lineWidth: 1,
+            data: target.whiskerLow,
         });
 
         const capHigh = createLine({
             id: `${category}-cap-high`,
-            x1: centre - capWidth / 2,
-            y1: valueScale(stats.max),
-            x2: centre + capWidth / 2,
-            y2: valueScale(stats.max),
+            x1: centre,
+            y1: target.capHigh.y1,
+            x2: centre,
+            y2: target.capHigh.y2,
             stroke: color,
             lineWidth: 1,
+            data: target.capHigh,
         });
 
         const capLow = createLine({
             id: `${category}-cap-low`,
-            x1: centre - capWidth / 2,
-            y1: valueScale(stats.min),
-            x2: centre + capWidth / 2,
-            y2: valueScale(stats.min),
+            x1: centre,
+            y1: target.capLow.y1,
+            x2: centre,
+            y2: target.capLow.y2,
             stroke: color,
             lineWidth: 1,
+            data: target.capLow,
         });
 
         const outliers = stats.outliers.map((outlier, index) => createCircle({
             id: `${category}-outlier-${index}`,
             cx: centre,
             cy: valueScale(outlier),
-            radius: 2.5,
+            radius: 0,
             fill: color,
+            data: {
+                cx: centre,
+                cy: valueScale(outlier),
+                radius: 2.5,
+            } as CircleState,
         }));
 
         return createGroup({
@@ -375,53 +456,195 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
         } = arrayJoin(items, this._groups, (item, group) => group.id === item.id);
 
         const exitAnimation = this.resolveAnimation(ANIMATION_REFERENCE.exit);
+        const enter = this.resolveAnimation(ANIMATION_REFERENCE.enter);
+        const update = this.resolveAnimation(ANIMATION_REFERENCE.update);
 
+        // Exit: fade the box's marks out, then destroy the group.
         exits.forEach(group => {
             void Promise.all(group.children.map(child => exitElement(this.renderer, child, exitAnimation, {
                 opacity: 0,
             }))).then(() => group.destroy());
         });
 
-        // Updated categories are rebuilt in place at their new positions (composite geometry).
-        updates.forEach(([item, group]) => {
-            group.clear();
-            group.add(this._createBox(item.id, item.stats, item.centre, boxWidth, valueScale, color).children);
-        });
-
         const entryGroups = entries.map(item => {
             const group = this._createBox(item.id, item.stats, item.centre, boxWidth, valueScale, color);
-
-            group.children.forEach(child => {
-                child.opacity = 0;
-            });
-
             this.addPlotContent(group);
-
             return group;
         });
 
+        // Update: reconcile geometry in place and transition to it — rather than clearing + rebuilding,
+        // which teleported the boxes to their new positions with no animation.
+        const updateResults = updates.map(([item, group]) => ({
+            group,
+            marks: this._reconcileBox(item, group, boxWidth, valueScale, color, exitAnimation),
+        }));
+
         this._groups = [
             ...entryGroups,
-            ...updates.map(([, group]) => group),
+            ...updateResults.map(result => result.group),
         ];
 
-        const enter = this.resolveAnimation(ANIMATION_REFERENCE.enter);
+        const categoryCount = Math.max(1, entryGroups.length);
 
-        const entryChildren = entryGroups.flatMap(group => group.children);
+        // Entry: grow each box out from the median (like a candlestick body), staggered left-to-right.
+        const entryTransitions = entryGroups.flatMap((group, index) => {
+            const box = group.getElementsByType('rect')[0] as Rect | undefined;
+            const lines = group.getElementsByType('line') as Line[];
+            const circles = group.getElementsByType('circle') as Circle[];
+            const delay = stagger(index, categoryCount, enter.duration, 0.6);
 
-        const entriesTransition = entryChildren.length
-            ? this.renderer.transition(entryChildren, (element, index, length) => ({
-                duration: enter.duration,
-                delay: stagger(index, length, enter.duration, 0.3),
-                state: {
-                    opacity: 1,
-                },
-            }))
-            : Promise.resolve();
+            return this._transitionMarks(box, lines, circles, enter.duration, delay, enter.ease);
+        });
+
+        const updateTransitions = updateResults.flatMap(result =>
+            this._transitionMarks(result.marks.box, result.marks.lines, result.marks.circles, update.duration, 0, update.ease));
 
         return Promise.all([
-            entriesTransition,
+            ...entryTransitions,
+            ...updateTransitions,
         ]);
+    }
+
+    /** Sets each box element's target `data` for an update, reconciling outliers by id, and returns the living marks to transition. */
+    private _reconcileBox(
+        item: {
+            id: string;
+            stats: BoxplotStats;
+            centre: number;
+        },
+        group: Group,
+        boxWidth: number,
+        valueScale: Scale<number>,
+        color: string,
+        exitAnimation: ResolvedAnimation
+    ): {
+        box?: Rect;
+        lines: Line[];
+        circles: Circle[];
+    } {
+        const target = this._boxTargets(item.stats, item.centre, boxWidth, valueScale);
+        const restFill = setColorAlpha(color, REST_ALPHA);
+
+        const box = group.getElementById(`${item.id}-box`) as Rect | undefined;
+
+        if (box) {
+            box.data = {
+                ...target.box,
+                fill: restFill,
+            } as RectState;
+            this._attachBoxHover(box, item.id, item.stats);
+        }
+
+        const lineTargets: Record<string, LineState> = {
+            [`${item.id}-median`]: target.median,
+            [`${item.id}-whisker-high`]: target.whiskerHigh,
+            [`${item.id}-whisker-low`]: target.whiskerLow,
+            [`${item.id}-cap-high`]: target.capHigh,
+            [`${item.id}-cap-low`]: target.capLow,
+        };
+
+        const lines = group.getElementsByType('line') as Line[];
+        lines.forEach(line => {
+            const lineTarget = lineTargets[line.id];
+
+            if (lineTarget) {
+                line.data = lineTarget;
+            }
+        });
+
+        // Reconcile outliers by id: exit removed points, grow in new ones, move existing ones.
+        const existing = group.getElementsByType('circle') as Circle[];
+        const outlierItems = item.stats.outliers.map((value, index) => ({
+            id: `${item.id}-outlier-${index}`,
+            value,
+        }));
+
+        const {
+            left: outlierEntries,
+            inner: outlierUpdates,
+            right: outlierExits,
+        } = arrayJoin(outlierItems, existing, (outlier, circle) => circle.id === outlier.id);
+
+        outlierExits.forEach(circle => exitElement(this.renderer, circle, exitAnimation, {
+            radius: 0,
+            opacity: 0,
+        }));
+
+        const circles: Circle[] = [];
+
+        outlierEntries.forEach(outlier => {
+            const circle = createCircle({
+                id: outlier.id,
+                cx: item.centre,
+                cy: valueScale(outlier.value),
+                radius: 0,
+                fill: color,
+                data: {
+                    cx: item.centre,
+                    cy: valueScale(outlier.value),
+                    radius: 2.5,
+                } as CircleState,
+            });
+
+            group.add(circle);
+            circles.push(circle);
+        });
+
+        outlierUpdates.forEach(([outlier, circle]) => {
+            circle.data = {
+                cx: item.centre,
+                cy: valueScale(outlier.value),
+                radius: 2.5,
+            } as CircleState;
+            circles.push(circle);
+        });
+
+        return {
+            box,
+            lines,
+            circles,
+        };
+    }
+
+    /** Transitions a box's rect + lines + circles to the target geometry stashed on their `data`. */
+    private _transitionMarks(
+        box: Rect | undefined,
+        lines: Line[],
+        circles: Circle[],
+        duration: number,
+        delay: number,
+        ease: Ease
+    ): Promise<unknown>[] {
+        const transitions: Promise<unknown>[] = [];
+
+        if (box) {
+            transitions.push(this.renderer.transition(box, {
+                duration,
+                delay,
+                ease,
+                state: box.data as RectState,
+            }));
+        }
+
+        if (lines.length > 0) {
+            transitions.push(this.renderer.transition(lines, element => ({
+                duration,
+                delay,
+                ease,
+                state: element.data as LineState,
+            })));
+        }
+
+        if (circles.length > 0) {
+            transitions.push(this.renderer.transition(circles, element => ({
+                duration,
+                delay,
+                ease,
+                state: element.data as CircleState,
+            })));
+        }
+
+        return transitions;
     }
 
 }

--- a/packages/charts/src/charts/gantt.ts
+++ b/packages/charts/src/charts/gantt.ts
@@ -58,6 +58,7 @@ import type {
 
 import {
     Box,
+    clamp,
     createGroup,
     createLine,
     createRect,
@@ -248,7 +249,7 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
             const y = categoryScale(label);
             const height = categoryScale.bandwidth;
 
-            const progress = getProgress ? Math.max(0, Math.min(1, getProgress(item))) : undefined;
+            const progress = getProgress ? clamp(getProgress(item), 0, 1) : undefined;
 
             return {
                 id: key,

--- a/packages/charts/src/charts/gauge.ts
+++ b/packages/charts/src/charts/gauge.ts
@@ -35,6 +35,7 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createArc,
     createGroup,
     createLine,
@@ -154,7 +155,7 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
             const startAngle = Math.PI * 0.75;
             const endAngle = Math.PI * 2.25;
             const range = max - min;
-            const clampedValue = Math.max(min, Math.min(max, value));
+            const clampedValue = clamp(value, min, max);
             const valueAngle = startAngle + ((clampedValue - min) / range) * (endAngle - startAngle);
 
             const isEntry = !this._group;

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -44,6 +44,10 @@ import type {
 } from '../core/series/context';
 
 import type {
+    ChartNavigatorSeries,
+} from '../components/navigator';
+
+import type {
     ChartArea,
 } from '../core/layout';
 
@@ -172,8 +176,25 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
         this.init();
     }
 
+    /** Line charts are category-on-x, so the navigator windows the x axis (bottom scrub bar). */
+    protected override navigationAxis(): 'x' {
+        return 'x';
+    }
+
     private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
         this.emit(MARKER_EVENTS[phase], event);
+    }
+
+    /** Builds the per-series overview data (id, colour, type, values) for the navigator strip. */
+    private _overviewSeries(): ChartNavigatorSeries[] {
+        const { data, series } = this.options;
+
+        return series.map(srs => ({
+            id: srs.id,
+            color: this.getSeriesColor(srs.id),
+            type: 'line' as const,
+            values: data.map(resolveAccessor<TData, number>(srs.value)),
+        }));
     }
 
     private _seriesContext(plot: ChartArea): LineSeriesContext<TData> {
@@ -225,6 +246,9 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
             this.reserveLegend(layout, legendItems);
 
+            // Reserve the overview strip band from the bottom before the axes are measured.
+            const navBand = this.reserveNavigatorBand(layout);
+
             const area = layout.area;
             const left = area.x;
             const top = area.y;
@@ -248,13 +272,10 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds.bottom = xAxisBox.top;
 
-            // Rescale to the navigator's pan/zoom window (no-op without a navigator or at rest):
-            // continuous y via domain rescale, categorical x via a pixel-space transform. Geometry
-            // and axes read the same scales, so both follow the view.
-            this._yScale = this.applyView(this._yScale, 'y');
+            // The navigator windows the x (category) axis only — the value axis stays at the full
+            // extent, so the strip scrubs horizontally without rescaling the y domain.
             this._xScale = this.applyViewToScale(this._xScale, 'x');
             this.xAxis.scale = this._xScale;
-            this.yAxis.scale = this._yScale;
 
             const plot = {
                 x: yAxisBox.right,
@@ -275,6 +296,8 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
             const seriesRender = this._series.render(series, this._seriesContext(plot));
             this.registerHighlightGroups(this._series.groups);
+
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -189,12 +189,7 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
     private _overviewSeries(): ChartNavigatorSeries[] {
         const { data, series } = this.options;
 
-        return series.map(srs => ({
-            id: srs.id,
-            color: this.getSeriesColor(srs.id),
-            type: 'line' as const,
-            values: data.map(resolveAccessor<TData, number>(srs.value)),
-        }));
+        return this.buildOverviewSeries(series, data, () => 'line', (srs, item) => resolveAccessor<TData, number>(srs.value)(item));
     }
 
     private _seriesContext(plot: ChartArea): LineSeriesContext<TData> {

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -22,7 +22,6 @@ import type {
 
 import {
     normalizeDataLabels,
-    resolveLineDash,
     resolveValueFormat,
 } from '../core/options';
 
@@ -31,64 +30,51 @@ import type {
 } from '../core/options';
 
 import {
-    createDataLabel,
-    resolveDataLabelLayout,
-} from '../core/labels';
-
-import {
-    ANIMATION_REFERENCE,
-    exitElement,
-    stagger,
-} from '../core/animation';
-
-import {
-    applyHoverHighlight,
-} from '../core/interaction';
-
-import {
     resolveAccessor,
 } from '../core/data';
+
+import {
+    LineSeriesRenderer,
+} from '../core/series/line-series';
+
+import type {
+    LineSeriesContext,
+    SeriesEventPhase,
+    SeriesInteractionEvent,
+} from '../core/series/context';
+
+import type {
+    ChartArea,
+} from '../core/layout';
 
 import type {
     LegendItem,
 } from '../components/legend';
 
 import type {
-    Circle,
-    CircleState,
     Context,
     EventMap,
-    Group,
-    Point,
-    Polyline,
     PolylineRenderer,
-    PolylineState,
     Scale,
-    Text,
-    TextState,
 } from '@ripl/core';
 
 import {
     Box,
-    createCircle,
-    createGroup,
-    createPolyline,
     getExtent,
-    interpolatePath,
-    interpolatePoints,
     scaleContinuous,
 } from '@ripl/core';
 
 import {
-    correspondence,
-    keysDiffer,
-} from '../core/morph';
-
-import {
-    arrayJoin,
     functionIdentity,
     typeIsFunction,
 } from '@ripl/utilities';
+
+/** Maps a pointer interaction phase to the corresponding line-chart marker event name. */
+const MARKER_EVENTS = {
+    enter: 'markerenter',
+    leave: 'markerleave',
+    click: 'markerclick',
+} as const;
 
 /** Configuration for an individual line chart series. */
 export interface LineChartSeriesOptions<TData> {
@@ -171,9 +157,7 @@ export interface LineChartEventMap extends EventMap {
  */
 export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<TData>, TData, LineChartEventMap> {
 
-    private _lineGroups: Group[] = [];
-    /** Previous ordered data keys per series, used to key-reconcile the line morph across add/remove. */
-    private _morphKeys = new Map<string, string[]>();
+    private _series = new LineSeriesRenderer<TData>();
     private _yScale!: Scale;
     private _xScale!: Scale<string>;
 
@@ -188,333 +172,27 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
         this.init();
     }
 
-    private _seriesLabel(series: LineChartSeriesOptions<TData>, item: TData): string {
-        return typeIsFunction(series.label) ? series.label(item) : series.label;
+    private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
+        this.emit(MARKER_EVENTS[phase], event);
     }
 
-    private _markerState(series: LineChartSeriesOptions<TData>, item: TData, getKey: (item: TData) => string) {
-        const value = resolveAccessor<TData, number>(series.value)(item);
-        const key = getKey(item);
-        const x = this._xScale(key);
-        const y = this._yScale(value);
-        const color = this.getSeriesColor(series.id);
-        // A hidden marker rests at radius 0 (the toggle animates it in/out on update).
-        const radius = series.markers === false ? 0 : (series.markerRadius ?? 3);
-
+    private _seriesContext(plot: ChartArea): LineSeriesContext<TData> {
         return {
-            id: `${series.id}-${key}`,
-            value,
-            point: [x, y] as Point,
-            state: {
-                fill: '#FFFFFF',
-                stroke: color,
-                lineWidth: 2,
-                cx: x,
-                cy: y,
-                radius,
-            } as CircleState,
-        };
-    }
-
-    private _attachMarkerHover(marker: Circle, series: LineChartSeriesOptions<TData>, item: TData, value: number, state: CircleState, key: string) {
-        if (series.markers === false) {
-            marker.pointerEvents = 'none';
-            return;
-        }
-
-        const radius = series.markerRadius ?? 3;
-        const formatValue = resolveValueFormat(this.options.format);
-
-        const payload = (point: { x: number;
-            y: number; }): LineChartMarkerEvent => ({
-            x: point.x,
-            y: point.y,
-            xValue: key,
-            yValue: value,
-            seriesId: series.id,
-        });
-
-        applyHoverHighlight(marker, {
+            data: this.options.data,
+            getKey: resolveAccessor<TData, string>(this.options.key),
+            yScale: this._yScale,
+            xScale: this._xScale,
+            plot,
+            baseline: this._yScale(0),
             renderer: this.renderer,
-            animation: () => this.resolveAnimation(ANIMATION_REFERENCE.hover),
             tooltip: this.tooltip,
-            anchor: () => ({
-                x: marker.cx,
-                y: marker.cy,
-            }),
-            content: () => `${this._seriesLabel(series, item)}: ${formatValue(value)}`,
-            highlight: {
-                fill: state.stroke as string,
-                radius: radius + 2,
-            },
-            restore: {
-                fill: '#FFFFFF',
-                radius,
-            },
-            onEnter: point => this.emit('markerenter', payload(point)),
-            onLeave: point => this.emit('markerleave', payload(point)),
-            onClick: point => this.emit('markerclick', payload(point)),
-        });
-    }
-
-    private async _drawLines(getKey: (item: TData) => string) {
-        const { data, series } = this.options;
-        const dataLabels = normalizeDataLabels(this.options.labels, { anchor: 'top' });
-        const formatValue = resolveValueFormat(this.options.format);
-
-        const {
-            left: seriesEntries,
-            inner: seriesUpdates,
-            right: seriesExits,
-        } = arrayJoin(series, this._lineGroups, 'id');
-
-        const exitAnimation = this.resolveAnimation(ANIMATION_REFERENCE.exit);
-
-        // Builds/updates the value label for a marker, offset clear of the marker radius.
-        const labelOffset = (srs: LineChartSeriesOptions<TData>) => (srs.markerRadius ?? 3) + 4;
-
-        const buildLabel = (srs: LineChartSeriesOptions<TData>) => (item: TData) => {
-            const { id, value, point } = this._markerState(srs, item, getKey);
-
-            return createDataLabel({
-                id: `${id}-label`,
-                x: point[0],
-                y: point[1],
-                anchor: dataLabels.anchor,
-                content: formatValue(value),
-                font: dataLabels.font,
-                fill: dataLabels.fontColor,
-                offset: labelOffset(srs),
-            });
+            getColor: id => this.getSeriesColor(id),
+            resolveAnimation: reference => this.resolveAnimation(reference),
+            formatValue: resolveValueFormat(this.options.format),
+            dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
+            addContent: elements => this.addPlotContent(elements),
+            emit: (phase, event) => this._emitMarker(phase, event),
         };
-
-        const updateLabel = (srs: LineChartSeriesOptions<TData>, item: TData, label: Text) => {
-            const { value, point } = this._markerState(srs, item, getKey);
-            const layout = resolveDataLabelLayout({
-                x: point[0],
-                y: point[1],
-                anchor: dataLabels.anchor,
-                offset: labelOffset(srs),
-            });
-
-            label.content = formatValue(value);
-            label.data = {
-                x: layout.x,
-                y: layout.y,
-                opacity: 1,
-            } as Partial<TextState>;
-        };
-
-        const enteringLabels: Text[] = [];
-        const updatingLabels: Text[] = [];
-
-        seriesExits.forEach(group => {
-            const exits = group.graph(false).map(element => exitElement(this.renderer, element, exitAnimation));
-            void Promise.all(exits).then(() => group.destroy());
-        });
-
-        const buildMarker = (srs: LineChartSeriesOptions<TData>) => (item: TData) => {
-            const { id, value, point, state } = this._markerState(srs, item, getKey);
-
-            const marker = createCircle({
-                id,
-                ...state,
-                radius: 0,
-                data: state,
-            });
-
-            this._attachMarkerHover(marker, srs, item, value, state, getKey(item));
-
-            return {
-                point,
-                marker,
-            };
-        };
-
-        const seriesEntryGroups = seriesEntries.map(srs => {
-            const color = this.getSeriesColor(srs.id);
-            const items = data.map(buildMarker(srs));
-
-            const line = createPolyline({
-                id: `${srs.id}-line`,
-                lineWidth: srs.lineWidth ?? 2,
-                stroke: color,
-                lineDash: resolveLineDash(srs.lineStyle),
-                points: items.map(item => item.point),
-                renderer: srs.lineType,
-            });
-
-            this._morphKeys.set(srs.id, data.map(getKey));
-
-            return createGroup({
-                id: srs.id,
-                children: [
-                    line,
-                    ...items.map(item => item.marker),
-                    ...(dataLabels.visible ? data.map(buildLabel(srs)) : []),
-                ],
-            });
-        });
-
-        const seriesUpdateGroups = seriesUpdates.map(([srs, group]) => {
-            const line = group.getElementsByType('polyline')[0] as Polyline;
-            const markers = group.getElementsByType('circle') as Circle[];
-
-            // Apply the curve renderer directly (not via the transition). The renderer is a
-            // discrete curve-function selector, not an interpolatable value — routing it through
-            // the transition made it snap to the `linear` fallback mid-animation (see interpolateAny).
-            line.renderer = srs.lineType;
-            // Dash pattern is a static style (not tweened) — apply it directly.
-            line.lineDash = resolveLineDash(srs.lineStyle);
-
-            const newKeys = data.map(getKey);
-            const targetPoints = data.map(item => this._markerState(srs, item, getKey).point);
-            const prevKeys = this._morphKeys.get(srs.id);
-
-            // When the set of keys changes (add/remove/reorder), match points by identity so the
-            // curve renderer keeps its shape across the morph instead of drawing through the
-            // straight-line points the default extrapolation would insert (which looks linear).
-            line.data = {
-                points: prevKeys && keysDiffer(prevKeys, newKeys)
-                    ? interpolatePoints(line.points, targetPoints, {
-                        resolveKeys: () => correspondence(prevKeys, newKeys),
-                    })
-                    : targetPoints,
-            };
-
-            this._morphKeys.set(srs.id, newKeys);
-
-            const {
-                left: markerEntries,
-                inner: markerUpdates,
-                right: markerExits,
-            } = arrayJoin(data, markers, (item, marker) => marker.id === `${srs.id}-${getKey(item)}`);
-
-            markerExits.forEach(marker => exitElement(this.renderer, marker, exitAnimation, {
-                radius: 0,
-                opacity: 0,
-            }));
-
-            markerEntries.forEach(item => group.add(buildMarker(srs)(item).marker));
-
-            markerUpdates.forEach(([item, marker]) => {
-                const { state, value } = this._markerState(srs, item, getKey);
-                marker.data = state;
-                this._attachMarkerHover(marker, srs, item, value, state, getKey(item));
-            });
-
-            // Reconcile value labels alongside the markers.
-            const labels = group.getElementsByType('text') as Text[];
-
-            if (dataLabels.visible) {
-                const {
-                    left: labelEntries,
-                    inner: labelUpdates,
-                    right: labelExits,
-                } = arrayJoin(data, labels, (item, label) => label.id === `${srs.id}-${getKey(item)}-label`);
-
-                labelExits.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-
-                labelEntries.forEach(item => {
-                    const label = buildLabel(srs)(item);
-                    group.add(label);
-                    enteringLabels.push(label);
-                });
-
-                labelUpdates.forEach(([item, label]) => {
-                    updateLabel(srs, item, label);
-                    updatingLabels.push(label);
-                });
-            } else {
-                labels.forEach(label => exitElement(this.renderer, label, exitAnimation, { opacity: 0 }));
-            }
-
-            return group;
-        });
-
-        this.addPlotContent(seriesEntryGroups);
-
-        this._lineGroups = [
-            ...seriesEntryGroups,
-            ...seriesUpdateGroups,
-        ];
-
-        // Series groups map 1:1 to legend items (by id); register them for legend hover-highlight.
-        this.registerHighlightGroups(this._lineGroups);
-
-        const enterAnimation = this.resolveAnimation(ANIMATION_REFERENCE.enter);
-        const updateAnimation = this.resolveAnimation(ANIMATION_REFERENCE.update);
-
-        const entryTransitions = seriesEntryGroups.flatMap(group => {
-            const markers = group.getElementsByType('circle') as Circle[];
-            const line = group.getElementsByType('polyline')[0] as Polyline;
-
-            return [
-                this.renderer.transition(line, {
-                    duration: enterAnimation.duration,
-                    ease: enterAnimation.ease,
-                    state: { points: interpolatePath(line.points) },
-                }),
-                this.renderer.transition(markers, (element, index, length) => ({
-                    duration: enterAnimation.duration,
-                    delay: stagger(index, length, enterAnimation.duration),
-                    ease: enterAnimation.ease,
-                    state: element.data as CircleState,
-                })),
-            ];
-        });
-
-        const updateTransitions = seriesUpdateGroups.flatMap(group => {
-            const markers = group.getElementsByType('circle') as Circle[];
-            const line = group.getElementsByType('polyline')[0] as Polyline;
-
-            return [
-                this.renderer.transition(line, {
-                    duration: updateAnimation.duration,
-                    ease: updateAnimation.ease,
-                    state: line.data as PolylineState,
-                }),
-                this.renderer.transition(markers, element => ({
-                    duration: updateAnimation.duration,
-                    ease: updateAnimation.ease,
-                    state: element.data as CircleState,
-                })),
-            ];
-        });
-
-        // Value labels: entry labels fade in; updated labels animate to their refreshed position.
-        const entryLabels = seriesEntryGroups.flatMap(group => group.getElementsByType('text') as Text[]);
-        const labelTransitions: Promise<unknown>[] = [];
-
-        if (entryLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(entryLabels, {
-                duration: enterAnimation.duration,
-                ease: enterAnimation.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (enteringLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(enteringLabels, {
-                duration: updateAnimation.duration,
-                ease: updateAnimation.ease,
-                state: { opacity: 1 },
-            }));
-        }
-
-        if (updatingLabels.length > 0) {
-            labelTransitions.push(this.renderer.transition(updatingLabels, element => ({
-                duration: updateAnimation.duration,
-                ease: updateAnimation.ease,
-                state: element.data as Partial<TextState>,
-            })));
-        }
-
-        return Promise.all([
-            ...entryTransitions,
-            ...updateTransitions,
-            ...labelTransitions,
-        ]);
     }
 
     public async render() {
@@ -595,10 +273,13 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
             this.setupCrosshair(plot);
 
+            const seriesRender = this._series.render(series, this._seriesContext(plot));
+            this.registerHighlightGroups(this._series.groups);
+
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
                 this.yAxis.visible ? this.yAxis.render() : Promise.resolve(),
-                this._drawLines(getKey),
+                seriesRender,
             ]);
         });
     }

--- a/packages/charts/src/charts/packed-circle.ts
+++ b/packages/charts/src/charts/packed-circle.ts
@@ -58,6 +58,7 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createCircle,
     createGroup,
     easeOutCubic,
@@ -269,7 +270,7 @@ export class PackedCircleChart<TData = unknown> extends Chart<PackedCircleChartO
             exits.forEach(group => group.destroy());
 
             const showLabel = (node: PackedNode) => node.r > 16;
-            const labelFont = (r: number) => `600 ${Math.min(14, Math.max(9, r / 3))}px sans-serif`;
+            const labelFont = (r: number) => `600 ${clamp(r / 3, 9, 14)}px sans-serif`;
 
             const entryGroups = entries.map(node => {
                 const restFill = setColorAlpha(node.color, REST_ALPHA);

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -49,6 +49,7 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createArc,
     createGroup,
     easeOutCubic,
@@ -247,7 +248,7 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
                 const ringOuter = outerRadius - i * band;
                 const thickness = band * (1 - gap);
                 const centre = ringOuter - thickness / 2;
-                const endAngle = TOP_ANGLE + Math.max(0, Math.min(1, itemValue / maxValue)) * sweep;
+                const endAngle = TOP_ANGLE + clamp(itemValue / maxValue, 0, 1) * sweep;
 
                 return {
                     centre,

--- a/packages/charts/src/charts/sankey.ts
+++ b/packages/charts/src/charts/sankey.ts
@@ -54,6 +54,7 @@ import {
     createGroup,
     createRect,
     easeOutCubic,
+    getTotal,
     setColorAlpha,
 } from '@ripl/core';
 
@@ -267,7 +268,7 @@ function computeSankeyLayout(
     let scale = Infinity;
 
     depthGroups.forEach(nodeIds => {
-        const columnValue = nodeIds.reduce((sum, id) => sum + (nodeValueMap.get(id) ?? 0), 0);
+        const columnValue = getTotal(nodeIds, id => nodeValueMap.get(id) ?? 0);
         const availableHeight = height - nodePadding * (nodeIds.length - 1);
 
         if (columnValue > 0 && availableHeight > 0) {
@@ -280,7 +281,7 @@ function computeSankeyLayout(
     }
 
     depthGroups.forEach((nodeIds, depth) => {
-        const columnValue = nodeIds.reduce((sum, id) => sum + (nodeValueMap.get(id) ?? 0), 0);
+        const columnValue = getTotal(nodeIds, id => nodeValueMap.get(id) ?? 0);
         const columnHeight = columnValue * scale + nodePadding * Math.max(nodeIds.length - 1, 0);
         // Centre each column's stack vertically within the plot area.
         let currentY = Math.max(0, (height - columnHeight) / 2);

--- a/packages/charts/src/charts/stock.ts
+++ b/packages/charts/src/charts/stock.ts
@@ -62,6 +62,7 @@ import type {
 
 import {
     Box,
+    clamp,
     createGroup,
     createLine,
     createRect,
@@ -688,7 +689,7 @@ export class StockChart<TData = unknown> extends Chart<StockChartOptions<TData>,
                 const rangeStart = yAxisBoundingBox.right + 20;
                 const rangeEnd = right;
                 const index = Math.round(((value - rangeStart) / (rangeEnd - rangeStart)) * keys.length - 0.5);
-                return keys[Math.max(0, Math.min(keys.length - 1, index))];
+                return keys[clamp(index, 0, keys.length - 1)];
             };
 
             this._xScale = Object.assign(

--- a/packages/charts/src/charts/stock.ts
+++ b/packages/charts/src/charts/stock.ts
@@ -765,6 +765,11 @@ export class StockChart<TData = unknown> extends Chart<StockChartOptions<TData>,
 
             if (hasVolume) {
                 promises.push(this._drawVolume(chartLeft, chartRight, volumeTop, volumeBottom));
+            } else if (this._volumeGroup) {
+                // Volume was toggled off — tear down the orphaned group so the reclaimed space
+                // (the candlesticks now expand into it) doesn't paint over stale bars.
+                this._volumeGroup.destroy();
+                this._volumeGroup = undefined;
             }
 
             return Promise.all(promises);

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -47,6 +47,7 @@ import {
     createArc,
     createGroup,
     easeOutQuint,
+    getTotal,
     scaleContinuous,
     setColorAlpha,
     TAU,
@@ -131,7 +132,7 @@ function flattenNodes<TData = unknown>(
     parentColor?: string,
     resolvedColors?: Map<string, string>
 ): FlattenedArc<TData>[] {
-    const total = nodes.reduce((sum, node) => sum + node.value, 0);
+    const total = getTotal(nodes, node => node.value);
 
     if (total === 0) return [];
 

--- a/packages/charts/src/charts/treemap.ts
+++ b/packages/charts/src/charts/treemap.ts
@@ -44,9 +44,11 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createGroup,
     createRect,
     easeOutCubic,
+    getTotal,
     setColorAlpha,
 } from '@ripl/core';
 
@@ -125,7 +127,7 @@ function layoutTreemap(
     height: number,
     gap: number
 ): TreemapNode[] {
-    const total = items.reduce((sum, item) => sum + item.value, 0);
+    const total = getTotal(items, item => item.value);
 
     if (items.length === 0 || total === 0) return [];
 
@@ -272,7 +274,7 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
             // the cell width. Shared by the entry and update branches so both stay in sync.
             const showLabelFor = (node: { width: number;
                 height: number; }) => node.width > 40 && node.height > 20;
-            const labelFont = (width: number) => `600 ${Math.min(12, Math.max(9, width / 8))}px sans-serif`;
+            const labelFont = (width: number) => `600 ${clamp(width / 8, 9, 12)}px sans-serif`;
 
             const entryGroups = entries.map(node => {
                 const nodeColor = colorFor(node);

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -265,6 +265,11 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
         return 'x';
     }
 
+    /** Trend marks (bars, plus line/area markers at band centres) are laid out in category bands. */
+    protected override navigatorCategoryLayout(): 'band' {
+        return 'band';
+    }
+
     private _seriesValue(series: TrendChartSeriesOptions<TData>, item: TData): number {
         return resolveAccessor<TData, number>(series.value)(item);
     }
@@ -485,7 +490,7 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
                 ...this._lineRenderer.groups,
             ]);
 
-            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]], stacked);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -51,12 +51,8 @@ import type {
     SeriesRenderContext,
 } from '../core/series/context';
 
-import {
-    ChartNavigator,
-} from '../components/navigator';
-
 import type {
-    ChartNavigatorWindow,
+    ChartNavigatorSeries,
 } from '../components/navigator';
 
 import type {
@@ -70,7 +66,6 @@ import type {
 import type {
     Context,
     EventMap,
-    NavigatorInteractions,
     PolylineRenderer,
     Scale,
 } from '@ripl/core';
@@ -100,17 +95,6 @@ const BAR_EVENTS = {
     leave: 'barleave',
     click: 'barclick',
 } as const;
-
-/** Default height of the overview strip, in pixels. */
-const DEFAULT_OVERVIEW_HEIGHT = 48;
-/** Gap between the x-axis and the overview strip, in pixels. */
-const OVERVIEW_GAP = 8;
-/** Minimum visible window width, as a fraction of the domain (bounds the maximum zoom). */
-const MIN_WINDOW = 0.02;
-
-function clamp(value: number, min: number, max: number): number {
-    return Math.min(Math.max(value, min), max);
-}
 
 /** Supported series visualization types within a trend chart. */
 export type TrendSeriesType = 'line' | 'bar' | 'area';
@@ -172,12 +156,6 @@ export type TrendChartSeriesOptions<TData> = TrendChartLineSeriesOptions<TData>
 | TrendChartAreaSeriesOptions<TData>
 | TrendChartBarSeriesOptions<TData>;
 
-/** Configuration for the trend chart's overview navigator strip. */
-export interface TrendNavigatorOptions {
-    /** Height of the overview strip, in pixels. Defaults to 48. */
-    height?: number;
-}
-
 /** Options for configuring a {@link TrendChart}. */
 export interface TrendChartOptions<TData = unknown> extends CartesianChartOptions<TData> {
     /** The dataset plotted across all series. */
@@ -190,12 +168,6 @@ export interface TrendChartOptions<TData = unknown> extends CartesianChartOption
     stacked?: boolean;
     /** Corner radius in pixels applied to each bar. Defaults to 2. */
     borderRadius?: number;
-    /**
-     * Overview navigator strip beneath the plot with a draggable window that selects the visible
-     * x-range. `true` enables it with defaults; an object sets its height. Enabling the strip also
-     * enables in-plot wheel/drag pan-zoom unless `navigator` is explicitly `false`.
-     */
-    overview?: boolean | TrendNavigatorOptions;
     /** Background grid configuration (`true`/`false` or detailed grid options). */
     grid?: ChartGridInput;
     /** Crosshair overlay configuration (`true`/`false` or detailed crosshair options). */
@@ -263,8 +235,9 @@ export interface TrendChartEventMap extends EventMap {
  * options specific to that type, and the chart reuses the same renderers as the standalone line,
  * bar, and area charts. Series paint back-to-front as area → bar → line so lines never hide behind
  * fills or bars, and overlaid areas are drawn largest-first so smaller areas stay visible. Same-type
- * series can be stacked, an optional overview strip windows the visible x-range, and every cartesian
- * feature (axes, grid, legend, crosshair, tooltip, navigator) is inherited from {@link CartesianChart}.
+ * series can be stacked, the optional {@link CartesianChartOptions.overview} strip windows the visible
+ * x-range, and every cartesian feature (axes, grid, legend, crosshair, tooltip, navigator) is
+ * inherited from {@link CartesianChart}.
  *
  * @typeParam TData - The type of each data item in the dataset.
  */
@@ -273,26 +246,11 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
     private _areaRenderer = new AreaSeriesRenderer<TData>();
     private _barRenderer = new BarSeriesRenderer<TData>();
     private _lineRenderer = new LineSeriesRenderer<TData>();
-    private _navigatorStrip!: ChartNavigator;
     private _yScale!: Scale;
     private _xCenter!: Scale<string>;
-    private _plot?: ChartArea;
 
     constructor(target: string | HTMLElement | Context, options: TrendChartOptions<TData>) {
         super(target, options);
-
-        this._navigatorStrip = new ChartNavigator({
-            scene: this.scene,
-            renderer: this.renderer,
-        });
-
-        // Attach the strip's listeners before setupCartesian creates the in-plot navigator, so a
-        // pointerdown in the strip band is claimed by the strip and never also pans the plot.
-        if (this.options.overview) {
-            this._navigatorStrip.attach();
-        }
-
-        this.options.navigator = this._resolveNavigator(this.options);
 
         this.setupCartesian({
             grid: { horizontal: true },
@@ -302,60 +260,9 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
         this.init();
     }
 
-    /**
-     * Merges options and re-renders, resolving the effective in-plot navigator from the `overview` and
-     * `navigator` options (enabling the strip implies a navigator to drive).
-     */
-    public override update(options: Partial<TrendChartOptions<TData>>): void {
-        const next = {
-            ...this.options,
-            ...options,
-        } as TrendChartOptions<TData>;
-
-        if (next.overview) {
-            this._navigatorStrip.attach();
-        }
-
-        super.update({
-            ...options,
-            navigator: this._resolveNavigator(next),
-        });
-    }
-
-    /** Destroys the chart and detaches the overview strip's listeners. */
-    public override destroy(): void {
-        this._navigatorStrip.destroy();
-        super.destroy();
-    }
-
-    private _resolveNavigator(options: TrendChartOptions<TData>): boolean | NavigatorInteractions {
-        const navigator = options.navigator;
-
-        if (!options.overview) {
-            return navigator ?? false;
-        }
-
-        // With the strip on but in-plot gestures explicitly off, still create an inert navigator so
-        // the strip has a transform to drive.
-        if (navigator === false) {
-            return {
-                zoom: false,
-                pan: false,
-                brush: false,
-            };
-        }
-
-        return navigator ?? true;
-    }
-
-    private _overviewHeight(): number {
-        const overview = this.options.overview;
-
-        if (overview && typeof overview === 'object') {
-            return overview.height ?? DEFAULT_OVERVIEW_HEIGHT;
-        }
-
-        return DEFAULT_OVERVIEW_HEIGHT;
+    /** The trend chart is category-on-x, so the navigator windows the x axis (bottom scrub bar). */
+    protected override navigationAxis(): 'x' {
+        return 'x';
     }
 
     private _seriesValue(series: TrendChartSeriesOptions<TData>, item: TData): number {
@@ -419,55 +326,16 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
         this.emit(BAR_EVENTS[phase], event);
     }
 
-    /** The visible window `[start, end]` (domain fractions) derived from the current navigator transform. */
-    private _currentWindow(): ChartNavigatorWindow {
-        const transform = this.navigator?.transform;
+    /** Builds the per-type overview series (id, colour, type, values) for the navigator strip. */
+    private _overviewSeries(): ChartNavigatorSeries[] {
+        const { data, series } = this.options;
 
-        if (!this._plot || !transform) {
-            return {
-                start: 0,
-                end: 1,
-            };
-        }
-
-        const width = Math.max(1, this._plot.width);
-        const origin = this._plot.x;
-        const start = ((origin - transform.x) / transform.k - origin) / width;
-        const end = ((origin + width - transform.x) / transform.k - origin) / width;
-
-        return {
-            start: clamp(start, 0, 1),
-            end: clamp(end, 0, 1),
-        };
-    }
-
-    /** Converts a strip window into a navigator transform, windowing the x-axis only (y stays fixed). */
-    private _onNavigatorWindow(window: ChartNavigatorWindow): void {
-        if (!this._plot || !this.navigator) {
-            return;
-        }
-
-        const width = Math.max(1, this._plot.width);
-        const origin = this._plot.x;
-
-        let start = window.start;
-        let end = window.end;
-
-        if (end - start < MIN_WINDOW) {
-            end = start + MIN_WINDOW;
-        }
-
-        start = clamp(start, 0, 1 - MIN_WINDOW);
-        end = clamp(end, start + MIN_WINDOW, 1);
-
-        const factor = 1 / (end - start);
-        const translate = origin - factor * (origin + start * width);
-
-        this.navigator.setTransform({
-            k: factor,
-            x: translate,
-            y: this.navigator.transform.y,
-        });
+        return series.map(srs => ({
+            id: srs.id,
+            color: this.getSeriesColor(srs.id),
+            type: srs.type,
+            values: data.map(item => this._seriesValue(srs, item)),
+        }));
     }
 
     private _commonContext(plot: ChartArea, emit: (phase: SeriesEventPhase, event: SeriesInteractionEvent) => void): SeriesRenderContext<TData> {
@@ -488,32 +356,10 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
         };
     }
 
-    private _renderOverview(band: ChartArea, plot: ChartArea, dataExtent: number[]): void {
-        const { data, series } = this.options;
-
-        this._navigatorStrip.render({
-            area: {
-                x: plot.x,
-                y: band.y + OVERVIEW_GAP,
-                width: plot.width,
-                height: this._overviewHeight(),
-            },
-            series: series.map(srs => ({
-                id: srs.id,
-                color: this.getSeriesColor(srs.id),
-                values: data.map(item => this._seriesValue(srs, item)),
-            })),
-            valueExtent: [dataExtent[0], dataExtent[1]],
-            window: this._currentWindow(),
-            onWindow: window => this._onNavigatorWindow(window),
-        });
-    }
-
     public async render() {
         return super.render(async () => {
             const { data, series, key } = this.options;
             const stacked = this.options.stacked ?? false;
-            const overviewEnabled = !!this.options.overview;
 
             this.resolveSeriesColors(series);
             this.prepareAxes();
@@ -559,9 +405,7 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
             this.reserveLegend(layout, legendItems);
 
             // Reserve the overview strip band from the bottom before the axes are measured.
-            const navBand = overviewEnabled
-                ? layout.reserveBottom(this._overviewHeight() + OVERVIEW_GAP)
-                : undefined;
+            const navBand = this.reserveNavigatorBand(layout);
 
             const area = layout.area;
             const left = area.x;
@@ -591,8 +435,7 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds.bottom = xAxisBox.top;
 
-            // The navigator windows the x (category) axis only — a single uniform transform can't zoom
-            // x without also zooming y, so the value axis stays at the full extent (trend/stock style).
+            // The navigator windows the x (category) axis only — the value axis stays at the full extent.
             const viewedBand = this.applyViewToScale(xBand, 'x');
             this._xCenter = this.bandCenterScale(viewedBand, keys);
             this.xAxis.scale = this._xCenter;
@@ -603,8 +446,6 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
                 width: right - yAxisBox.right,
                 height: xAxisBox.top - top,
             };
-
-            this._plot = plot;
 
             this.clipPlot(plot);
             this.renderGrid([], this._yScale.ticks(10).map(tick => this._yScale(tick)), plot);
@@ -644,11 +485,7 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
                 ...this._lineRenderer.groups,
             ]);
 
-            if (overviewEnabled && navBand) {
-                this._renderOverview(navBand, plot, dataExtent);
-            } else {
-                this._navigatorStrip.clear();
-            }
+            this.renderNavigator(navBand, navBand ? this._overviewSeries() : [], [dataExtent[0], dataExtent[1]]);
 
             return Promise.all([
                 this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -27,6 +27,8 @@ import {
 } from '../core/options';
 
 import {
+    cumulativeExtent,
+    positiveNegativeExtent,
     resolveAccessor,
 } from '../core/data';
 
@@ -274,55 +276,6 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
         return resolveAccessor<TData, number>(series.value)(item);
     }
 
-    /** Value extent of independently stacked positive/negative totals (bar stacking). */
-    private _positiveNegativeExtent(series: TrendChartSeriesOptions<TData>[], data: TData[]): [number, number] {
-        let max = 0;
-        let min = 0;
-
-        data.forEach(item => {
-            let positive = 0;
-            let negative = 0;
-
-            series.forEach(srs => {
-                const value = this._seriesValue(srs, item);
-
-                if (value >= 0) {
-                    positive += value;
-                } else {
-                    negative += value;
-                }
-            });
-
-            max = Math.max(max, positive);
-            min = Math.min(min, negative);
-        });
-
-        return [min, max];
-    }
-
-    /** Value extent of the running cumulative total (area stacking). */
-    private _cumulativeExtent(series: TrendChartSeriesOptions<TData>[], data: TData[]): [number, number] {
-        let max = 0;
-        let min = 0;
-
-        data.forEach(item => {
-            let cumulative = 0;
-            let cumulativeMax = 0;
-            let cumulativeMin = 0;
-
-            series.forEach(srs => {
-                cumulative += this._seriesValue(srs, item);
-                cumulativeMax = Math.max(cumulativeMax, cumulative);
-                cumulativeMin = Math.min(cumulativeMin, cumulative);
-            });
-
-            max = Math.max(max, cumulativeMax);
-            min = Math.min(min, cumulativeMin);
-        });
-
-        return [min, max];
-    }
-
     private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
         this.emit(MARKER_EVENTS[phase], event);
     }
@@ -335,12 +288,7 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
     private _overviewSeries(): ChartNavigatorSeries[] {
         const { data, series } = this.options;
 
-        return series.map(srs => ({
-            id: srs.id,
-            color: this.getSeriesColor(srs.id),
-            type: srs.type,
-            values: data.map(item => this._seriesValue(srs, item)),
-        }));
+        return this.buildOverviewSeries(series, data, srs => srs.type, (srs, item) => this._seriesValue(srs, item));
     }
 
     private _commonContext(plot: ChartArea, emit: (phase: SeriesEventPhase, event: SeriesInteractionEvent) => void): SeriesRenderContext<TData> {
@@ -380,13 +328,13 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
             const extents: number[] = [0];
 
             if (stacked && barSeries.length > 0) {
-                extents.push(...this._positiveNegativeExtent(barSeries, data));
+                extents.push(...positiveNegativeExtent(barSeries, data, (srs, item) => this._seriesValue(srs, item)));
             } else {
                 barSeries.forEach(srs => extents.push(...getExtent(data, item => this._seriesValue(srs, item))));
             }
 
             if (stacked && areaSeries.length > 0) {
-                extents.push(...this._cumulativeExtent(areaSeries, data));
+                extents.push(...cumulativeExtent(areaSeries, data, (srs, item) => this._seriesValue(srs, item)));
             } else {
                 areaSeries.forEach(srs => extents.push(...getExtent(data, item => this._seriesValue(srs, item))));
             }

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -3,824 +3,659 @@ import type {
 } from '../core/data';
 
 import type {
-    BaseChartOptions,
-} from '../core/chart';
+    CartesianChartOptions,
+} from '../core/cartesian';
 
 import {
-    Chart,
-} from '../core/chart';
+    CartesianChart,
+} from '../core/cartesian';
 
 import type {
     ChartAxisInput,
+    ChartCrosshairInput,
+    ChartDataLabelsInput,
     ChartGridInput,
     ChartLegendInput,
     ChartTooltipInput,
+    LineStyle,
+    ValueFormatInput,
 } from '../core/options';
 
 import {
-    formatNumber,
-    normalizeAxis,
-    normalizeAxisItem,
-    normalizeGrid,
-    normalizeTooltip,
-    normalizeYAxisItem,
-    resolveFormatLabel,
+    normalizeDataLabels,
+    resolveValueFormat,
 } from '../core/options';
 
 import {
-    ChartXAxis,
-    ChartYAxis,
-} from '../components/axis';
+    resolveAccessor,
+} from '../core/data';
 
 import {
-    Tooltip,
-} from '../components/tooltip';
+    AreaSeriesRenderer,
+} from '../core/series/area-series';
 
 import {
-    applyHoverHighlight,
-} from '../core/interaction';
+    BarSeriesRenderer,
+} from '../core/series/bar-series';
 
 import {
-    correspondence,
-    keysDiffer,
-} from '../core/morph';
+    LineSeriesRenderer,
+} from '../core/series/line-series';
+
+import type {
+    AreaSeriesContext,
+    BarSeriesContext,
+    LineSeriesContext,
+    SeriesEventPhase,
+    SeriesInteractionEvent,
+    SeriesRenderContext,
+} from '../core/series/context';
+
+import {
+    ChartNavigator,
+} from '../components/navigator';
+
+import type {
+    ChartNavigatorWindow,
+} from '../components/navigator';
+
+import type {
+    ChartArea,
+} from '../core/layout';
 
 import type {
     LegendItem,
 } from '../components/legend';
 
-import {
-    Grid,
-} from '../components/grid';
-
 import type {
-    BandScale,
-    Circle,
-    CircleState,
     Context,
     EventMap,
-    Group,
-    Point,
-    Polyline,
+    NavigatorInteractions,
     PolylineRenderer,
-    PolylineState,
-    Rect,
-    RectState,
     Scale,
 } from '@ripl/core';
 
 import {
     Box,
-    createCircle,
-    createGroup,
-    createPolyline,
-    createRect,
-    createScale,
-    easeOutCubic,
-    easeOutQuart,
     getExtent,
-    interpolatePath,
-    interpolatePoints,
-    max,
-    queryAll,
     scaleBand,
     scaleContinuous,
-    setColorAlpha,
 } from '@ripl/core';
 
 import {
-    arrayJoin,
     functionIdentity,
     typeIsFunction,
 } from '@ripl/utilities';
 
-/** Supported series visualization types within a trend chart. */
-export type SeriesType = 'bar' | 'line' | 'area';
+/** Maps a pointer interaction phase to the corresponding trend-chart marker event name. */
+const MARKER_EVENTS = {
+    enter: 'markerenter',
+    leave: 'markerleave',
+    click: 'markerclick',
+} as const;
 
-/** Base configuration shared by all trend chart series types. */
-export interface BaseTrendChartSeriesOptions<TData> {
-    /** Unique identifier for the series. */
+/** Maps a pointer interaction phase to the corresponding trend-chart bar event name. */
+const BAR_EVENTS = {
+    enter: 'barenter',
+    leave: 'barleave',
+    click: 'barclick',
+} as const;
+
+/** Default height of the overview strip, in pixels. */
+const DEFAULT_OVERVIEW_HEIGHT = 48;
+/** Gap between the x-axis and the overview strip, in pixels. */
+const OVERVIEW_GAP = 8;
+/** Minimum visible window width, as a fraction of the domain (bounds the maximum zoom). */
+const MIN_WINDOW = 0.02;
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/** Supported series visualization types within a trend chart. */
+export type TrendSeriesType = 'line' | 'bar' | 'area';
+
+/** Configuration shared by every trend chart series type. */
+export interface TrendChartBaseSeriesOptions<TData> {
+    /** Unique identifier for the series, used for colour assignment, legend, and data joins. */
     id: string;
     /** Which visualization type to render this series as. */
-    type: SeriesType;
-    /** Optional colour override for the series (otherwise a palette colour is generated). */
+    type: TrendSeriesType;
+    /** Explicit series colour; falls back to the chart's generated palette when omitted. */
     color?: string;
-    /** Accessor for each item's numeric value. */
-    value: NumericAccessor<TData>;
-    /** Display label for the series, or an accessor deriving a per-item label. */
+    /** Accessor for the series' value at each data item, or a constant applied to every item. */
+    value: NumericAccessor<TData> | number;
+    /** Series name shown in the legend and tooltips (or a per-item function). */
     label: string | ((item: TData) => string);
 }
 
-/** Series options for bar-type series within a trend chart. */
-export interface TrendChartBarSeriesOptions<TData> extends BaseTrendChartSeriesOptions<TData> {
+/** Series options for a line-type series within a trend chart. */
+export interface TrendChartLineSeriesOptions<TData> extends TrendChartBaseSeriesOptions<TData> {
+    /** Discriminant marking this as a line series. */
+    type: 'line';
+    /** Renderer used to draw the line (e.g. straight or curved); defaults to straight segments. */
+    lineType?: PolylineRenderer;
+    /** Width in pixels of the series line. */
+    lineWidth?: number;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
+    lineStyle?: LineStyle;
+    /** Show point markers along the line. Defaults to `true`. */
+    markers?: boolean;
+    /** Radius in pixels of each point marker. Defaults to 3. */
+    markerRadius?: number;
+}
+
+/** Series options for an area-type series within a trend chart. */
+export interface TrendChartAreaSeriesOptions<TData> extends TrendChartBaseSeriesOptions<TData> {
+    /** Discriminant marking this as an area series. */
+    type: 'area';
+    /** Renderer used to draw the area top edge (e.g. straight or curved); defaults to straight segments. */
+    lineType?: PolylineRenderer;
+    /** Width in pixels of the series line. */
+    lineWidth?: number;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
+    lineStyle?: LineStyle;
+    /** Fill opacity of the area band. Defaults to 0.3. */
+    opacity?: number;
+    /** Show point markers at each data value. Defaults to `true`. */
+    markers?: boolean;
+}
+
+/** Series options for a bar-type series within a trend chart. */
+export interface TrendChartBarSeriesOptions<TData> extends TrendChartBaseSeriesOptions<TData> {
     /** Discriminant marking this as a bar series. */
     type: 'bar';
 }
 
-/** Series options for area-type series within a trend chart. */
-export interface TrendChartAreaSeriesOptions<TData> extends BaseTrendChartSeriesOptions<TData> {
-    /** Discriminant marking this as an area series. */
-    type: 'area';
-    /** Whether the region beneath the line is filled. */
-    filled: boolean;
-}
-
-/** Series options for line-type series within a trend chart. */
-export interface TrendChartLineSeriesOptions<TData> extends BaseTrendChartSeriesOptions<TData> {
-    /** Discriminant marking this as a line series. */
-    type: 'line';
-    /** Renderer controlling the line's shape (e.g. straight or curved). */
-    lineType?: PolylineRenderer;
-}
-
 /** Discriminated union of all trend chart series option types. */
-export type TrendChartSeriesOptions<TData> = TrendChartBarSeriesOptions<TData>
+export type TrendChartSeriesOptions<TData> = TrendChartLineSeriesOptions<TData>
 | TrendChartAreaSeriesOptions<TData>
-| TrendChartLineSeriesOptions<TData>;
+| TrendChartBarSeriesOptions<TData>;
+
+/** Configuration for the trend chart's overview navigator strip. */
+export interface TrendNavigatorOptions {
+    /** Height of the overview strip, in pixels. Defaults to 48. */
+    height?: number;
+}
 
 /** Options for configuring a {@link TrendChart}. */
-export interface TrendChartOptions<TData = unknown> extends BaseChartOptions {
+export interface TrendChartOptions<TData = unknown> extends CartesianChartOptions<TData> {
     /** The dataset plotted across all series. */
     data: TData[];
-    /** The series to render, mixing bar, line, and area types on shared axes. */
+    /** The series to render, mixing line, bar, and area types on shared axes. */
     series: TrendChartSeriesOptions<TData>[];
-    /** Accessor for each item's unique key, used for the categorical x-axis and matching across updates. */
+    /** Accessor for each item's category key (the value plotted along the x axis). */
     key: keyof TData | ((item: TData) => string);
-    /** Background grid line configuration. */
+    /** Stack same-type series cumulatively (bars among bars, areas among areas). Defaults to false. */
+    stacked?: boolean;
+    /** Corner radius in pixels applied to each bar. Defaults to 2. */
+    borderRadius?: number;
+    /**
+     * Overview navigator strip beneath the plot with a draggable window that selects the visible
+     * x-range. `true` enables it with defaults; an object sets its height. Enabling the strip also
+     * enables in-plot wheel/drag pan-zoom unless `navigator` is explicitly `false`.
+     */
+    overview?: boolean | TrendNavigatorOptions;
+    /** Background grid configuration (`true`/`false` or detailed grid options). */
     grid?: ChartGridInput;
-    /** Hover tooltip configuration. */
+    /** Crosshair overlay configuration (`true`/`false` or detailed crosshair options). */
+    crosshair?: ChartCrosshairInput;
+    /** Hover tooltip configuration (`true`/`false` or detailed tooltip options). */
     tooltip?: ChartTooltipInput;
-    /** Series legend configuration. */
+    /** Legend configuration (`true`/`false`, a position, or detailed legend options). */
     legend?: ChartLegendInput;
-    /** Axis configuration (labels, ticks, titles). */
+    /** Axis configuration for the x and y axes. */
     axis?: ChartAxisInput<TData>;
+    /** Show value labels next to each mark. `true` uses the default anchor; a string sets the anchor side. */
+    labels?: ChartDataLabelsInput;
+    /** Format applied to values shown as text (tooltips and labels). */
+    format?: ValueFormatInput;
 }
 
-/** Payload emitted for trend bar/marker interaction events. */
-export interface TrendChartValueEvent {
-    /** X position of the bar/marker, in canvas coordinates. */
+/** Payload emitted for trend bar interaction events. */
+export interface TrendChartBarEvent {
+    /** The x coordinate (in chart pixels) of the bar's anchor point. */
     x: number;
-    /** Y position of the bar/marker, in canvas coordinates. */
+    /** The y coordinate (in chart pixels) of the bar's anchor point. */
     y: number;
-    /** The bar/marker's numeric value. */
-    value: number;
+    /** The category key of the interacted bar. */
+    xValue: string;
+    /** The numeric value of the interacted bar. */
+    yValue: number;
+    /** The id of the series the bar belongs to. */
+    seriesId: string;
+}
+
+/** Payload emitted for trend line/area marker interaction events. */
+export interface TrendChartMarkerEvent {
+    /** The x coordinate (in chart pixels) of the marker. */
+    x: number;
+    /** The y coordinate (in chart pixels) of the marker. */
+    y: number;
+    /** The category key of the interacted marker. */
+    xValue: string;
+    /** The numeric value of the interacted marker. */
+    yValue: number;
+    /** The id of the series the marker belongs to. */
+    seriesId: string;
 }
 
 /** Events emitted by a {@link TrendChart} that consumers can subscribe to via `chart.on(...)`. */
 export interface TrendChartEventMap extends EventMap {
     /** Emitted when a bar is clicked. */
-    barclick: TrendChartValueEvent;
+    barclick: TrendChartBarEvent;
     /** Emitted when the pointer enters a bar. */
-    barenter: TrendChartValueEvent;
+    barenter: TrendChartBarEvent;
     /** Emitted when the pointer leaves a bar. */
-    barleave: TrendChartValueEvent;
-    /** Emitted when a line marker is clicked. */
-    markerclick: TrendChartValueEvent;
-    /** Emitted when the pointer enters a line marker. */
-    markerenter: TrendChartValueEvent;
-    /** Emitted when the pointer leaves a line marker. */
-    markerleave: TrendChartValueEvent;
+    barleave: TrendChartBarEvent;
+    /** Emitted when a line/area marker is clicked. */
+    markerclick: TrendChartMarkerEvent;
+    /** Emitted when the pointer enters a line/area marker. */
+    markerenter: TrendChartMarkerEvent;
+    /** Emitted when the pointer leaves a line/area marker. */
+    markerleave: TrendChartMarkerEvent;
 }
 
 /**
- * Trend chart combining bar and line series on shared categorical/value axes.
+ * Trend chart combining line, bar, and area series on shared categorical/value axes.
  *
- * Renders bar series as grouped rectangles and line series as polylines with
- * markers on the same chart area. Supports tooltips, legend, grid, and
- * animated entry/update/exit transitions for both series types.
+ * A true mixed cartesian chart: each series declares a `type` (`line`, `bar`, or `area`) plus the
+ * options specific to that type, and the chart reuses the same renderers as the standalone line,
+ * bar, and area charts. Series paint back-to-front as area → bar → line so lines never hide behind
+ * fills or bars, and overlaid areas are drawn largest-first so smaller areas stay visible. Same-type
+ * series can be stacked, an optional overview strip windows the visible x-range, and every cartesian
+ * feature (axes, grid, legend, crosshair, tooltip, navigator) is inherited from {@link CartesianChart}.
  *
  * @typeParam TData - The type of each data item in the dataset.
  */
-export class TrendChart<TData = unknown> extends Chart<TrendChartOptions<TData>, TrendChartEventMap> {
+export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOptions<TData>, TData, TrendChartEventMap> {
 
-    private _barGroups: Group[] = [];
-    private _lineGroups: Group[] = [];
-    /** Previous ordered data keys per line series, used to key-reconcile the morph across add/remove. */
-    private _morphKeys = new Map<string, string[]>();
+    private _areaRenderer = new AreaSeriesRenderer<TData>();
+    private _barRenderer = new BarSeriesRenderer<TData>();
+    private _lineRenderer = new LineSeriesRenderer<TData>();
+    private _navigatorStrip!: ChartNavigator;
     private _yScale!: Scale;
-    private _xScaleBand!: BandScale<string>;
-    private _xScalePoint!: Scale<string>;
-    private _xAxis: ChartXAxis;
-    private _yAxis: ChartYAxis;
-    private _tooltip!: Tooltip;
-    private _grid?: Grid;
+    private _xCenter!: Scale<string>;
+    private _plot?: ChartArea;
+
     constructor(target: string | HTMLElement | Context, options: TrendChartOptions<TData>) {
         super(target, options);
 
-        const axisOpts = normalizeAxis(options.axis);
-        const xAxis = normalizeAxisItem(axisOpts.x);
-        const yAxis = normalizeYAxisItem(
-            Array.isArray(axisOpts.y) ? axisOpts.y[0] : axisOpts.y
-        );
-        const gridOpts = normalizeGrid(options.grid);
-        const tooltipOpts = normalizeTooltip(options.tooltip);
-
-        this._xAxis = new ChartXAxis({
+        this._navigatorStrip = new ChartNavigator({
             scene: this.scene,
             renderer: this.renderer,
-            bounds: Box.empty(),
-            scale: this._xScalePoint,
-            labelFont: xAxis.font,
-            labelColor: xAxis.fontColor,
-            formatLabel: resolveFormatLabel(xAxis.format),
-            title: xAxis.title,
         });
 
-        this._yAxis = new ChartYAxis({
-            scene: this.scene,
-            renderer: this.renderer,
-            bounds: Box.empty(),
-            scale: this._yScale,
-            labelFont: yAxis.font,
-            labelColor: yAxis.fontColor,
-            formatLabel: resolveFormatLabel(yAxis.format),
-            title: yAxis.title,
+        // Attach the strip's listeners before setupCartesian creates the in-plot navigator, so a
+        // pointerdown in the strip band is claimed by the strip and never also pans the plot.
+        if (this.options.overview) {
+            this._navigatorStrip.attach();
+        }
+
+        this.options.navigator = this._resolveNavigator(this.options);
+
+        this.setupCartesian({
+            grid: { horizontal: true },
+            crosshair: true,
         });
-
-        if (tooltipOpts.visible) {
-            this._tooltip = new Tooltip({
-                scene: this.scene,
-                renderer: this.renderer,
-                font: tooltipOpts.font,
-                fontColor: tooltipOpts.fontColor,
-                backgroundColor: tooltipOpts.backgroundColor,
-            });
-        }
-
-        if (gridOpts.visible) {
-            this._grid = new Grid({
-                scene: this.scene,
-                renderer: this.renderer,
-                horizontal: true,
-                vertical: false,
-                stroke: gridOpts.lineColor,
-                lineWidth: gridOpts.lineWidth,
-                lineDash: gridOpts.lineDash,
-            });
-        }
 
         this.init();
     }
 
     /**
-     * Wires hover highlight + tooltip onto a line marker. Uses {@link applyHoverHighlight} so
-     * prior listeners are disposed on re-apply — calling this on every update no longer leaks.
+     * Merges options and re-renders, resolving the effective in-plot navigator from the `overview` and
+     * `navigator` options (enabling the strip implies a navigator to drive).
      */
-    private _attachMarkerHover(marker: Circle, value: number, color: string) {
-        const payload = (point: { x: number;
-            y: number; }): TrendChartValueEvent => ({
-            x: point.x,
-            y: point.y,
-            value,
-        });
+    public override update(options: Partial<TrendChartOptions<TData>>): void {
+        const next = {
+            ...this.options,
+            ...options,
+        } as TrendChartOptions<TData>;
 
-        applyHoverHighlight(marker, {
-            renderer: this.renderer,
-            animation: () => ({
-                duration: this.getAnimationDuration(300),
-                ease: easeOutQuart,
-            }),
-            tooltip: this._tooltip,
-            anchor: () => ({
-                x: marker.cx,
-                y: marker.cy,
-            }),
-            content: () => formatNumber(value),
-            onEnter: point => this.emit('markerenter', payload(point)),
-            onLeave: point => this.emit('markerleave', payload(point)),
-            onClick: point => this.emit('markerclick', payload(point)),
-            highlight: {
-                fill: color,
-                radius: 5,
-            },
-            restore: {
-                fill: '#FFFFFF',
-                radius: 3,
-            },
+        if (next.overview) {
+            this._navigatorStrip.attach();
+        }
+
+        super.update({
+            ...options,
+            navigator: this._resolveNavigator(next),
         });
     }
 
-    /**
-     * Wires hover highlight + tooltip onto a bar. Uses {@link applyHoverHighlight} so prior
-     * listeners are disposed on re-apply — calling this on every update no longer leaks.
-     */
-    private _attachBarHover(bar: Rect, value: number, fill: string) {
-        const payload = (point: { x: number;
-            y: number; }): TrendChartValueEvent => ({
-            x: point.x,
-            y: point.y,
-            value,
-        });
-
-        applyHoverHighlight(bar, {
-            renderer: this.renderer,
-            animation: () => ({
-                duration: this.getAnimationDuration(300),
-                ease: easeOutQuart,
-            }),
-            tooltip: this._tooltip,
-            anchor: () => ({
-                x: bar.x + bar.width / 2,
-                y: bar.y,
-            }),
-            content: () => formatNumber(value),
-            onEnter: point => this.emit('barenter', payload(point)),
-            onLeave: point => this.emit('barleave', payload(point)),
-            onClick: point => this.emit('barclick', payload(point)),
-            highlight: {
-                fill,
-            },
-            restore: {
-                fill: setColorAlpha(fill, 0.7),
-            },
-        });
+    /** Destroys the chart and detaches the overview strip's listeners. */
+    public override destroy(): void {
+        this._navigatorStrip.destroy();
+        super.destroy();
     }
 
-    private async _drawLines() {
-        const {
-            data,
-            series,
-            key,
-        } = this.options;
+    private _resolveNavigator(options: TrendChartOptions<TData>): boolean | NavigatorInteractions {
+        const navigator = options.navigator;
 
-        const lineSeries = series.filter(srs => srs.type === 'line') as TrendChartLineSeriesOptions<TData>[];
+        if (!options.overview) {
+            return navigator ?? false;
+        }
 
-        const {
-            left: seriesEntries,
-            inner: seriesUpdates,
-            right: seriesExits,
-        } = arrayJoin(lineSeries, this._lineGroups, 'id');
-
-        seriesExits.forEach(el => el.destroy());
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const getKey = typeIsFunction(key) ? key : (item: any) => item[key] as string;
-
-        const seriesLineValueProducer = ({ id, value: valueBy, label: labelBy }: TrendChartLineSeriesOptions<TData>) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getValue = typeIsFunction(valueBy) ? valueBy : (item: any) => item[valueBy] as number;
-            const getLabel = typeIsFunction(labelBy) ? labelBy : () => labelBy;
-            const color = this.getSeriesColor(id);
-
-            return (item: TData) => {
-                const key = getKey(item);
-                const value = getValue(item);
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const label = getLabel(item);
-
-                const x = this._xScalePoint(key);
-                const y = this._yScale(value);
-
-                return {
-                    id: `${id}-${key}`,
-                    point: [x, y] as Point,
-                    state: {
-                        fill: '#FFFFFF',
-                        stroke: color,
-                        lineWidth: 2,
-                        cx: x,
-                        cy: y,
-                        radius: 3,
-                    } as CircleState,
-                };
+        // With the strip on but in-plot gestures explicitly off, still create an inert navigator so
+        // the strip has a transform to drive.
+        if (navigator === false) {
+            return {
+                zoom: false,
+                pan: false,
+                brush: false,
             };
+        }
+
+        return navigator ?? true;
+    }
+
+    private _overviewHeight(): number {
+        const overview = this.options.overview;
+
+        if (overview && typeof overview === 'object') {
+            return overview.height ?? DEFAULT_OVERVIEW_HEIGHT;
+        }
+
+        return DEFAULT_OVERVIEW_HEIGHT;
+    }
+
+    private _seriesValue(series: TrendChartSeriesOptions<TData>, item: TData): number {
+        return resolveAccessor<TData, number>(series.value)(item);
+    }
+
+    /** Value extent of independently stacked positive/negative totals (bar stacking). */
+    private _positiveNegativeExtent(series: TrendChartSeriesOptions<TData>[], data: TData[]): [number, number] {
+        let max = 0;
+        let min = 0;
+
+        data.forEach(item => {
+            let positive = 0;
+            let negative = 0;
+
+            series.forEach(srs => {
+                const value = this._seriesValue(srs, item);
+
+                if (value >= 0) {
+                    positive += value;
+                } else {
+                    negative += value;
+                }
+            });
+
+            max = Math.max(max, positive);
+            min = Math.min(min, negative);
+        });
+
+        return [min, max];
+    }
+
+    /** Value extent of the running cumulative total (area stacking). */
+    private _cumulativeExtent(series: TrendChartSeriesOptions<TData>[], data: TData[]): [number, number] {
+        let max = 0;
+        let min = 0;
+
+        data.forEach(item => {
+            let cumulative = 0;
+            let cumulativeMax = 0;
+            let cumulativeMin = 0;
+
+            series.forEach(srs => {
+                cumulative += this._seriesValue(srs, item);
+                cumulativeMax = Math.max(cumulativeMax, cumulative);
+                cumulativeMin = Math.min(cumulativeMin, cumulative);
+            });
+
+            max = Math.max(max, cumulativeMax);
+            min = Math.min(min, cumulativeMin);
+        });
+
+        return [min, max];
+    }
+
+    private _emitMarker(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
+        this.emit(MARKER_EVENTS[phase], event);
+    }
+
+    private _emitBar(phase: SeriesEventPhase, event: SeriesInteractionEvent): void {
+        this.emit(BAR_EVENTS[phase], event);
+    }
+
+    /** The visible window `[start, end]` (domain fractions) derived from the current navigator transform. */
+    private _currentWindow(): ChartNavigatorWindow {
+        const transform = this.navigator?.transform;
+
+        if (!this._plot || !transform) {
+            return {
+                start: 0,
+                end: 1,
+            };
+        }
+
+        const width = Math.max(1, this._plot.width);
+        const origin = this._plot.x;
+        const start = ((origin - transform.x) / transform.k - origin) / width;
+        const end = ((origin + width - transform.x) / transform.k - origin) / width;
+
+        return {
+            start: clamp(start, 0, 1),
+            end: clamp(end, 0, 1),
         };
-
-        const seriesEntryGroups = seriesEntries.map(series => {
-
-            const getMarkerValues = seriesLineValueProducer(series);
-
-            const items = data.map(item => {
-                const { id, point, state } = getMarkerValues(item);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const getValue = typeIsFunction(series.value) ? series.value : (item: any) => item[series.value] as number;
-                const value = getValue(item);
-
-                const marker = createCircle({
-                    id,
-                    ...state,
-                    radius: 0,
-                    data: state,
-                });
-
-                this._attachMarkerHover(marker, value, state.stroke as string);
-
-                return {
-                    point,
-                    marker,
-                };
-            });
-
-            const line = createPolyline({
-                id: `${series.id}-line`,
-                lineWidth: 2,
-                stroke: this.getSeriesColor(series.id),
-                points: items.map(item => item.point),
-                renderer: series.lineType,
-            });
-
-            this._morphKeys.set(series.id, data.map(getKey));
-
-            return createGroup({
-                id: series.id,
-                children: [
-                    line,
-                    ...items.map(item => item.marker),
-                ],
-            });
-        });
-
-        const seriesUpdateGroups = seriesUpdates.map(([series, group]) => {
-            const getMarkerValues = seriesLineValueProducer(series);
-            const line = group.getElementsByType('polyline')[0] as Polyline;
-            const markers = group.getElementsByType('circle') as Circle[];
-
-            const targetPoints = data.map(item => getMarkerValues(item).point);
-            const newKeys = data.map(getKey);
-            const prevKeys = this._morphKeys.get(series.id);
-
-            // Apply the renderer directly (not via the transition, which would snap it at t=0.5),
-            // and key-reconcile the point morph so curved lines stay curved across add/remove.
-            line.renderer = series.lineType;
-
-            line.data = {
-                points: prevKeys && keysDiffer(prevKeys, newKeys)
-                    ? interpolatePoints(line.points, targetPoints, {
-                        resolveKeys: () => correspondence(prevKeys, newKeys),
-                    })
-                    : targetPoints,
-            };
-
-            this._morphKeys.set(series.id, newKeys);
-
-            const {
-                left: markerEntries,
-                inner: markerUpdates,
-                right: markerExits,
-            } = arrayJoin(data, markers, (item, marker) => marker.id === `${series.id}-${getKey(item)}`);
-
-            markerExits.forEach(el => el.destroy());
-
-            markerEntries.map(item => {
-                const { id, state } = getMarkerValues(item);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const getValue = typeIsFunction(series.value) ? series.value : (item: any) => item[series.value] as number;
-
-                const marker = createCircle({
-                    id,
-                    ...state,
-                    radius: 0,
-                    data: state,
-                });
-
-                this._attachMarkerHover(marker, getValue(item), state.stroke as string);
-
-                group.add(marker);
-            });
-
-            markerUpdates.forEach(([item, marker]) => {
-                const { state } = getMarkerValues(item);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const getValue = typeIsFunction(series.value) ? series.value : (item: any) => item[series.value] as number;
-                const value = getValue(item);
-
-                marker.data = state;
-
-                this._attachMarkerHover(marker, value, state.stroke as string);
-            });
-
-            return group;
-        });
-
-        this.scene.add(seriesEntryGroups);
-
-        this._lineGroups = [
-            ...seriesEntryGroups,
-            ...seriesUpdateGroups,
-        ];
-
-        const entryTransitions = seriesEntryGroups.map(group => {
-            const markers = group.queryAll('circle') as Circle[];
-            const line = group.query('polyline') as Polyline;
-
-            const lineTransition = this.renderer.transition(line, {
-                duration: this.getAnimationDuration(1000),
-                ease: easeOutCubic,
-                state: {
-                    points: interpolatePath(line.points),
-                },
-            });
-
-            const markersTransition = this.renderer.transition(markers, (element, index, length) => ({
-                duration: this.getAnimationDuration(1000),
-                delay: index * (this.getAnimationDuration(1000) / length),
-                ease: easeOutCubic,
-                state: element.data as CircleState,
-            }));
-
-            return [
-                lineTransition,
-                markersTransition,
-            ];
-        });
-
-        const updateTransitions = seriesUpdateGroups.map(group => {
-            const markers = group.queryAll('circle') as Circle[];
-            const line = group.query('polyline') as Polyline;
-
-            const lineTransition = this.renderer.transition(line, {
-                duration: this.getAnimationDuration(1000),
-                ease: easeOutCubic,
-                state: line.data as PolylineState,
-            });
-
-            const markersTransition = this.renderer.transition(markers, (element) => ({
-                duration: this.getAnimationDuration(1000),
-                ease: easeOutCubic,
-                state: element.data as CircleState,
-            }));
-
-            return [
-                lineTransition,
-                markersTransition,
-            ];
-        });
-
-        return Promise.all([
-            ...entryTransitions,
-            ...updateTransitions,
-        ].flat());
     }
 
-    private async _drawBars() {
-        const {
-            data,
-            series,
-            key,
-        } = this.options;
+    /** Converts a strip window into a navigator transform, windowing the x-axis only (y stays fixed). */
+    private _onNavigatorWindow(window: ChartNavigatorWindow): void {
+        if (!this._plot || !this.navigator) {
+            return;
+        }
 
-        const barSeries = series.filter(srs => srs.type === 'bar') as TrendChartBarSeriesOptions<TData>[];
+        const width = Math.max(1, this._plot.width);
+        const origin = this._plot.x;
 
-        const {
-            left: seriesEntries,
-            inner: seriesUpdates,
-            right: seriesExits,
-        } = arrayJoin(barSeries, this._barGroups, 'id');
+        let start = window.start;
+        let end = window.end;
 
-        seriesExits.forEach(el => el.destroy());
+        if (end - start < MIN_WINDOW) {
+            end = start + MIN_WINDOW;
+        }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const getKey = typeIsFunction(key) ? key : (item: any) => item[key] as string;
-        const baseline = this._yScale(0);
+        start = clamp(start, 0, 1 - MIN_WINDOW);
+        end = clamp(end, start + MIN_WINDOW, 1);
 
-        const xScaleSeries = scaleBand(barSeries.map(srs => srs.id), [0, this._xScaleBand.bandwidth], {
-            innerPadding: 0.25,
+        const factor = 1 / (end - start);
+        const translate = origin - factor * (origin + start * width);
+
+        this.navigator.setTransform({
+            k: factor,
+            x: translate,
+            y: this.navigator.transform.y,
         });
+    }
 
-        const seriesBarValueProducer = ({ id, value: valueBy, label: labelBy }: TrendChartBarSeriesOptions<TData>) => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getValue = typeIsFunction(valueBy) ? valueBy : (item: any) => item[valueBy] as number;
-            const getLabel = typeIsFunction(labelBy) ? labelBy : () => labelBy;
-            const color = this.getSeriesColor(id);
-
-            return (item: TData) => {
-                const key = getKey(item);
-                const value = getValue(item);
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const label = getLabel(item);
-
-                const x = this._xScaleBand(key) + xScaleSeries(id);
-                const y = this._yScale(max(0, value));
-                const width = xScaleSeries.bandwidth;
-                const height = Math.abs(baseline - this._yScale(value));
-
-                return {
-                    id: `${id}-${key}`,
-                    state: {
-                        fill: color,
-                        x,
-                        y,
-                        width,
-                        height,
-                    } as RectState,
-                };
-            };
+    private _commonContext(plot: ChartArea, emit: (phase: SeriesEventPhase, event: SeriesInteractionEvent) => void): SeriesRenderContext<TData> {
+        return {
+            data: this.options.data,
+            getKey: resolveAccessor<TData, string>(this.options.key),
+            yScale: this._yScale,
+            plot,
+            baseline: this._yScale(0),
+            renderer: this.renderer,
+            tooltip: this.tooltip,
+            getColor: id => this.getSeriesColor(id),
+            resolveAnimation: reference => this.resolveAnimation(reference),
+            formatValue: resolveValueFormat(this.options.format),
+            dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
+            addContent: elements => this.addPlotContent(elements),
+            emit,
         };
+    }
 
-        const seriesEntryGroups = seriesEntries.map((series) => {
+    private _renderOverview(band: ChartArea, plot: ChartArea, dataExtent: number[]): void {
+        const { data, series } = this.options;
 
-            const getBarValues = seriesBarValueProducer(series);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getValue = typeIsFunction(series.value) ? series.value : (item: any) => item[series.value] as number;
-
-            const children = data.map(item => {
-                const { id, state } = getBarValues(item);
-                const value = getValue(item);
-
-                const bar = createRect({
-                    id,
-                    ...state,
-                    fill: setColorAlpha(state.fill as string, 0.7),
-                    y: baseline,
-                    height: 0,
-                    data: {
-                        ...state,
-                        fill: setColorAlpha(state.fill as string, 0.7),
-                    },
-                });
-
-                this._attachBarHover(bar, value, state.fill as string);
-
-                return bar;
-            });
-
-            return createGroup({
-                id: series.id,
-                children,
-            });
+        this._navigatorStrip.render({
+            area: {
+                x: plot.x,
+                y: band.y + OVERVIEW_GAP,
+                width: plot.width,
+                height: this._overviewHeight(),
+            },
+            series: series.map(srs => ({
+                id: srs.id,
+                color: this.getSeriesColor(srs.id),
+                values: data.map(item => this._seriesValue(srs, item)),
+            })),
+            valueExtent: [dataExtent[0], dataExtent[1]],
+            window: this._currentWindow(),
+            onWindow: window => this._onNavigatorWindow(window),
         });
-
-        const seriesUpdateGroups = seriesUpdates.map(([series, group]) => {
-            const getBarValues = seriesBarValueProducer(series);
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getValue = typeIsFunction(series.value) ? series.value : (item: any) => item[series.value] as number;
-            const bars = group.getElementsByType('rect') as Rect[];
-
-            const {
-                left: barEntries,
-                inner: barUpdates,
-                right: barExits,
-            } = arrayJoin(data, bars, (item, bar) => bar.id === `${series.id}-${getKey(item)}`);
-
-            barExits.forEach(el => el.destroy());
-
-            barEntries.map(item => {
-                const { id, state } = getBarValues(item);
-
-                const rect = createRect({
-                    id,
-                    ...state,
-                    y: baseline,
-                    height: 0,
-                    data: state,
-                });
-
-                this._attachBarHover(rect, getValue(item), state.fill as string);
-
-                group.add(rect);
-            });
-
-            barUpdates.forEach(([item, bar]) => {
-                const { state } = getBarValues(item);
-                const value = getValue(item);
-
-                bar.data = {
-                    ...state,
-                    fill: setColorAlpha(state.fill as string, 0.7),
-                };
-
-                this._attachBarHover(bar, value, state.fill as string);
-            });
-
-            return group;
-        });
-
-        this.scene.add(seriesEntryGroups);
-
-        this._barGroups = [
-            ...seriesEntryGroups,
-            ...seriesUpdateGroups,
-        ];
-
-        const barEntries = (queryAll(seriesEntryGroups, 'rect') as Rect[]).sort((a, b) => a.x - b.x);
-
-        const entriesTransition = this.renderer.transition(barEntries, (element, index, length) => ({
-            duration: this.getAnimationDuration(1000),
-            delay: index * (this.getAnimationDuration(1000) / length),
-            ease: easeOutCubic,
-            state: element.data as RectState,
-        }));
-
-        const updatesTransition = this.renderer.transition(queryAll(seriesUpdateGroups, 'rect') as Rect[], element => ({
-            duration: this.getAnimationDuration(1000),
-            ease: easeOutCubic,
-            state: element.data as RectState,
-        }));
-
-        return Promise.all([
-            entriesTransition,
-            updatesTransition,
-        ]);
     }
 
     public async render() {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        return super.render((scene, renderer) => {
-            const {
-                data,
-                series,
-                key,
-            } = this.options;
+        return super.render(async () => {
+            const { data, series, key } = this.options;
+            const stacked = this.options.stacked ?? false;
+            const overviewEnabled = !!this.options.overview;
 
             this.resolveSeriesColors(series);
+            this.prepareAxes();
 
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getKey = typeIsFunction(key) ? key : (item: any) => item[key] as string;
+            const getKey = resolveAccessor<TData, string>(key);
             const keys = data.map(getKey);
-            const seriesExtents = series.flatMap(({ value: valueAccessor }) => {
-                const getValue = typeIsFunction(valueAccessor)
-                    ? valueAccessor
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    : (item: any) => item[valueAccessor] as number;
 
-                return getExtent(data, getValue);
-            }).concat(0);
+            const areaSeries = series.filter((srs): srs is TrendChartAreaSeriesOptions<TData> => srs.type === 'area');
+            const barSeries = series.filter((srs): srs is TrendChartBarSeriesOptions<TData> => srs.type === 'bar');
+            const lineSeries = series.filter((srs): srs is TrendChartLineSeriesOptions<TData> => srs.type === 'line');
 
-            const dataExtent = getExtent(seriesExtents, functionIdentity);
+            // The value domain must cover every series, respecting per-type stacking.
+            const extents: number[] = [0];
 
-            // Shared layout pass: reserve title and legend bands.
+            if (stacked && barSeries.length > 0) {
+                extents.push(...this._positiveNegativeExtent(barSeries, data));
+            } else {
+                barSeries.forEach(srs => extents.push(...getExtent(data, item => this._seriesValue(srs, item))));
+            }
+
+            if (stacked && areaSeries.length > 0) {
+                extents.push(...this._cumulativeExtent(areaSeries, data));
+            } else {
+                areaSeries.forEach(srs => extents.push(...getExtent(data, item => this._seriesValue(srs, item))));
+            }
+
+            lineSeries.forEach(srs => extents.push(...getExtent(data, item => this._seriesValue(srs, item))));
+
+            const dataExtent = getExtent(extents, functionIdentity);
+
             const layout = this.createLayout();
             this.reserveTitle(layout);
 
             const legendItems: LegendItem[] = series.length > 1
                 ? series.map(srs => ({
                     id: srs.id,
-                    label: typeIsFunction(srs.label) ? srs.id : srs.label as string,
+                    label: typeIsFunction(srs.label) ? srs.id : srs.label,
                     color: this.getSeriesColor(srs.id),
                     active: true,
                 }))
                 : [];
 
-            this.reserveLegend(layout, legendItems, this.options.legend);
+            this.reserveLegend(layout, legendItems);
+
+            // Reserve the overview strip band from the bottom before the axes are measured.
+            const navBand = overviewEnabled
+                ? layout.reserveBottom(this._overviewHeight() + OVERVIEW_GAP)
+                : undefined;
 
             const area = layout.area;
-            const chartTop = area.y;
-            const chartBottom = area.y + area.height;
-            const chartRight = area.x + area.width;
+            const left = area.x;
+            const top = area.y;
+            const right = area.x + area.width;
+            const bottom = area.y + area.height;
 
-            this._yScale = scaleContinuous(dataExtent, [chartBottom, chartTop], {
-                padToTicks: 10,
+            // Provisional value scale to measure the y-axis width.
+            this._yScale = scaleContinuous(dataExtent, [bottom, top], { padToTicks: 10 });
+            this.yAxis.scale = this._yScale;
+            this.yAxis.bounds = new Box(top, left, bottom, right);
+
+            const yAxisBox = this.yAxis.getBoundingBox();
+
+            // A band scale positions bars; its centres position line/area markers and the x-axis ticks.
+            const xBand = scaleBand(keys, [yAxisBox.right, right], {
+                outerPadding: 0.15,
+                innerPadding: 0.2,
             });
 
-            this._yAxis.scale = this._yScale;
-            this._yAxis.bounds = new Box(
-                chartTop,
-                area.x,
-                chartBottom,
-                chartRight
-            );
+            this.xAxis.scale = this.bandCenterScale(xBand, keys);
+            this.xAxis.bounds = new Box(top, yAxisBox.right, bottom, right);
 
-            const yAxisBoundingBox = this._yAxis.getBoundingBox();
+            const xAxisBox = this.xAxis.getBoundingBox();
 
-            this._xScaleBand = scaleBand(keys, [yAxisBoundingBox.right, chartRight], {
-                outerPadding: 0.25,
-                innerPadding: 0.25,
-            });
+            this._yScale = scaleContinuous(dataExtent, [xAxisBox.top, top], { padToTicks: 10 });
+            this.yAxis.scale = this._yScale;
+            this.yAxis.bounds.bottom = xAxisBox.top;
 
-            this._xScalePoint = createScale({
-                domain: this._xScaleBand.domain,
-                range: this._xScaleBand.range,
-                convert: value => this._xScaleBand(value) + this._xScaleBand.bandwidth / 2,
-                invert: value => this._xScaleBand.inverse(value),
-            });
+            // The navigator windows the x (category) axis only — a single uniform transform can't zoom
+            // x without also zooming y, so the value axis stays at the full extent (trend/stock style).
+            const viewedBand = this.applyViewToScale(xBand, 'x');
+            this._xCenter = this.bandCenterScale(viewedBand, keys);
+            this.xAxis.scale = this._xCenter;
 
-            this._xAxis.scale = this._xScalePoint;
-            this._xAxis.bounds = new Box(
-                chartTop,
-                yAxisBoundingBox.right,
-                chartBottom,
-                chartRight
-            );
+            const plot = {
+                x: yAxisBox.right,
+                y: top,
+                width: right - yAxisBox.right,
+                height: xAxisBox.top - top,
+            };
 
-            const xAxisBoundingBox = this._xAxis.getBoundingBox();
+            this._plot = plot;
 
-            this._yScale = scaleContinuous(dataExtent, [xAxisBoundingBox.top, chartTop], {
-                padToTicks: 10,
-            });
+            this.clipPlot(plot);
+            this.renderGrid([], this._yScale.ticks(10).map(tick => this._yScale(tick)), plot);
+            this.setupCrosshair(plot);
 
-            this._yAxis.scale = this._yScale;
-            this._yAxis.bounds.bottom = xAxisBoundingBox.top;
+            // Draw back-to-front: areas (largest first), then bars, then lines/markers on top.
+            const areaContext: AreaSeriesContext<TData> = {
+                ...this._commonContext(plot, (phase, event) => this._emitMarker(phase, event)),
+                xScale: this._xCenter,
+                stacked,
+                zIndexBase: 0,
+            };
 
-            // Render grid
-            if (this._grid) {
-                const yTicks = this._yScale.ticks(10);
-                const yTickPositions = yTicks.map(tick => this._yScale(tick));
+            const barContext: BarSeriesContext<TData> = {
+                ...this._commonContext(plot, (phase, event) => this._emitBar(phase, event)),
+                categoryScale: viewedBand,
+                valueScale: this._yScale,
+                orientation: 'vertical',
+                stacked,
+                borderRadius: this.options.borderRadius ?? 2,
+                zIndexBase: areaSeries.length,
+            };
 
-                this._grid.render(
-                    [],
-                    yTickPositions,
-                    yAxisBoundingBox.right,
-                    chartTop,
-                    chartRight - yAxisBoundingBox.right,
-                    xAxisBoundingBox.top - chartTop
-                );
+            const lineContext: LineSeriesContext<TData> = {
+                ...this._commonContext(plot, (phase, event) => this._emitMarker(phase, event)),
+                xScale: this._xCenter,
+                zIndexBase: areaSeries.length + barSeries.length,
+            };
+
+            const areaRender = this._areaRenderer.render(areaSeries, areaContext);
+            const barRender = this._barRenderer.render(barSeries, barContext);
+            const lineRender = this._lineRenderer.render(lineSeries, lineContext);
+
+            this.registerHighlightGroups([
+                ...this._areaRenderer.groups,
+                ...this._barRenderer.groups,
+                ...this._lineRenderer.groups,
+            ]);
+
+            if (overviewEnabled && navBand) {
+                this._renderOverview(navBand, plot, dataExtent);
+            } else {
+                this._navigatorStrip.clear();
             }
 
             return Promise.all([
-                this._xAxis.render(),
-                this._yAxis.render(),
-                this._drawBars(),
-                this._drawLines(),
+                this.xAxis.visible ? this.xAxis.render() : Promise.resolve(),
+                this.yAxis.visible ? this.yAxis.render() : Promise.resolve(),
+                areaRender,
+                barRender,
+                lineRender,
             ]);
         });
     }
@@ -834,14 +669,16 @@ export class TrendChart<TData = unknown> extends Chart<TrendChartOptions<TData>,
  * ```ts
  * createTrendChart(target, {
  *     data: [
- *         { month: 'Jan', revenue: 120, target: 100 },
- *         { month: 'Feb', revenue: 150, target: 130 },
+ *         { month: 'Jan', revenue: 120, profit: 40, target: 100 },
+ *         { month: 'Feb', revenue: 150, profit: 55, target: 130 },
  *     ],
  *     key: 'month',
  *     series: [
- *         { id: 'revenue', type: 'bar', label: 'Revenue', value: 'revenue' },
+ *         { id: 'revenue', type: 'area', label: 'Revenue', value: 'revenue' },
+ *         { id: 'profit', type: 'bar', label: 'Profit', value: 'profit' },
  *         { id: 'target', type: 'line', label: 'Target', value: 'target' },
  *     ],
+ *     overview: true,
  * });
  * ```
  */

--- a/packages/charts/src/components/axis.ts
+++ b/packages/charts/src/components/axis.ts
@@ -276,14 +276,17 @@ export class ChartAxis extends ChartComponent {
         }
 
         const band = this.getBoundingBox();
-        // The x-axis measures labels by width; it slides horizontally, so clip its horizontal
-        // span to the plot and keep the full band height. The y-axis is the mirror image.
+        // The x-axis measures labels by width; it slides horizontally, so clip its horizontal span to
+        // the plot. Across the axis (its label thickness) it needs breathing room so a label's
+        // ascent/descent isn't shaved at the plot/strip edge — pad the cross extent generously. The
+        // y-axis is the mirror image.
         const horizontal = this._labelDimension === 'width';
+        const crossPad = 20;
 
-        this._clip.x = horizontal ? area.x : band.left;
-        this._clip.y = horizontal ? band.top : area.y;
-        this._clip.width = horizontal ? area.width : band.width;
-        this._clip.height = horizontal ? band.height : area.height;
+        this._clip.x = horizontal ? area.x : band.left - crossPad;
+        this._clip.y = horizontal ? band.top - crossPad : area.y;
+        this._clip.width = horizontal ? area.width : band.width + crossPad * 2;
+        this._clip.height = horizontal ? band.height + crossPad * 2 : area.height;
         this._clip.clip = enabled;
     }
 

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -1,0 +1,383 @@
+/**
+ * Overview navigator strip.
+ *
+ * Renders a compressed, non-interactive overview of the full series beneath the plot, with a
+ * draggable window (two edge handles + a movable body) that selects the visible x-range. The strip
+ * owns none of the transform maths — it reports the selected window as fractions `[start, end]` of
+ * the domain via `onWindow`, and the host chart converts that to a navigator transform. On each
+ * render the host feeds back the current window (derived from the transform) so in-plot pan/zoom and
+ * the strip stay in lock-step.
+ *
+ * Dragging is wired with DOM pointer listeners on the render context so a drag keeps tracking outside
+ * the strip (pointer capture). A `pointerdown` inside the strip band calls
+ * `stopImmediatePropagation` so the in-plot navigator — whose listeners are attached *after* the
+ * strip's — never also pans; a `pointerdown` outside the band is left untouched so in-plot pan/zoom
+ * still works over the plot.
+ */
+
+import {
+    ChartComponent,
+} from './_base';
+
+import type {
+    ChartArea,
+} from '../core/layout';
+
+import type {
+    Element,
+    Group,
+    Point,
+} from '@ripl/core';
+
+import {
+    createGroup,
+    createPolyline,
+    createRect,
+} from '@ripl/core';
+
+import {
+    onDOMEvent,
+} from '@ripl/dom';
+
+/** Retention key for the strip's DOM pointer listeners. */
+const LISTENER_KEY = Symbol('navigator-strip-listeners');
+/** Pixel slop for grabbing an edge handle. */
+const HANDLE_SLOP = 10;
+/** Visible width of an edge handle, in pixels. */
+const HANDLE_WIDTH = 8;
+/** Minimum window width as a fraction of the domain (bounds the maximum zoom). */
+const MIN_WINDOW = 0.02;
+
+const STRIP_BACKGROUND = 'rgba(148, 163, 184, 0.10)';
+const STRIP_BORDER = 'rgba(148, 163, 184, 0.45)';
+const MASK_FILL = 'rgba(148, 163, 184, 0.32)';
+const WINDOW_BORDER = 'rgba(100, 116, 139, 0.9)';
+const HANDLE_FILL = 'rgba(100, 116, 139, 0.95)';
+const OVERVIEW_OPACITY = 0.7;
+
+/** A single series' values across the categories, for the overview mini-render. */
+export interface ChartNavigatorSeries {
+    /** The series id (used for the overview element ids). */
+    id: string;
+    /** The series colour. */
+    color: string;
+    /** The series' value at each category, in key order. */
+    values: number[];
+}
+
+/** The selected window, as fractions `[0, 1]` of the domain. */
+export interface ChartNavigatorWindow {
+    /** The left edge of the window (`0` = domain start). */
+    start: number;
+    /** The right edge of the window (`1` = domain end). */
+    end: number;
+}
+
+/** Inputs for one render of the {@link ChartNavigator} strip. */
+export interface ChartNavigatorRenderOptions {
+    /** The rectangle the overview draws into (aligned to the main plot's x-range). */
+    area: ChartArea;
+    /** The overview series to draw. */
+    series: ChartNavigatorSeries[];
+    /** The value extent `[min, max]` used to scale the overview vertically. */
+    valueExtent: [number, number];
+    /** The currently visible window (derived by the host from the navigator transform). */
+    window: ChartNavigatorWindow;
+    /** Called with the new window whenever the user drags a handle or the window body. */
+    onWindow: (window: ChartNavigatorWindow) => void;
+}
+
+/** Which part of the window a drag is manipulating. */
+type DragMode = 'move' | 'resize-start' | 'resize-end';
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/** The overview strip component that drives the chart's visible x-window. */
+export class ChartNavigator extends ChartComponent {
+
+    private _group?: Group;
+    private _element?: HTMLElement;
+    private _area?: ChartArea;
+    private _window: ChartNavigatorWindow = {
+        start: 0,
+        end: 1,
+    };
+    private _onWindow?: (window: ChartNavigatorWindow) => void;
+    private _attached = false;
+    private _drag?: {
+        mode: DragMode;
+        startX: number;
+        startWindow: ChartNavigatorWindow;
+    };
+
+    /**
+     * Attaches the strip's DOM pointer listeners to the render context. Call this **before** the chart
+     * creates its in-plot navigator so the strip's `pointerdown` listener runs first and can suppress
+     * in-plot panning within the strip band. No-op on non-DOM contexts or if already attached.
+     */
+    public attach(): void {
+        if (this._attached) {
+            return;
+        }
+
+        const element = this.context.element as unknown as HTMLElement;
+
+        if (!element || typeof element.getBoundingClientRect !== 'function' || typeof element.addEventListener !== 'function') {
+            return;
+        }
+
+        this._element = element;
+        this.retain(onDOMEvent(element, 'pointerdown', this._onPointerDown), LISTENER_KEY);
+        this.retain(onDOMEvent(element, 'pointermove', this._onPointerMove), LISTENER_KEY);
+        this.retain(onDOMEvent(element, 'pointerup', this._onPointerUp), LISTENER_KEY);
+        this.retain(onDOMEvent(element, 'pointercancel', this._onPointerUp), LISTENER_KEY);
+        this._attached = true;
+    }
+
+    /** Draws the overview, mask, and window for the current state. */
+    public render(options: ChartNavigatorRenderOptions): void {
+        const { area, series, valueExtent, window, onWindow } = options;
+
+        this._area = area;
+        this._window = window;
+        this._onWindow = onWindow;
+
+        const group = this._ensureGroup();
+        group.clear();
+
+        const children: Element[] = [
+            createRect({
+                id: 'navigator-strip',
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: area.height,
+                fill: STRIP_BACKGROUND,
+                stroke: STRIP_BORDER,
+                lineWidth: 1,
+                borderRadius: 3,
+                pointerEvents: 'none',
+            }),
+            ...this._overviewElements(area, series, valueExtent),
+            ...this._windowElements(area, window),
+        ];
+
+        group.add(children);
+    }
+
+    /** Removes the strip's drawn elements (e.g. when the overview is toggled off), leaving listeners inert. */
+    public clear(): void {
+        this._area = undefined;
+        this._onWindow = undefined;
+        this._group?.destroy();
+        this._group = undefined;
+    }
+
+    /** Detaches the strip's listeners and destroys its elements. */
+    public destroy(): void {
+        this.dispose(LISTENER_KEY);
+        this._group?.destroy();
+        this._group = undefined;
+        this._attached = false;
+        super.destroy();
+    }
+
+    private _ensureGroup(): Group {
+        if (!this._group) {
+            this._group = createGroup({
+                id: '__navigator-strip',
+                // Above the plot content (z-index 1) so the strip and its window sit on top.
+                zIndex: 4,
+            });
+
+            this.scene.add(this._group);
+        }
+
+        return this._group;
+    }
+
+    private _overviewElements(area: ChartArea, series: ChartNavigatorSeries[], valueExtent: [number, number]): Element[] {
+        const [min, max] = valueExtent;
+        const span = max - min || 1;
+
+        const xAt = (index: number, count: number) => {
+            const t = count <= 1 ? 0.5 : index / (count - 1);
+            return area.x + t * area.width;
+        };
+
+        const yAt = (value: number) => area.y + area.height - ((value - min) / span) * area.height;
+
+        return series
+            .filter(srs => srs.values.length > 0)
+            .map(srs => {
+                const points: Point[] = srs.values.map((value, index) => [xAt(index, srs.values.length), yAt(value)]);
+
+                return createPolyline({
+                    id: `navigator-overview-${srs.id}`,
+                    points,
+                    stroke: srs.color,
+                    lineWidth: 1,
+                    opacity: OVERVIEW_OPACITY,
+                    pointerEvents: 'none',
+                });
+            });
+    }
+
+    private _windowElements(area: ChartArea, window: ChartNavigatorWindow): Element[] {
+        const wx0 = area.x + clamp(window.start, 0, 1) * area.width;
+        const wx1 = area.x + clamp(window.end, 0, 1) * area.width;
+
+        return [
+            // Dim the unselected regions on each side of the window.
+            createRect({
+                id: 'navigator-mask-left',
+                x: area.x,
+                y: area.y,
+                width: Math.max(0, wx0 - area.x),
+                height: area.height,
+                fill: MASK_FILL,
+                pointerEvents: 'none',
+            }),
+            createRect({
+                id: 'navigator-mask-right',
+                x: wx1,
+                y: area.y,
+                width: Math.max(0, area.x + area.width - wx1),
+                height: area.height,
+                fill: MASK_FILL,
+                pointerEvents: 'none',
+            }),
+            // The window outline.
+            createRect({
+                id: 'navigator-window',
+                x: wx0,
+                y: area.y,
+                width: Math.max(0, wx1 - wx0),
+                height: area.height,
+                fill: 'transparent',
+                stroke: WINDOW_BORDER,
+                lineWidth: 1,
+                pointerEvents: 'none',
+            }),
+            // The two draggable edge handles.
+            this._handle('navigator-handle-start', wx0, area),
+            this._handle('navigator-handle-end', wx1, area),
+        ];
+    }
+
+    private _handle(id: string, x: number, area: ChartArea): Element {
+        return createRect({
+            id,
+            x: x - HANDLE_WIDTH / 2,
+            y: area.y + area.height / 2 - area.height / 4,
+            width: HANDLE_WIDTH,
+            height: area.height / 2,
+            fill: HANDLE_FILL,
+            borderRadius: 2,
+            pointerEvents: 'none',
+        });
+    }
+
+    private _localPoint(event: PointerEvent): Point {
+        const rect = this._element!.getBoundingClientRect();
+
+        return [
+            event.clientX - rect.left,
+            event.clientY - rect.top,
+        ];
+    }
+
+    private _hitTest(x: number): DragMode | null {
+        if (!this._area) {
+            return null;
+        }
+
+        const wx0 = this._area.x + this._window.start * this._area.width;
+        const wx1 = this._area.x + this._window.end * this._area.width;
+
+        if (Math.abs(x - wx0) <= HANDLE_SLOP) {
+            return 'resize-start';
+        }
+
+        if (Math.abs(x - wx1) <= HANDLE_SLOP) {
+            return 'resize-end';
+        }
+
+        if (x >= wx0 && x <= wx1) {
+            return 'move';
+        }
+
+        return null;
+    }
+
+    private _onPointerDown = (event: PointerEvent): void => {
+        if (!this._area || !this._onWindow || !this._element) {
+            return;
+        }
+
+        const [x, y] = this._localPoint(event);
+
+        // Only claim pointers that land inside the strip band; leave the rest to the in-plot navigator.
+        if (y < this._area.y || y > this._area.y + this._area.height) {
+            return;
+        }
+
+        // Block the in-plot navigator (its listeners were attached after ours) from also panning.
+        event.stopImmediatePropagation();
+        event.preventDefault();
+
+        const mode = this._hitTest(x);
+
+        if (!mode) {
+            return;
+        }
+
+        this._drag = {
+            mode,
+            startX: x,
+            startWindow: { ...this._window },
+        };
+
+        this._element.setPointerCapture?.(event.pointerId);
+    };
+
+    private _onPointerMove = (event: PointerEvent): void => {
+        if (!this._drag || !this._area || !this._onWindow) {
+            return;
+        }
+
+        const [x] = this._localPoint(event);
+        const delta = (x - this._drag.startX) / Math.max(1, this._area.width);
+        const { mode, startWindow } = this._drag;
+
+        let start = startWindow.start;
+        let end = startWindow.end;
+
+        if (mode === 'move') {
+            const width = end - start;
+            start = clamp(startWindow.start + delta, 0, 1 - width);
+            end = start + width;
+        } else if (mode === 'resize-start') {
+            start = clamp(startWindow.start + delta, 0, end - MIN_WINDOW);
+        } else {
+            end = clamp(startWindow.end + delta, start + MIN_WINDOW, 1);
+        }
+
+        this._onWindow({
+            start,
+            end,
+        });
+    };
+
+    private _onPointerUp = (event: PointerEvent): void => {
+        if (!this._drag) {
+            return;
+        }
+
+        this._drag = undefined;
+        this._element?.releasePointerCapture?.(event.pointerId);
+    };
+
+}

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -1,18 +1,18 @@
 /**
  * Overview navigator strip.
  *
- * Renders a compressed, non-interactive overview of the full series beneath the plot, with a
- * draggable window (two edge handles + a movable body) that selects the visible x-range. The strip
- * owns none of the transform maths — it reports the selected window as fractions `[start, end]` of
- * the domain via `onWindow`, and the host chart converts that to a navigator transform. On each
- * render the host feeds back the current window (derived from the transform) so in-plot pan/zoom and
- * the strip stay in lock-step.
+ * Renders a compressed overview of the full series with a draggable window (two edge handles + a
+ * movable body) that selects the visible range of the **category** axis. The strip is
+ * orientation-aware: a `horizontal` strip (category on x) is a bottom bar whose window slides
+ * left↔right; a `vertical` strip (category on y, e.g. a horizontal bar chart) is a side bar whose
+ * window slides up↕down. It reports the window as fractions `[start, end]` of the category domain via
+ * `onWindow`; the host converts that to a navigator transform. The overview draws each series by
+ * type — lines as polylines, areas as filled bands, bars as silhouettes — along the **main** (category)
+ * axis, scaled along the **cross** (value) axis.
  *
- * Dragging is wired with DOM pointer listeners on the render context so a drag keeps tracking outside
- * the strip (pointer capture). A `pointerdown` inside the strip band calls
- * `stopImmediatePropagation` so the in-plot navigator — whose listeners are attached *after* the
- * strip's — never also pans; a `pointerdown` outside the band is left untouched so in-plot pan/zoom
- * still works over the plot.
+ * Dragging is wired with DOM pointer listeners on the render context (pointer capture keeps a drag
+ * tracking outside the strip). A `pointerdown` inside the strip band calls `stopImmediatePropagation`
+ * so the in-plot navigator — whose listeners attach after the strip's — never also pans.
  */
 
 import {
@@ -33,6 +33,7 @@ import {
     createGroup,
     createPolyline,
     createRect,
+    setColorAlpha,
 } from '@ripl/core';
 
 import {
@@ -43,7 +44,7 @@ import {
 const LISTENER_KEY = Symbol('navigator-strip-listeners');
 /** Pixel slop for grabbing an edge handle. */
 const HANDLE_SLOP = 10;
-/** Visible width of an edge handle, in pixels. */
+/** Thickness of an edge handle along the main axis, in pixels. */
 const HANDLE_WIDTH = 8;
 /** Minimum window width as a fraction of the domain (bounds the maximum zoom). */
 const MIN_WINDOW = 0.02;
@@ -54,6 +55,14 @@ const MASK_FILL = 'rgba(148, 163, 184, 0.32)';
 const WINDOW_BORDER = 'rgba(100, 116, 139, 0.9)';
 const HANDLE_FILL = 'rgba(100, 116, 139, 0.95)';
 const OVERVIEW_OPACITY = 0.7;
+const AREA_FILL_ALPHA = 0.25;
+const BAR_FILL_ALPHA = 0.55;
+
+/** Which screen axis the strip's window slides along (matching the host's category axis). */
+export type ChartNavigatorOrientation = 'horizontal' | 'vertical';
+
+/** How a single overview series is drawn in the strip. */
+export type ChartNavigatorSeriesType = 'line' | 'bar' | 'area';
 
 /** A single series' values across the categories, for the overview mini-render. */
 export interface ChartNavigatorSeries {
@@ -61,25 +70,29 @@ export interface ChartNavigatorSeries {
     id: string;
     /** The series colour. */
     color: string;
+    /** How the series is drawn in the overview. */
+    type: ChartNavigatorSeriesType;
     /** The series' value at each category, in key order. */
     values: number[];
 }
 
-/** The selected window, as fractions `[0, 1]` of the domain. */
+/** The selected window, as fractions `[0, 1]` of the category domain. */
 export interface ChartNavigatorWindow {
-    /** The left edge of the window (`0` = domain start). */
+    /** The start edge of the window (`0` = domain start). */
     start: number;
-    /** The right edge of the window (`1` = domain end). */
+    /** The end edge of the window (`1` = domain end). */
     end: number;
 }
 
 /** Inputs for one render of the {@link ChartNavigator} strip. */
 export interface ChartNavigatorRenderOptions {
-    /** The rectangle the overview draws into (aligned to the main plot's x-range). */
+    /** Which axis the window slides along. */
+    orientation: ChartNavigatorOrientation;
+    /** The rectangle the overview draws into (aligned to the main plot's category range). */
     area: ChartArea;
     /** The overview series to draw. */
     series: ChartNavigatorSeries[];
-    /** The value extent `[min, max]` used to scale the overview vertically. */
+    /** The value extent `[min, max]` used to scale the overview across the cross axis. */
     valueExtent: [number, number];
     /** The currently visible window (derived by the host from the navigator transform). */
     window: ChartNavigatorWindow;
@@ -94,11 +107,12 @@ function clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
 }
 
-/** The overview strip component that drives the chart's visible x-window. */
+/** The overview strip component that drives the chart's visible category-axis window. */
 export class ChartNavigator extends ChartComponent {
 
     private _group?: Group;
     private _element?: HTMLElement;
+    private _orientation: ChartNavigatorOrientation = 'horizontal';
     private _area?: ChartArea;
     private _window: ChartNavigatorWindow = {
         start: 0,
@@ -108,7 +122,7 @@ export class ChartNavigator extends ChartComponent {
     private _attached = false;
     private _drag?: {
         mode: DragMode;
-        startX: number;
+        startMain: number;
         startWindow: ChartNavigatorWindow;
     };
 
@@ -138,8 +152,9 @@ export class ChartNavigator extends ChartComponent {
 
     /** Draws the overview, mask, and window for the current state. */
     public render(options: ChartNavigatorRenderOptions): void {
-        const { area, series, valueExtent, window, onWindow } = options;
+        const { orientation, area, series, valueExtent, window, onWindow } = options;
 
+        this._orientation = orientation;
         this._area = area;
         this._window = window;
         this._onWindow = onWindow;
@@ -147,7 +162,7 @@ export class ChartNavigator extends ChartComponent {
         const group = this._ensureGroup();
         group.clear();
 
-        const children: Element[] = [
+        group.add([
             createRect({
                 id: 'navigator-strip',
                 x: area.x,
@@ -160,11 +175,9 @@ export class ChartNavigator extends ChartComponent {
                 borderRadius: 3,
                 pointerEvents: 'none',
             }),
-            ...this._overviewElements(area, series, valueExtent),
-            ...this._windowElements(area, window),
-        ];
-
-        group.add(children);
+            ...this._overviewElements(series, valueExtent),
+            ...this._windowElements(window),
+        ]);
     }
 
     /** Removes the strip's drawn elements (e.g. when the overview is toggled off), leaving listeners inert. */
@@ -184,6 +197,231 @@ export class ChartNavigator extends ChartComponent {
         super.destroy();
     }
 
+    private get _horizontal(): boolean {
+        return this._orientation === 'horizontal';
+    }
+
+    private _mainStart(): number {
+        return this._horizontal ? this._area!.x : this._area!.y;
+    }
+
+    private _mainSize(): number {
+        return this._horizontal ? this._area!.width : this._area!.height;
+    }
+
+    private _crossStart(): number {
+        return this._horizontal ? this._area!.y : this._area!.x;
+    }
+
+    private _crossSize(): number {
+        return this._horizontal ? this._area!.height : this._area!.width;
+    }
+
+    /** The main-axis pixel position for a data index across `count` categories. */
+    private _mainForIndex(index: number, count: number): number {
+        const fraction = count <= 1 ? 0.5 : index / (count - 1);
+        return this._mainStart() + fraction * this._mainSize();
+    }
+
+    /** The main-axis pixel position for a `[0, 1]` window fraction. */
+    private _mainForFraction(fraction: number): number {
+        return this._mainStart() + clamp(fraction, 0, 1) * this._mainSize();
+    }
+
+    /** The cross-axis pixel position for a value (values grow up for horizontal, right for vertical). */
+    private _crossForValue(value: number, min: number, span: number): number {
+        const fraction = (value - min) / span;
+        return this._horizontal
+            ? this._crossStart() + this._crossSize() - fraction * this._crossSize()
+            : this._crossStart() + fraction * this._crossSize();
+    }
+
+    /** Maps a (main, cross) coordinate pair to an (x, y) point for the current orientation. */
+    private _point(main: number, cross: number): Point {
+        return this._horizontal ? [main, cross] : [cross, main];
+    }
+
+    private _overviewElements(series: ChartNavigatorSeries[], valueExtent: [number, number]): Element[] {
+        const [min, max] = valueExtent;
+        const span = max - min || 1;
+        // Values ≥ 0 sit on the strip floor; a diverging series anchors at 0.
+        const baseline = clamp(0, min, max);
+
+        return series
+            .filter(srs => srs.values.length > 0)
+            .flatMap(srs => {
+                if (srs.type === 'area') {
+                    return this._areaOverview(srs, min, span, baseline);
+                }
+
+                if (srs.type === 'bar') {
+                    return this._barOverview(srs, min, span, baseline);
+                }
+
+                return this._lineOverview(srs, min, span);
+            });
+    }
+
+    private _lineOverview(srs: ChartNavigatorSeries, min: number, span: number): Element[] {
+        const count = srs.values.length;
+        const points = srs.values.map((value, index) => this._point(this._mainForIndex(index, count), this._crossForValue(value, min, span)));
+
+        return [
+            createPolyline({
+                id: `navigator-overview-${srs.id}`,
+                points,
+                stroke: srs.color,
+                lineWidth: 1,
+                opacity: OVERVIEW_OPACITY,
+                pointerEvents: 'none',
+            }),
+        ];
+    }
+
+    private _areaOverview(srs: ChartNavigatorSeries, min: number, span: number, baseline: number): Element[] {
+        const count = srs.values.length;
+        const top = srs.values.map((value, index) => this._point(this._mainForIndex(index, count), this._crossForValue(value, min, span)));
+        const bottom = srs.values.map((_, index) => this._point(this._mainForIndex(index, count), this._crossForValue(baseline, min, span)));
+
+        const fill = createPolyline({
+            id: `navigator-overview-${srs.id}-fill`,
+            points: [
+                ...top,
+                ...bottom.reverse(),
+            ],
+            fill: setColorAlpha(srs.color, AREA_FILL_ALPHA),
+            pointerEvents: 'none',
+        });
+
+        fill.autoStroke = false;
+
+        return [
+            fill,
+            createPolyline({
+                id: `navigator-overview-${srs.id}-line`,
+                points: top,
+                stroke: srs.color,
+                lineWidth: 1,
+                opacity: OVERVIEW_OPACITY,
+                pointerEvents: 'none',
+            }),
+        ];
+    }
+
+    private _barOverview(srs: ChartNavigatorSeries, min: number, span: number, baseline: number): Element[] {
+        const count = srs.values.length;
+        const baseCross = this._crossForValue(baseline, min, span);
+        const thickness = Math.max(1, this._mainSize() / (count * 1.5));
+        const fill = setColorAlpha(srs.color, BAR_FILL_ALPHA);
+
+        return srs.values.map((value, index) => {
+            const mainCentre = this._mainForIndex(index, count);
+            const valueCross = this._crossForValue(value, min, span);
+            const mainLo = mainCentre - thickness / 2;
+            const crossLo = Math.min(baseCross, valueCross);
+            const crossHi = Math.max(baseCross, valueCross);
+
+            const rect = this._horizontal
+                ? {
+                    x: mainLo,
+                    y: crossLo,
+                    width: thickness,
+                    height: crossHi - crossLo,
+                }
+                : {
+                    x: crossLo,
+                    y: mainLo,
+                    width: crossHi - crossLo,
+                    height: thickness,
+                };
+
+            return createRect({
+                id: `navigator-overview-${srs.id}-bar-${index}`,
+                ...rect,
+                fill,
+                pointerEvents: 'none',
+            });
+        });
+    }
+
+    private _windowElements(window: ChartNavigatorWindow): Element[] {
+        const wStart = this._mainForFraction(window.start);
+        const wEnd = this._mainForFraction(window.end);
+        const mainLo = this._mainStart();
+        const mainHi = this._mainStart() + this._mainSize();
+
+        return [
+            // Dim the unselected regions on each side of the window.
+            this._spanRect('navigator-mask-start', mainLo, wStart, {
+                fill: MASK_FILL,
+            }),
+            this._spanRect('navigator-mask-end', wEnd, mainHi, {
+                fill: MASK_FILL,
+            }),
+            // The window outline.
+            this._spanRect('navigator-window', wStart, wEnd, {
+                fill: 'transparent',
+                stroke: WINDOW_BORDER,
+                lineWidth: 1,
+            }),
+            // The two draggable edge handles.
+            this._handle('navigator-handle-start', wStart),
+            this._handle('navigator-handle-end', wEnd),
+        ];
+    }
+
+    /** A rect spanning `[mainLo, mainHi]` along the main axis and the full cross extent. */
+    private _spanRect(id: string, mainLo: number, mainHi: number, style: { fill: string;
+        stroke?: string;
+        lineWidth?: number; }): Element {
+        const size = Math.max(0, mainHi - mainLo);
+        const rect = this._horizontal
+            ? {
+                x: mainLo,
+                y: this._crossStart(),
+                width: size,
+                height: this._crossSize(),
+            }
+            : {
+                x: this._crossStart(),
+                y: mainLo,
+                width: this._crossSize(),
+                height: size,
+            };
+
+        return createRect({
+            id,
+            ...rect,
+            ...style,
+            pointerEvents: 'none',
+        });
+    }
+
+    private _handle(id: string, mainCoord: number): Element {
+        const crossInset = this._crossSize() / 4;
+        const rect = this._horizontal
+            ? {
+                x: mainCoord - HANDLE_WIDTH / 2,
+                y: this._crossStart() + crossInset,
+                width: HANDLE_WIDTH,
+                height: this._crossSize() / 2,
+            }
+            : {
+                x: this._crossStart() + crossInset,
+                y: mainCoord - HANDLE_WIDTH / 2,
+                width: this._crossSize() / 2,
+                height: HANDLE_WIDTH,
+            };
+
+        return createRect({
+            id,
+            ...rect,
+            fill: HANDLE_FILL,
+            borderRadius: 2,
+            pointerEvents: 'none',
+        });
+    }
+
     private _ensureGroup(): Group {
         if (!this._group) {
             this._group = createGroup({
@@ -198,88 +436,6 @@ export class ChartNavigator extends ChartComponent {
         return this._group;
     }
 
-    private _overviewElements(area: ChartArea, series: ChartNavigatorSeries[], valueExtent: [number, number]): Element[] {
-        const [min, max] = valueExtent;
-        const span = max - min || 1;
-
-        const xAt = (index: number, count: number) => {
-            const t = count <= 1 ? 0.5 : index / (count - 1);
-            return area.x + t * area.width;
-        };
-
-        const yAt = (value: number) => area.y + area.height - ((value - min) / span) * area.height;
-
-        return series
-            .filter(srs => srs.values.length > 0)
-            .map(srs => {
-                const points: Point[] = srs.values.map((value, index) => [xAt(index, srs.values.length), yAt(value)]);
-
-                return createPolyline({
-                    id: `navigator-overview-${srs.id}`,
-                    points,
-                    stroke: srs.color,
-                    lineWidth: 1,
-                    opacity: OVERVIEW_OPACITY,
-                    pointerEvents: 'none',
-                });
-            });
-    }
-
-    private _windowElements(area: ChartArea, window: ChartNavigatorWindow): Element[] {
-        const wx0 = area.x + clamp(window.start, 0, 1) * area.width;
-        const wx1 = area.x + clamp(window.end, 0, 1) * area.width;
-
-        return [
-            // Dim the unselected regions on each side of the window.
-            createRect({
-                id: 'navigator-mask-left',
-                x: area.x,
-                y: area.y,
-                width: Math.max(0, wx0 - area.x),
-                height: area.height,
-                fill: MASK_FILL,
-                pointerEvents: 'none',
-            }),
-            createRect({
-                id: 'navigator-mask-right',
-                x: wx1,
-                y: area.y,
-                width: Math.max(0, area.x + area.width - wx1),
-                height: area.height,
-                fill: MASK_FILL,
-                pointerEvents: 'none',
-            }),
-            // The window outline.
-            createRect({
-                id: 'navigator-window',
-                x: wx0,
-                y: area.y,
-                width: Math.max(0, wx1 - wx0),
-                height: area.height,
-                fill: 'transparent',
-                stroke: WINDOW_BORDER,
-                lineWidth: 1,
-                pointerEvents: 'none',
-            }),
-            // The two draggable edge handles.
-            this._handle('navigator-handle-start', wx0, area),
-            this._handle('navigator-handle-end', wx1, area),
-        ];
-    }
-
-    private _handle(id: string, x: number, area: ChartArea): Element {
-        return createRect({
-            id,
-            x: x - HANDLE_WIDTH / 2,
-            y: area.y + area.height / 2 - area.height / 4,
-            width: HANDLE_WIDTH,
-            height: area.height / 2,
-            fill: HANDLE_FILL,
-            borderRadius: 2,
-            pointerEvents: 'none',
-        });
-    }
-
     private _localPoint(event: PointerEvent): Point {
         const rect = this._element!.getBoundingClientRect();
 
@@ -289,23 +445,29 @@ export class ChartNavigator extends ChartComponent {
         ];
     }
 
-    private _hitTest(x: number): DragMode | null {
-        if (!this._area) {
-            return null;
-        }
+    /** The pointer coordinate along the main (window) axis. */
+    private _mainCoord(point: Point): number {
+        return this._horizontal ? point[0] : point[1];
+    }
 
-        const wx0 = this._area.x + this._window.start * this._area.width;
-        const wx1 = this._area.x + this._window.end * this._area.width;
+    /** The pointer coordinate along the cross axis (used for the band hit test). */
+    private _crossCoord(point: Point): number {
+        return this._horizontal ? point[1] : point[0];
+    }
 
-        if (Math.abs(x - wx0) <= HANDLE_SLOP) {
+    private _hitTest(main: number): DragMode | null {
+        const wStart = this._mainForFraction(this._window.start);
+        const wEnd = this._mainForFraction(this._window.end);
+
+        if (Math.abs(main - wStart) <= HANDLE_SLOP) {
             return 'resize-start';
         }
 
-        if (Math.abs(x - wx1) <= HANDLE_SLOP) {
+        if (Math.abs(main - wEnd) <= HANDLE_SLOP) {
             return 'resize-end';
         }
 
-        if (x >= wx0 && x <= wx1) {
+        if (main >= wStart && main <= wEnd) {
             return 'move';
         }
 
@@ -317,10 +479,11 @@ export class ChartNavigator extends ChartComponent {
             return;
         }
 
-        const [x, y] = this._localPoint(event);
+        const point = this._localPoint(event);
+        const cross = this._crossCoord(point);
 
         // Only claim pointers that land inside the strip band; leave the rest to the in-plot navigator.
-        if (y < this._area.y || y > this._area.y + this._area.height) {
+        if (cross < this._crossStart() || cross > this._crossStart() + this._crossSize()) {
             return;
         }
 
@@ -328,7 +491,8 @@ export class ChartNavigator extends ChartComponent {
         event.stopImmediatePropagation();
         event.preventDefault();
 
-        const mode = this._hitTest(x);
+        const main = this._mainCoord(point);
+        const mode = this._hitTest(main);
 
         if (!mode) {
             return;
@@ -336,7 +500,7 @@ export class ChartNavigator extends ChartComponent {
 
         this._drag = {
             mode,
-            startX: x,
+            startMain: main,
             startWindow: { ...this._window },
         };
 
@@ -348,8 +512,8 @@ export class ChartNavigator extends ChartComponent {
             return;
         }
 
-        const [x] = this._localPoint(event);
-        const delta = (x - this._drag.startX) / Math.max(1, this._area.width);
+        const main = this._mainCoord(this._localPoint(event));
+        const delta = (main - this._drag.startMain) / Math.max(1, this._mainSize());
         const { mode, startWindow } = this._drag;
 
         let start = startWindow.start;

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -23,7 +23,12 @@ import type {
     ChartArea,
 } from '../core/layout';
 
+import {
+    computeStackOffset,
+} from '../core/data';
+
 import type {
+    BandScale,
     Element,
     Group,
     Point,
@@ -33,6 +38,7 @@ import {
     createGroup,
     createPolyline,
     createRect,
+    scaleBand,
     setColorAlpha,
 } from '@ripl/core';
 
@@ -64,6 +70,9 @@ export type ChartNavigatorOrientation = 'horizontal' | 'vertical';
 /** How a single overview series is drawn in the strip. */
 export type ChartNavigatorSeriesType = 'line' | 'bar' | 'area';
 
+/** How the category axis positions overview marks: padded bands (bars/trend) or edge-to-edge points (line/area). */
+export type ChartNavigatorCategoryLayout = 'band' | 'point';
+
 /** A single series' values across the categories, for the overview mini-render. */
 export interface ChartNavigatorSeries {
     /** The series id (used for the overview element ids). */
@@ -94,6 +103,18 @@ export interface ChartNavigatorRenderOptions {
     series: ChartNavigatorSeries[];
     /** The value extent `[min, max]` used to scale the overview across the cross axis. */
     valueExtent: [number, number];
+    /**
+     * Whether same-type series are stacked: bar series stack cumulatively (positive/negative
+     * independently) and area series stack as running cumulative bands. Defaults to `false` — bars are
+     * drawn grouped side-by-side and areas as independent baseline bands.
+     */
+    stacked?: boolean;
+    /**
+     * How the category axis positions marks. `'band'` (bar/trend charts) centres each category in a
+     * padded band so bars sit fully inside the strip and line/area marks align to band centres;
+     * `'point'` (line/area charts) spreads marks edge-to-edge. Defaults to `'point'`.
+     */
+    categoryLayout?: ChartNavigatorCategoryLayout;
     /** The currently visible window (derived by the host from the navigator transform). */
     window: ChartNavigatorWindow;
     /** Called with the new window whenever the user drags a handle or the window body. */
@@ -152,7 +173,7 @@ export class ChartNavigator extends ChartComponent {
 
     /** Draws the overview, mask, and window for the current state. */
     public render(options: ChartNavigatorRenderOptions): void {
-        const { orientation, area, series, valueExtent, window, onWindow } = options;
+        const { orientation, area, series, valueExtent, window, onWindow, stacked = false, categoryLayout = 'point' } = options;
 
         this._orientation = orientation;
         this._area = area;
@@ -175,7 +196,7 @@ export class ChartNavigator extends ChartComponent {
                 borderRadius: 3,
                 pointerEvents: 'none',
             }),
-            ...this._overviewElements(series, valueExtent),
+            ...this._overviewElements(series, valueExtent, stacked, categoryLayout),
             ...this._windowElements(window),
         ]);
     }
@@ -241,30 +262,46 @@ export class ChartNavigator extends ChartComponent {
         return this._horizontal ? [main, cross] : [cross, main];
     }
 
-    private _overviewElements(series: ChartNavigatorSeries[], valueExtent: [number, number]): Element[] {
+    private _overviewElements(series: ChartNavigatorSeries[], valueExtent: [number, number], stacked: boolean, categoryLayout: ChartNavigatorCategoryLayout): Element[] {
         const [min, max] = valueExtent;
         const span = max - min || 1;
         // Values ≥ 0 sit on the strip floor; a diverging series anchors at 0.
         const baseline = clamp(0, min, max);
 
-        return series
-            .filter(srs => srs.values.length > 0)
-            .flatMap(srs => {
-                if (srs.type === 'area') {
-                    return this._areaOverview(srs, min, span, baseline);
-                }
+        const active = series.filter(srs => srs.values.length > 0);
+        const areaSeries = active.filter(srs => srs.type === 'area');
+        const barSeries = active.filter(srs => srs.type === 'bar');
+        const lineSeries = active.filter(srs => srs.type === 'line');
 
-                if (srs.type === 'bar') {
-                    return this._barOverview(srs, min, span, baseline);
-                }
+        // A band host (bar/trend) positions marks in padded category bands so bars stay inside the strip
+        // and line/area marks align to band centres; a point host (line/area) spreads marks edge-to-edge.
+        const count = Math.max(1, ...active.map(srs => srs.values.length));
+        const band = categoryLayout === 'band' ? this._categoryScale(count) : undefined;
+        const mainFor: (index: number, seriesCount: number) => number = band
+            ? index => band(index) + band.bandwidth / 2
+            : (index, seriesCount) => this._mainForIndex(index, seriesCount);
 
-                return this._lineOverview(srs, min, span);
-            });
+        // Back-to-front: areas, then bars, then lines/markers on top (mirrors the plot's paint order).
+        return [
+            ...this._areaGroupOverview(areaSeries, min, span, baseline, stacked, mainFor),
+            ...(band ? this._barGroupOverview(barSeries, min, span, baseline, stacked, band) : []),
+            ...lineSeries.flatMap(srs => this._lineOverview(srs, min, span, mainFor)),
+        ];
     }
 
-    private _lineOverview(srs: ChartNavigatorSeries, min: number, span: number): Element[] {
+    /** A band scale over category indices `[0, count)` spanning the main axis, matching the chart's padded bars. */
+    private _categoryScale(count: number): BandScale<number> {
+        const domain = Array.from({ length: count }, (_, index) => index);
+
+        return scaleBand(domain, [this._mainStart(), this._mainStart() + this._mainSize()], {
+            outerPadding: 0.15,
+            innerPadding: 0.2,
+        });
+    }
+
+    private _lineOverview(srs: ChartNavigatorSeries, min: number, span: number, mainFor: (index: number, count: number) => number): Element[] {
         const count = srs.values.length;
-        const points = srs.values.map((value, index) => this._point(this._mainForIndex(index, count), this._crossForValue(value, min, span)));
+        const points = srs.values.map((value, index) => this._point(mainFor(index, count), this._crossForValue(value, min, span)));
 
         return [
             createPolyline({
@@ -278,16 +315,13 @@ export class ChartNavigator extends ChartComponent {
         ];
     }
 
-    private _areaOverview(srs: ChartNavigatorSeries, min: number, span: number, baseline: number): Element[] {
-        const count = srs.values.length;
-        const top = srs.values.map((value, index) => this._point(this._mainForIndex(index, count), this._crossForValue(value, min, span)));
-        const bottom = srs.values.map((_, index) => this._point(this._mainForIndex(index, count), this._crossForValue(baseline, min, span)));
-
+    /** Builds the filled band polygon + top line for one area series from precomputed top/bottom points. */
+    private _areaBand(srs: ChartNavigatorSeries, top: Point[], bottom: Point[]): Element[] {
         const fill = createPolyline({
             id: `navigator-overview-${srs.id}-fill`,
             points: [
                 ...top,
-                ...bottom.reverse(),
+                ...bottom.slice().reverse(),
             ],
             fill: setColorAlpha(srs.color, AREA_FILL_ALPHA),
             pointerEvents: 'none',
@@ -308,38 +342,91 @@ export class ChartNavigator extends ChartComponent {
         ];
     }
 
-    private _barOverview(srs: ChartNavigatorSeries, min: number, span: number, baseline: number): Element[] {
-        const count = srs.values.length;
-        const baseCross = this._crossForValue(baseline, min, span);
-        const thickness = Math.max(1, this._mainSize() / (count * 1.5));
-        const fill = setColorAlpha(srs.color, BAR_FILL_ALPHA);
+    /**
+     * Draws area series. Unstacked areas are independent baseline bands (correct for overlapping
+     * areas); stacked areas are running cumulative bands — each series stacked on the sum of the
+     * previous ones — mirroring the area renderer's plain cumulative accumulation.
+     */
+    private _areaGroupOverview(areaSeries: ChartNavigatorSeries[], min: number, span: number, baseline: number, stacked: boolean, mainFor: (index: number, count: number) => number): Element[] {
+        if (areaSeries.length === 0) {
+            return [];
+        }
 
-        return srs.values.map((value, index) => {
-            const mainCentre = this._mainForIndex(index, count);
-            const valueCross = this._crossForValue(value, min, span);
-            const mainLo = mainCentre - thickness / 2;
-            const crossLo = Math.min(baseCross, valueCross);
-            const crossHi = Math.max(baseCross, valueCross);
+        if (!stacked) {
+            return areaSeries.flatMap(srs => {
+                const count = srs.values.length;
+                const top = srs.values.map((value, index) => this._point(mainFor(index, count), this._crossForValue(value, min, span)));
+                const bottom = srs.values.map((_, index) => this._point(mainFor(index, count), this._crossForValue(baseline, min, span)));
 
-            const rect = this._horizontal
-                ? {
-                    x: mainLo,
-                    y: crossLo,
-                    width: thickness,
-                    height: crossHi - crossLo,
-                }
-                : {
-                    x: crossLo,
-                    y: mainLo,
-                    width: crossHi - crossLo,
-                    height: thickness,
-                };
+                return this._areaBand(srs, top, bottom);
+            });
+        }
 
-            return createRect({
-                id: `navigator-overview-${srs.id}-bar-${index}`,
-                ...rect,
-                fill,
-                pointerEvents: 'none',
+        return areaSeries.flatMap((srs, seriesIndex) => {
+            const count = srs.values.length;
+            const top: Point[] = [];
+            const bottom: Point[] = [];
+
+            srs.values.forEach((value, index) => {
+                const lower = areaSeries.slice(0, seriesIndex).reduce((sum, previous) => sum + (previous.values[index] ?? 0), 0);
+                const main = mainFor(index, count);
+
+                top.push(this._point(main, this._crossForValue(lower + value, min, span)));
+                bottom.push(this._point(main, this._crossForValue(lower, min, span)));
+            });
+
+            return this._areaBand(srs, top, bottom);
+        });
+    }
+
+    /**
+     * Draws bar series as a group in padded category bands: grouped side-by-side (a nested per-series
+     * band) by default, or stacked cumulatively (positive/negative independent) when `stacked`. Band
+     * positioning keeps every bar fully inside the strip.
+     */
+    private _barGroupOverview(barSeries: ChartNavigatorSeries[], min: number, span: number, baseline: number, stacked: boolean, band: BandScale<number>): Element[] {
+        if (barSeries.length === 0) {
+            return [];
+        }
+
+        const seriesScale = stacked
+            ? undefined
+            : scaleBand(barSeries.map((_, index) => index), [0, band.bandwidth], { innerPadding: 0.1 });
+
+        return barSeries.flatMap((srs, seriesIndex) => {
+            const fill = setColorAlpha(srs.color, BAR_FILL_ALPHA);
+
+            return srs.values.map((value, index) => {
+                const offset = stacked
+                    ? computeStackOffset(barSeries, srs, index, (entry, dataIndex) => entry.values[dataIndex] ?? 0)
+                    : 0;
+                const lowerCross = this._crossForValue(stacked ? offset : baseline, min, span);
+                const upperCross = this._crossForValue(value + offset, min, span);
+                const crossLo = Math.min(lowerCross, upperCross);
+                const crossHi = Math.max(lowerCross, upperCross);
+                const mainPos = stacked ? band(index) : band(index) + seriesScale!(seriesIndex);
+                const thickness = stacked ? band.bandwidth : seriesScale!.bandwidth;
+
+                const rect = this._horizontal
+                    ? {
+                        x: mainPos,
+                        y: crossLo,
+                        width: thickness,
+                        height: crossHi - crossLo,
+                    }
+                    : {
+                        x: crossLo,
+                        y: mainPos,
+                        width: crossHi - crossLo,
+                        height: thickness,
+                    };
+
+                return createRect({
+                    id: `navigator-overview-${srs.id}-bar-${index}`,
+                    ...rect,
+                    fill,
+                    pointerEvents: 'none',
+                });
             });
         });
     }

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -35,6 +35,7 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createGroup,
     createPolyline,
     createRect,
@@ -123,10 +124,6 @@ export interface ChartNavigatorRenderOptions {
 
 /** Which part of the window a drag is manipulating. */
 type DragMode = 'move' | 'resize-start' | 'resize-end';
-
-function clamp(value: number, min: number, max: number): number {
-    return Math.min(Math.max(value, min), max);
-}
 
 /** The overview strip component that drives the chart's visible category-axis window. */
 export class ChartNavigator extends ChartComponent {

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -83,6 +83,7 @@ import {
 import type {
     ChartNavigatorCategoryLayout,
     ChartNavigatorSeries,
+    ChartNavigatorSeriesType,
     ChartNavigatorWindow,
 } from '../components/navigator';
 
@@ -100,6 +101,7 @@ import type {
 
 import {
     Box,
+    clamp,
     createFrameBuffer,
     createGroup,
     createRect,
@@ -140,16 +142,12 @@ function isSameTransform(a: NavigatorTransform, b: NavigatorTransform): boolean 
     return a.k === b.k && a.x === b.x && a.y === b.y;
 }
 
-function clampValue(value: number, min: number, max: number): number {
-    return Math.min(Math.max(value, min), max);
-}
-
 /**
  * Clamps a view translation so the visible window stays within the full domain: given the axis plot
  * `origin`/`size` and zoom `k`, the translate must lie in `[(origin+size)(1-k), origin(1-k)]`.
  */
 function clampTranslate(translate: number, origin: number, size: number, k: number): number {
-    return clampValue(translate, (origin + size) * (1 - k), origin * (1 - k));
+    return clamp(translate, (origin + size) * (1 - k), origin * (1 - k));
 }
 
 /** Options shared by all cartesian charts. */
@@ -482,6 +480,33 @@ export abstract class CartesianChart<
         return 'point';
     }
 
+    /**
+     * Builds the per-series overview data ({@link ChartNavigatorSeries}) the strip renders — id,
+     * palette colour, draw type, and per-category values — from a series list and per-series
+     * `type`/`value` resolvers. Shared by the line, area, bar, and trend charts so each only supplies
+     * how to resolve its own type and values.
+     *
+     * @typeParam TSeries - The chart's series-options type (must carry an `id`).
+     * @param series - The series to describe.
+     * @param data - The dataset each series is sampled over.
+     * @param getType - Resolves how a series is drawn in the strip (`line`/`bar`/`area`).
+     * @param getValue - Resolves a series' numeric value at a data item.
+     * @returns One {@link ChartNavigatorSeries} per input series, in order.
+     */
+    protected buildOverviewSeries<TSeries extends { id: string }>(
+        series: TSeries[],
+        data: TData[],
+        getType: (series: TSeries) => ChartNavigatorSeriesType,
+        getValue: (series: TSeries, item: TData) => number
+    ): ChartNavigatorSeries[] {
+        return series.map(srs => ({
+            id: srs.id,
+            color: this.getSeriesColor(srs.id),
+            type: getType(srs),
+            values: data.map(item => getValue(srs, item)),
+        }));
+    }
+
     /** Whether the overview strip is enabled and applicable (a category-axis chart with `overview` on). */
     private _overviewEnabled(): boolean {
         return !!this.options.overview && this.navigationAxis() !== 'both';
@@ -619,8 +644,8 @@ export abstract class CartesianChart<
         const end = ((origin + size - translate) / transform.k - origin) / size;
 
         return {
-            start: clampValue(start, 0, 1),
-            end: clampValue(end, 0, 1),
+            start: clamp(start, 0, 1),
+            end: clamp(end, 0, 1),
         };
     }
 
@@ -641,8 +666,8 @@ export abstract class CartesianChart<
             end = start + MIN_WINDOW;
         }
 
-        start = clampValue(start, 0, 1 - MIN_WINDOW);
-        end = clampValue(end, start + MIN_WINDOW, 1);
+        start = clamp(start, 0, 1 - MIN_WINDOW);
+        end = clamp(end, start + MIN_WINDOW, 1);
 
         const k = 1 / (end - start);
         const translate = origin - k * (origin + start * size);
@@ -836,7 +861,7 @@ export abstract class CartesianChart<
         const invert = (position: number) => {
             const t = (position - left) / Math.max(1, right - left);
             const index = Math.round(t * span);
-            return keys[Math.max(0, Math.min(keys.length - 1, index))];
+            return keys[clamp(index, 0, keys.length - 1)];
         };
 
         return Object.assign(convert, {

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -77,6 +77,7 @@ import type {
 } from '../components/legend';
 
 import type {
+    BandScale,
     Context,
     Element,
     EventMap,
@@ -559,6 +560,24 @@ export abstract class CartesianChart<
             ticks: () => keys,
             includes: (value: string) => keys.includes(value),
         }) as unknown as Scale<string>;
+    }
+
+    /**
+     * Wraps a band scale as a point scale positioned at each band's centre, rendering one centred
+     * tick per category. Shared by the bar chart (its categorical axis) and the trend chart (which
+     * places line/area markers at the centre of each category slot).
+     */
+    protected bandCenterScale(band: BandScale<string>, keys: string[]): Scale<string> {
+        return Object.assign(
+            (value: string) => band(value) + band.bandwidth / 2,
+            {
+                domain: keys,
+                range: band.range,
+                inverse: band.inverse,
+                ticks: () => keys,
+                includes: (value: string) => keys.includes(value),
+            }
+        ) as unknown as Scale<string>;
     }
 
 }

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -81,6 +81,7 @@ import {
 } from '../components/navigator';
 
 import type {
+    ChartNavigatorCategoryLayout,
     ChartNavigatorSeries,
     ChartNavigatorWindow,
 } from '../components/navigator';
@@ -472,6 +473,15 @@ export abstract class CartesianChart<
         return 'both';
     }
 
+    /**
+     * How the overview strip positions category marks: `'band'` (bar/trend — padded category bands with
+     * marks at band centres, so bars sit fully inside the strip) or `'point'` (line/area — marks spread
+     * edge-to-edge). Defaults to `'point'`; category-band charts override it.
+     */
+    protected navigatorCategoryLayout(): ChartNavigatorCategoryLayout {
+        return 'point';
+    }
+
     /** Whether the overview strip is enabled and applicable (a category-axis chart with `overview` on). */
     private _overviewEnabled(): boolean {
         return !!this.options.overview && this.navigationAxis() !== 'both';
@@ -552,9 +562,10 @@ export abstract class CartesianChart<
 
     /**
      * Renders the overview strip into the reserved `band` from the given series and value extent, or
-     * clears it when the strip is off. Call after the plot rect is known (i.e. after `clipPlot`).
+     * clears it when the strip is off. Call after the plot rect is known (i.e. after `clipPlot`). Pass
+     * `stacked` so the strip stacks same-type bar/area series rather than grouping/overlaying them.
      */
-    protected renderNavigator(band: ChartArea | undefined, series: ChartNavigatorSeries[], valueExtent: [number, number]): void {
+    protected renderNavigator(band: ChartArea | undefined, series: ChartNavigatorSeries[], valueExtent: [number, number], stacked = false): void {
         if (!band || !this._overviewEnabled() || !this._navPlot) {
             this._navigatorStrip.clear();
             return;
@@ -582,6 +593,8 @@ export abstract class CartesianChart<
             area,
             series,
             valueExtent,
+            stacked,
+            categoryLayout: this.navigatorCategoryLayout(),
             window: this._currentWindow(),
             onWindow: window => this._onNavigatorWindow(window),
         });

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -76,6 +76,15 @@ import type {
     LegendItem,
 } from '../components/legend';
 
+import {
+    ChartNavigator,
+} from '../components/navigator';
+
+import type {
+    ChartNavigatorSeries,
+    ChartNavigatorWindow,
+} from '../components/navigator';
+
 import type {
     BandScale,
     Context,
@@ -111,9 +120,35 @@ import type {
 /** Resolved animation used to snap geometry into place during navigator-driven re-renders. */
 const NO_ANIMATION = normalizeAnimation(false);
 
+/** Default size (height for a bottom strip, width for a side strip) of the overview navigator, in pixels. */
+const DEFAULT_OVERVIEW_SIZE = 48;
+/** Gap between the plot/axis and the overview strip, in pixels. */
+const OVERVIEW_GAP = 14;
+/** Minimum visible window width, as a fraction of the domain (bounds the maximum zoom). */
+const MIN_WINDOW = 0.02;
+/** Maximum zoom factor `k` — you can zoom in to this, and out only to the full-data identity view (`k = 1`). */
+const NAV_MAX_ZOOM = 50;
+
 /** Whether a view transform is the identity (no pan, no zoom). */
 function isIdentityTransform(transform: NavigatorTransform): boolean {
     return transform.k === 1 && transform.x === 0 && transform.y === 0;
+}
+
+/** Whether two view transforms are exactly equal. */
+function isSameTransform(a: NavigatorTransform, b: NavigatorTransform): boolean {
+    return a.k === b.k && a.x === b.x && a.y === b.y;
+}
+
+function clampValue(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Clamps a view translation so the visible window stays within the full domain: given the axis plot
+ * `origin`/`size` and zoom `k`, the translate must lie in `[(origin+size)(1-k), origin(1-k)]`.
+ */
+function clampTranslate(translate: number, origin: number, size: number, k: number): number {
+    return clampValue(translate, (origin + size) * (1 - k), origin * (1 - k));
 }
 
 /** Options shared by all cartesian charts. */
@@ -136,6 +171,20 @@ export interface CartesianChartOptions<TData = unknown> extends BaseChartOptions
      * (`centerOn`/`fitBounds`) or brush-and-link.
      */
     navigator?: boolean | NavigatorInteractions;
+    /**
+     * Enables an overview "scrub bar" strip beside the plot with a draggable window that selects the
+     * visible range of the **category** axis (a bottom bar for category-on-x charts, a side bar for a
+     * horizontal bar chart). `true` uses the default size; an object sets it. Enabling the strip also
+     * turns on in-plot wheel/drag pan-zoom (category-axis only) unless `navigator` is explicitly `false`.
+     * Only category-axis charts (line, area, bar, trend) render the strip.
+     */
+    overview?: boolean | ChartOverviewOptions;
+}
+
+/** Configuration for the overview navigator strip. */
+export interface ChartOverviewOptions {
+    /** Size of the strip (height for a bottom strip, width for a side strip), in pixels. Defaults to 48. */
+    size?: number;
 }
 
 /** Declares which optional cartesian components a chart wants constructed. */
@@ -185,6 +234,11 @@ export abstract class CartesianChart<
     private _plotContent?: Group;
     private _plotClip?: Rect;
 
+    /** The overview "scrub bar" strip (created in `setupCartesian`; only rendered by category-axis charts). */
+    private _navigatorStrip!: ChartNavigator;
+    /** The plot rectangle from the most recent render, used to bound pan and window the category axis. */
+    private _navPlot?: ChartArea;
+
     /**
      * The pan/zoom/brush controller for this chart, or `undefined` when the `navigator` option is off.
      * Use it for imperative framing (`centerOn`, `fitBounds`, `reset`) and to subscribe to
@@ -196,15 +250,22 @@ export abstract class CartesianChart<
 
     /**
      * Merges options and re-renders (see {@link Chart.update}), additionally creating or destroying the
-     * navigator when the `navigator` option is toggled. The controller is otherwise a construction-time
-     * concern, so reconciling here keeps `chart.update({ navigator })` working at runtime.
+     * navigator when the `navigator` or `overview` option is toggled. The controller is otherwise a
+     * construction-time concern, so reconciling here keeps `chart.update({ navigator })` /
+     * `chart.update({ overview })` working at runtime.
      */
     public override update(options: Partial<TOptions>): void {
-        if (options.navigator !== undefined) {
+        if (options.navigator !== undefined || options.overview !== undefined) {
             this.options = {
                 ...this.options,
                 ...options,
             };
+
+            this.options.navigator = this._resolveNavigator();
+
+            if (this._overviewEnabled()) {
+                this._navigatorStrip.attach();
+            }
 
             this._reconcileNavigator();
         }
@@ -217,6 +278,20 @@ export abstract class CartesianChart<
      * constructor (after `super(...)`) and before `init()`.
      */
     protected setupCartesian(setup: CartesianSetup = {}) {
+        // Build the overview strip and attach its listeners before the in-plot navigator is created, so
+        // a pointerdown inside the strip band is claimed by the strip and never also pans the plot.
+        this._navigatorStrip = new ChartNavigator({
+            scene: this.scene,
+            renderer: this.renderer,
+        });
+
+        if (this._overviewEnabled()) {
+            this._navigatorStrip.attach();
+        }
+
+        // Enabling the overview implies a navigator for the strip to drive.
+        this.options.navigator = this._resolveNavigator();
+
         const axisOpts = normalizeAxis(this.options.axis);
         const xAxis = normalizeAxisItem(axisOpts.x);
         const yAxis = normalizeYAxisItem(Array.isArray(axisOpts.y) ? axisOpts.y[0] : axisOpts.y);
@@ -288,7 +363,10 @@ export abstract class CartesianChart<
         }
 
         this.retain({
-            dispose: () => this._destroyNavigator(),
+            dispose: () => {
+                this._destroyNavigator();
+                this._navigatorStrip.destroy();
+            },
         });
 
         this._reconcileNavigator();
@@ -341,10 +419,22 @@ export abstract class CartesianChart<
 
         this._navigator = createNavigator(this.scene.context, {
             interactions,
+            // You can zoom in up to NAV_MAX_ZOOM, but only out to the full-data identity view (k = 1) —
+            // never past the extent of the dataset.
+            scaleExtent: [1, NAV_MAX_ZOOM],
         });
 
         this._navigator.on('change', event => {
-            this._view = event.data;
+            // Bound the transform so pan/zoom can't scroll past the data edges. Clamping is a fixpoint,
+            // so re-applying the clamped transform re-enters once and then settles.
+            const clamped = this._clampView(event.data);
+
+            if (!isSameTransform(clamped, event.data)) {
+                this._navigator?.setTransform(clamped);
+                return;
+            }
+
+            this._view = clamped;
             this._scheduleNavigatorRender(() => this._renderFromNavigator());
         });
     }
@@ -369,6 +459,186 @@ export abstract class CartesianChart<
 
         void Promise.resolve(this.render()).finally(() => {
             this._navigating = false;
+        });
+    }
+
+    /**
+     * Which axis the navigator windows: `'x'` (category on x — line/area/vertical bar/trend), `'y'`
+     * (category on y — horizontal bar), or `'both'` (2-D charts like scatter). Category-axis charts get
+     * the overview strip and hold the value axis fixed; `'both'` charts zoom both axes uniformly. Only
+     * `'x'`/`'y'` charts render the strip. Defaults to `'both'`.
+     */
+    protected navigationAxis(): 'x' | 'y' | 'both' {
+        return 'both';
+    }
+
+    /** Whether the overview strip is enabled and applicable (a category-axis chart with `overview` on). */
+    private _overviewEnabled(): boolean {
+        return !!this.options.overview && this.navigationAxis() !== 'both';
+    }
+
+    /** The strip's size (height for a bottom strip, width for a side strip), in pixels. */
+    private _overviewSize(): number {
+        const overview = this.options.overview;
+
+        if (overview && typeof overview === 'object') {
+            return overview.size ?? DEFAULT_OVERVIEW_SIZE;
+        }
+
+        return DEFAULT_OVERVIEW_SIZE;
+    }
+
+    /** Resolves the effective in-plot navigator config, ensuring a controller exists when the strip is on. */
+    private _resolveNavigator(): boolean | NavigatorInteractions | undefined {
+        const navigator = this.options.navigator;
+
+        if (!this._overviewEnabled()) {
+            return navigator;
+        }
+
+        // Strip on but in-plot gestures explicitly off — still create an inert controller for the strip.
+        if (navigator === false) {
+            return {
+                zoom: false,
+                pan: false,
+                brush: false,
+            };
+        }
+
+        return navigator ?? true;
+    }
+
+    /** Clamps a transform's category-axis translation so the visible window stays within the full domain. */
+    private _clampView(transform: NavigatorTransform): NavigatorTransform {
+        if (!this._navPlot || isIdentityTransform(transform)) {
+            return transform;
+        }
+
+        const axis = this.navigationAxis();
+        const { k } = transform;
+        let { x, y } = transform;
+
+        if (axis === 'x' || axis === 'both') {
+            x = clampTranslate(x, this._navPlot.x, this._navPlot.width, k);
+        }
+
+        if (axis === 'y' || axis === 'both') {
+            y = clampTranslate(y, this._navPlot.y, this._navPlot.height, k);
+        }
+
+        return {
+            k,
+            x,
+            y,
+        };
+    }
+
+    /**
+     * Reserves the strip band from the layout (a bottom band for a category-on-x chart, a right band for
+     * a horizontal bar chart). Call after `reserveTitle`/`reserveLegend` and before measuring the axes.
+     * Returns `undefined` when the strip is off.
+     */
+    protected reserveNavigatorBand(layout: ChartLayout): ChartArea | undefined {
+        if (!this._overviewEnabled()) {
+            return undefined;
+        }
+
+        const size = this._overviewSize() + OVERVIEW_GAP;
+
+        return this.navigationAxis() === 'y'
+            ? layout.reserveRight(size)
+            : layout.reserveBottom(size);
+    }
+
+    /**
+     * Renders the overview strip into the reserved `band` from the given series and value extent, or
+     * clears it when the strip is off. Call after the plot rect is known (i.e. after `clipPlot`).
+     */
+    protected renderNavigator(band: ChartArea | undefined, series: ChartNavigatorSeries[], valueExtent: [number, number]): void {
+        if (!band || !this._overviewEnabled() || !this._navPlot) {
+            this._navigatorStrip.clear();
+            return;
+        }
+
+        const plot = this._navPlot;
+        const vertical = this.navigationAxis() === 'y';
+
+        const area = vertical
+            ? {
+                x: band.x + OVERVIEW_GAP,
+                y: plot.y,
+                width: this._overviewSize(),
+                height: plot.height,
+            }
+            : {
+                x: plot.x,
+                y: band.y + OVERVIEW_GAP,
+                width: plot.width,
+                height: this._overviewSize(),
+            };
+
+        this._navigatorStrip.render({
+            orientation: vertical ? 'vertical' : 'horizontal',
+            area,
+            series,
+            valueExtent,
+            window: this._currentWindow(),
+            onWindow: window => this._onNavigatorWindow(window),
+        });
+    }
+
+    /** The visible window `[start, end]` (category-domain fractions) derived from the current transform. */
+    private _currentWindow(): ChartNavigatorWindow {
+        const transform = this._navigator?.transform;
+
+        if (!this._navPlot || !transform) {
+            return {
+                start: 0,
+                end: 1,
+            };
+        }
+
+        const vertical = this.navigationAxis() === 'y';
+        const origin = vertical ? this._navPlot.y : this._navPlot.x;
+        const size = Math.max(1, vertical ? this._navPlot.height : this._navPlot.width);
+        const translate = vertical ? transform.y : transform.x;
+        const start = ((origin - translate) / transform.k - origin) / size;
+        const end = ((origin + size - translate) / transform.k - origin) / size;
+
+        return {
+            start: clampValue(start, 0, 1),
+            end: clampValue(end, 0, 1),
+        };
+    }
+
+    /** Converts a strip window into a navigator transform, windowing the category axis (value axis fixed). */
+    private _onNavigatorWindow(window: ChartNavigatorWindow): void {
+        if (!this._navPlot || !this._navigator) {
+            return;
+        }
+
+        const vertical = this.navigationAxis() === 'y';
+        const origin = vertical ? this._navPlot.y : this._navPlot.x;
+        const size = Math.max(1, vertical ? this._navPlot.height : this._navPlot.width);
+
+        let start = window.start;
+        let end = window.end;
+
+        if (end - start < MIN_WINDOW) {
+            end = start + MIN_WINDOW;
+        }
+
+        start = clampValue(start, 0, 1 - MIN_WINDOW);
+        end = clampValue(end, start + MIN_WINDOW, 1);
+
+        const k = 1 / (end - start);
+        const translate = origin - k * (origin + start * size);
+        const current = this._navigator.transform;
+
+        this._navigator.setTransform({
+            k,
+            x: vertical ? current.x : translate,
+            y: vertical ? translate : current.y,
         });
     }
 
@@ -483,13 +753,16 @@ export abstract class CartesianChart<
      * navigator the clip stays inert, preserving the exact un-clipped rendering.
      */
     protected clipPlot(area: ChartArea): void {
+        this._navPlot = area;
         this._ensurePlotContent();
 
-        // Everything positioned by the (navigator-rescaled) scales — marks, grid, and axis
-        // ticks/labels — must stay within the plot while navigating. The marks live in
-        // `_plotContent` (masked by `_plotClip`); the grid and axes live in their own scene-root
-        // groups, so they get their own clips here. All are inert without a navigator.
+        // Marks + grid must stay within the plot while navigating; they live in `_plotContent` (masked by
+        // `_plotClip`) and the grid's own clip. Axis labels only need clipping along the axis they
+        // actually slide: the category axis slides under the window, so clip it; the value axis is held
+        // at the full extent, so leave it unclipped (clipping it bisected its min/max labels). 2-D charts
+        // (`both`) slide both axes.
         const navigating = !!this._navigator;
+        const axis = this.navigationAxis();
 
         if (this._plotClip) {
             this._plotClip.x = area.x;
@@ -499,8 +772,8 @@ export abstract class CartesianChart<
             this._plotClip.clip = navigating;
         }
 
-        this.xAxis.clipTo(area, navigating);
-        this.yAxis.clipTo(area, navigating);
+        this.xAxis.clipTo(area, navigating && (axis === 'x' || axis === 'both'));
+        this.yAxis.clipTo(area, navigating && (axis === 'y' || axis === 'both'));
         this.grid?.clipTo(area, navigating);
     }
 

--- a/packages/charts/src/core/data.ts
+++ b/packages/charts/src/core/data.ts
@@ -72,3 +72,83 @@ export function computeStackOffset<TSeries, TData>(
         return sum;
     }, 0);
 }
+
+/**
+ * Computes the value extent `[min, max]` of independently stacked positive and negative totals — the
+ * span a stacked bar chart covers when, per item, positive and negative values accumulate from the
+ * baseline in opposite directions. Both bounds seed at `0`, so an all-positive (or all-negative)
+ * dataset keeps a zero baseline.
+ *
+ * @typeParam TSeries - The series type.
+ * @typeParam TData - The data-item type.
+ * @param series - The series that stack together.
+ * @param data - The dataset iterated per item.
+ * @param getValue - Resolves a series' numeric value at a data item.
+ * @returns The `[min, max]` extent covering every item's positive and negative stacked totals.
+ */
+export function positiveNegativeExtent<TSeries, TData>(
+    series: TSeries[],
+    data: TData[],
+    getValue: (series: TSeries, item: TData) => number
+): [number, number] {
+    let max = 0;
+    let min = 0;
+
+    data.forEach(item => {
+        let positive = 0;
+        let negative = 0;
+
+        series.forEach(srs => {
+            const value = getValue(srs, item);
+
+            if (value >= 0) {
+                positive += value;
+            } else {
+                negative += value;
+            }
+        });
+
+        max = Math.max(max, positive);
+        min = Math.min(min, negative);
+    });
+
+    return [min, max];
+}
+
+/**
+ * Computes the value extent `[min, max]` of the running cumulative total across series — the span a
+ * stacked area chart covers as each series accumulates on top of the previous ones. Both bounds seed
+ * at `0`, so a single-sign dataset keeps a zero baseline.
+ *
+ * @typeParam TSeries - The series type.
+ * @typeParam TData - The data-item type.
+ * @param series - The series that stack together, in stacking order.
+ * @param data - The dataset iterated per item.
+ * @param getValue - Resolves a series' numeric value at a data item.
+ * @returns The `[min, max]` extent covering the cumulative running total across every item.
+ */
+export function cumulativeExtent<TSeries, TData>(
+    series: TSeries[],
+    data: TData[],
+    getValue: (series: TSeries, item: TData) => number
+): [number, number] {
+    let max = 0;
+    let min = 0;
+
+    data.forEach(item => {
+        let cumulative = 0;
+        let cumulativeMax = 0;
+        let cumulativeMin = 0;
+
+        series.forEach(srs => {
+            cumulative += getValue(srs, item);
+            cumulativeMax = Math.max(cumulativeMax, cumulative);
+            cumulativeMin = Math.min(cumulativeMin, cumulative);
+        });
+
+        max = Math.max(max, cumulativeMax);
+        min = Math.min(min, cumulativeMin);
+    });
+
+    return [min, max];
+}

--- a/packages/charts/src/core/series/area-series.ts
+++ b/packages/charts/src/core/series/area-series.ts
@@ -1,0 +1,511 @@
+/**
+ * Area series renderer: draws each series as a filled band beneath a line with optional markers.
+ *
+ * Extracted from the area chart so the standalone {@link AreaChart} and the mixed trend chart share
+ * one implementation — including cumulative stacking, the left→right fill reveal on entry, the
+ * key-reconciled top/bottom morph, and the largest-at-back paint ordering that keeps small areas
+ * from hiding behind large ones.
+ */
+
+import {
+    SeriesRenderer,
+} from './base';
+
+import type {
+    SeriesLabelBatch,
+} from './base';
+
+import type {
+    AreaSeriesContext,
+    AreaSeriesLike,
+} from './context';
+
+import {
+    ANIMATION_REFERENCE,
+    exitElement,
+} from '../animation';
+
+import type {
+    ResolvedAnimation,
+} from '../animation';
+
+import {
+    resolveLineDash,
+} from '../options';
+
+import {
+    createDataLabel,
+} from '../labels';
+
+import type {
+    DataLabelSpec,
+} from '../labels';
+
+import {
+    correspondence,
+    keysDiffer,
+} from '../morph';
+
+import {
+    resolveAccessor,
+} from '../data';
+
+import {
+    areaBandRenderer,
+} from '../fill';
+
+import type {
+    Circle,
+    CircleState,
+    Group,
+    Interpolator,
+    Point,
+    Polyline,
+    PolylineState,
+} from '@ripl/core';
+
+import {
+    createCircle,
+    createGroup,
+    createPolyline,
+    interpolatePath,
+    interpolatePoints,
+    interpolateWaypoint,
+    setColorAlpha,
+} from '@ripl/core';
+
+import {
+    arrayJoin,
+    typeIsFunction,
+} from '@ripl/utilities';
+
+/** The top/bottom boundary points of an area band. */
+interface AreaPoints {
+    linePoints: Point[];
+    bottomPoints: Point[];
+    areaPoints: Point[];
+}
+
+/** Per-render precompute for the area renderer. */
+interface AreaPrepared<TData> {
+    /** The plotted (cumulative when stacked) value for a series at a data item. */
+    getSeriesValue: (series: AreaSeriesLike<TData>, item: TData, dataIndex: number) => number;
+    /** The lower boundary value for a series at a data item (previous cumulative, or 0). */
+    getPrevSeriesValue: (series: AreaSeriesLike<TData>, dataIndex: number) => number;
+    /** Top/bottom boundaries per entering series, driving the left→right reveal. */
+    entryReveal: Map<string, { linePoints: Point[];
+        bottomPoints: Point[]; }>;
+    /** Paint rank per series id (0 = backmost); largest area at the back when unstacked. */
+    orderRank: Map<string, number>;
+}
+
+/**
+ * Builds an interpolator that reveals a filled area band left→right, growing a closed polygon from
+ * the left edge to a moving front along the real top and lower boundaries — a true wipe, not a
+ * horizontal stretch.
+ */
+function interpolateAreaReveal(top: Point[], bottom: Point[]): Interpolator<Point[]> {
+    const lastIndex = top.length - 1;
+    const topAt = interpolateWaypoint(top);
+    const bottomAt = interpolateWaypoint(bottom);
+
+    return position => {
+        if (position >= 1) {
+            return [
+                ...top,
+                ...bottom.slice().reverse(),
+            ];
+        }
+
+        const count = Math.ceil(lastIndex * position);
+        const revealedTop = top.slice(0, count).concat([topAt(position)]);
+        const revealedBottom = bottom.slice(0, count).concat([bottomAt(position)]);
+
+        return [
+            ...revealedTop,
+            ...revealedBottom.reverse(),
+        ];
+    };
+}
+
+/** Renders area series (filled band + line + markers) for a host chart. */
+export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TData>, TData, AreaSeriesContext<TData>, AreaPrepared<TData>> {
+
+    /** Previous ordered data keys per series, used to key-reconcile the line/fill morph across add/remove. */
+    private _morphKeys = new Map<string, string[]>();
+
+    private _rawValue(series: AreaSeriesLike<TData>, item: TData): number {
+        return resolveAccessor<TData, number>(series.value)(item);
+    }
+
+    private _seriesLabel(series: AreaSeriesLike<TData>, item: TData): string {
+        return typeIsFunction(series.label) ? series.label(item) : series.label;
+    }
+
+    private _buildPoints(series: AreaSeriesLike<TData>, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): AreaPoints {
+        const linePoints: Point[] = [];
+        const bottomPoints: Point[] = [];
+
+        ctx.data.forEach((item, dataIndex) => {
+            const x = ctx.xScale(ctx.getKey(item));
+            const y = ctx.yScale(prepared.getSeriesValue(series, item, dataIndex));
+            // Lower boundary: the previous series' cumulative top when stacked, else the baseline.
+            const bottomY = ctx.stacked ? ctx.yScale(prepared.getPrevSeriesValue(series, dataIndex)) : ctx.baseline;
+
+            linePoints.push([x, y]);
+            bottomPoints.push([x, bottomY]);
+        });
+
+        return {
+            linePoints,
+            bottomPoints,
+            // Closed band polygon: top edge left→right, then the lower boundary right→left.
+            areaPoints: [
+                ...linePoints,
+                ...bottomPoints.slice().reverse(),
+            ],
+        };
+    }
+
+    private _buildMarker(series: AreaSeriesLike<TData>, item: TData, dataIndex: number, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): Circle {
+        const color = ctx.getColor(series.id);
+        const key = ctx.getKey(item);
+        const x = ctx.xScale(key);
+        const y = ctx.yScale(prepared.getSeriesValue(series, item, dataIndex));
+
+        const state: CircleState = {
+            fill: '#FFFFFF',
+            stroke: color,
+            lineWidth: 2,
+            cx: x,
+            cy: y,
+            radius: 3,
+        };
+
+        const marker = createCircle({
+            id: `${series.id}-marker-${key}`,
+            ...state,
+            radius: 0,
+            data: state,
+        });
+
+        this.attachMarkerHover(marker, ctx, {
+            seriesId: series.id,
+            key,
+            value: this._rawValue(series, item),
+            label: this._seriesLabel(series, item),
+            radius: 3,
+            highlightColor: color,
+        });
+
+        return marker;
+    }
+
+    private _labelSpec(series: AreaSeriesLike<TData>, item: TData, dataIndex: number, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): DataLabelSpec {
+        const key = ctx.getKey(item);
+
+        return {
+            id: `${series.id}-marker-${key}-label`,
+            x: ctx.xScale(key),
+            y: ctx.yScale(prepared.getSeriesValue(series, item, dataIndex)),
+            anchor: ctx.dataLabels.anchor,
+            content: ctx.formatValue(this._rawValue(series, item)),
+            font: ctx.dataLabels.font,
+            fill: ctx.dataLabels.fontColor,
+            offset: 7,
+        };
+    }
+
+    protected prepare(series: AreaSeriesLike<TData>[], ctx: AreaSeriesContext<TData>): AreaPrepared<TData> {
+        const { data } = ctx;
+        const stackedValues: number[][] = [];
+
+        if (ctx.stacked) {
+            data.forEach((item, dataIndex) => {
+                stackedValues[dataIndex] = [];
+                let cumulative = 0;
+
+                series.forEach((srs, seriesIndex) => {
+                    cumulative += this._rawValue(srs, item);
+                    stackedValues[dataIndex][seriesIndex] = cumulative;
+                });
+            });
+        }
+
+        const getSeriesValue = (srs: AreaSeriesLike<TData>, item: TData, dataIndex: number) => {
+            const raw = this._rawValue(srs, item);
+            const seriesIndex = series.indexOf(srs);
+
+            if (ctx.stacked && seriesIndex >= 0) {
+                return stackedValues[dataIndex]?.[seriesIndex] ?? raw;
+            }
+
+            return raw;
+        };
+
+        const getPrevSeriesValue = (srs: AreaSeriesLike<TData>, dataIndex: number) => {
+            const seriesIndex = series.indexOf(srs);
+
+            if (ctx.stacked && seriesIndex > 0) {
+                return stackedValues[dataIndex]?.[seriesIndex - 1] ?? 0;
+            }
+
+            return 0;
+        };
+
+        return {
+            getSeriesValue,
+            getPrevSeriesValue,
+            entryReveal: new Map(),
+            orderRank: this._computeOrderRank(series, ctx),
+        };
+    }
+
+    /** Ranks series for paint order: stacked keeps stack order, unstacked sorts largest→smallest (back→front). */
+    private _computeOrderRank(series: AreaSeriesLike<TData>[], ctx: AreaSeriesContext<TData>): Map<string, number> {
+        const rank = new Map<string, number>();
+
+        if (ctx.stacked) {
+            series.forEach((srs, index) => rank.set(srs.id, index));
+            return rank;
+        }
+
+        const sized = series.map((srs, index) => ({
+            id: srs.id,
+            index,
+            size: ctx.data.reduce((sum, item) => sum + Math.abs(this._rawValue(srs, item)), 0),
+        }));
+
+        // Largest first; ties keep the original series order (stable).
+        sized.sort((a, b) => b.size - a.size || a.index - b.index);
+        sized.forEach((entry, index) => rank.set(entry.id, index));
+
+        return rank;
+    }
+
+    protected buildSeriesGroup(series: AreaSeriesLike<TData>, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): Group {
+        const color = ctx.getColor(series.id);
+        const opacity = series.opacity ?? 0.3;
+        const showMarkers = series.markers !== false;
+        const { linePoints, bottomPoints, areaPoints } = this._buildPoints(series, ctx, prepared);
+
+        prepared.entryReveal.set(series.id, {
+            linePoints,
+            bottomPoints,
+        });
+
+        const markerElements = showMarkers
+            ? ctx.data.map((item, dataIndex) => this._buildMarker(series, item, dataIndex, ctx, prepared))
+            : [];
+
+        // Curve only the top edge (matching the line) and straight-close the baseline.
+        const areaFill = createPolyline({
+            id: `${series.id}-area`,
+            fill: setColorAlpha(color, opacity),
+            stroke: undefined,
+            points: areaPoints,
+            renderer: areaBandRenderer(series.lineType),
+            data: {
+                points: areaPoints,
+            } as PolylineState,
+        });
+
+        areaFill.autoStroke = false;
+
+        const line = createPolyline({
+            id: `${series.id}-line`,
+            lineWidth: series.lineWidth ?? 2,
+            stroke: color,
+            lineDash: resolveLineDash(series.lineStyle),
+            points: linePoints,
+            renderer: series.lineType,
+            data: {
+                points: linePoints,
+            } as PolylineState,
+        });
+
+        this._morphKeys.set(series.id, ctx.data.map(ctx.getKey));
+
+        return createGroup({
+            id: series.id,
+            children: [
+                areaFill,
+                line,
+                ...markerElements,
+                ...(ctx.dataLabels.visible ? ctx.data.map((item, dataIndex) => createDataLabel(this._labelSpec(series, item, dataIndex, ctx, prepared))) : []),
+            ],
+        });
+    }
+
+    protected updateSeriesGroup(series: AreaSeriesLike<TData>, group: Group, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>, batch: SeriesLabelBatch): Group {
+        const color = ctx.getColor(series.id);
+        const polylines = group.getElementsByType('polyline') as Polyline[];
+        const areaFill = polylines[0];
+        const line = polylines[1];
+        const markers = group.getElementsByType('circle') as Circle[];
+        const { linePoints, areaPoints } = this._buildPoints(series, ctx, prepared);
+
+        const newKeys = ctx.data.map(ctx.getKey);
+        const prevKeys = this._morphKeys.get(series.id);
+        const keyed = !!prevKeys && keysDiffer(prevKeys, newKeys);
+
+        // Apply the renderer + dash directly (not via the transition), and key-reconcile the morph so
+        // curved lines/fills stay curved. The fill is a closed [top, reversed-bottom] polygon, so its
+        // keys are disambiguated per run (t:/b:) to keep top matched to top and bottom to bottom.
+        line.renderer = series.lineType;
+        areaFill.renderer = areaBandRenderer(series.lineType);
+        line.lineDash = resolveLineDash(series.lineStyle);
+
+        const fillKeys = (keys: string[]): string[] => [
+            ...keys.map(key => `t:${key}`),
+            ...keys.slice().reverse().map(key => `b:${key}`),
+        ];
+
+        line.data = {
+            points: keyed
+                ? interpolatePoints(line.points, linePoints, {
+                    resolveKeys: () => correspondence(prevKeys!, newKeys),
+                })
+                : linePoints,
+        };
+
+        areaFill.data = {
+            points: keyed
+                ? interpolatePoints(areaFill.points, areaPoints, {
+                    resolveKeys: () => correspondence(fillKeys(prevKeys!), fillKeys(newKeys)),
+                })
+                : areaPoints,
+        };
+
+        this._morphKeys.set(series.id, newKeys);
+
+        const exitAnimation = ctx.resolveAnimation(ANIMATION_REFERENCE.exit);
+
+        const {
+            left: markerEntries,
+            inner: markerUpdates,
+            right: markerExits,
+        } = arrayJoin(ctx.data, markers, (item, marker) => marker.id === `${series.id}-marker-${ctx.getKey(item)}`);
+
+        markerExits.forEach(marker => exitElement(ctx.renderer, marker, exitAnimation, {
+            radius: 0,
+            opacity: 0,
+        }));
+
+        if (series.markers !== false) {
+            markerEntries.forEach(item => group.add(this._buildMarker(series, item, ctx.data.indexOf(item), ctx, prepared)));
+        }
+
+        markerUpdates.forEach(([item, marker]) => {
+            const dataIndex = ctx.data.indexOf(item);
+            const x = ctx.xScale(ctx.getKey(item));
+            const y = ctx.yScale(prepared.getSeriesValue(series, item, dataIndex));
+
+            marker.data = {
+                fill: '#FFFFFF',
+                stroke: color,
+                lineWidth: 2,
+                cx: x,
+                cy: y,
+                radius: 3,
+            } as CircleState;
+
+            this.attachMarkerHover(marker, ctx, {
+                seriesId: series.id,
+                key: ctx.getKey(item),
+                value: this._rawValue(series, item),
+                label: this._seriesLabel(series, item),
+                radius: 3,
+                highlightColor: color,
+            });
+        });
+
+        this.reconcileLabels(
+            group,
+            ctx,
+            exitAnimation,
+            item => `${series.id}-marker-${ctx.getKey(item)}-label`,
+            item => this._labelSpec(series, item, ctx.data.indexOf(item), ctx, prepared),
+            batch
+        );
+
+        return group;
+    }
+
+    protected entryTransitions(groups: Group[], ctx: AreaSeriesContext<TData>, enter: ResolvedAnimation, prepared: AreaPrepared<TData>): Promise<unknown>[] {
+        return groups.flatMap(group => {
+            const markers = group.getElementsByType('circle') as Circle[];
+            const reveal = prepared.entryReveal.get(group.id);
+            const polylines = group.getElementsByType('polyline') as Polyline[];
+            const areaFill = polylines[0];
+            const line = polylines[1];
+
+            const polylineTransitions: Promise<unknown>[] = [];
+
+            if (line && reveal) {
+                polylineTransitions.push(ctx.renderer.transition(line, {
+                    duration: enter.duration,
+                    ease: enter.ease,
+                    state: { points: interpolatePath(reveal.linePoints) },
+                }));
+            }
+
+            if (areaFill && reveal) {
+                polylineTransitions.push(ctx.renderer.transition(areaFill, {
+                    duration: enter.duration,
+                    ease: enter.ease,
+                    state: { points: interpolateAreaReveal(reveal.linePoints, reveal.bottomPoints) },
+                }));
+            }
+
+            return [
+                ...polylineTransitions,
+                ...(markers.length > 0
+                    ? [ctx.renderer.transition(markers, element => {
+                        const fraction = ctx.plot.width > 0
+                            ? Math.min(Math.max(((element as Circle).cx - ctx.plot.x) / ctx.plot.width, 0), 1)
+                            : 0;
+
+                        return {
+                            duration: enter.duration * 0.4,
+                            delay: fraction * enter.duration,
+                            ease: enter.ease,
+                            state: element.data as CircleState,
+                        };
+                    })]
+                    : []),
+            ];
+        });
+    }
+
+    protected updateTransitions(groups: Group[], ctx: AreaSeriesContext<TData>, update: ResolvedAnimation): Promise<unknown>[] {
+        return groups.flatMap(group => {
+            const markers = group.getElementsByType('circle') as Circle[];
+            const polylines = group.getElementsByType('polyline') as Polyline[];
+
+            return [
+                ...polylines.map(polyline => ctx.renderer.transition(polyline, {
+                    duration: update.duration,
+                    ease: update.ease,
+                    state: polyline.data as PolylineState,
+                })),
+                ...(markers.length > 0
+                    ? [ctx.renderer.transition(markers, element => ({
+                        duration: update.duration,
+                        ease: update.ease,
+                        state: element.data as CircleState,
+                    }))]
+                    : []),
+            ];
+        });
+    }
+
+    protected orderGroups(series: AreaSeriesLike<TData>[], ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): void {
+        const base = ctx.zIndexBase ?? 0;
+
+        this._groups.forEach(group => {
+            group.zIndex = base + (prepared.orderRank.get(group.id) ?? 0);
+        });
+    }
+
+}

--- a/packages/charts/src/core/series/area-series.ts
+++ b/packages/charts/src/core/series/area-series.ts
@@ -65,9 +65,11 @@ import type {
 } from '@ripl/core';
 
 import {
+    clamp,
     createCircle,
     createGroup,
     createPolyline,
+    getTotal,
     interpolatePath,
     interpolatePoints,
     interpolateWaypoint,
@@ -273,7 +275,7 @@ export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TDa
         const sized = series.map((srs, index) => ({
             id: srs.id,
             index,
-            size: ctx.data.reduce((sum, item) => sum + Math.abs(this._rawValue(srs, item)), 0),
+            size: getTotal(ctx.data, item => Math.abs(this._rawValue(srs, item))),
         }));
 
         // Largest first; ties keep the original series order (stable).
@@ -463,7 +465,7 @@ export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TDa
                 ...(markers.length > 0
                     ? [ctx.renderer.transition(markers, element => {
                         const fraction = ctx.plot.width > 0
-                            ? Math.min(Math.max(((element as Circle).cx - ctx.plot.x) / ctx.plot.width, 0), 1)
+                            ? clamp(((element as Circle).cx - ctx.plot.x) / ctx.plot.width, 0, 1)
                             : 0;
 
                         return {

--- a/packages/charts/src/core/series/bar-series.ts
+++ b/packages/charts/src/core/series/bar-series.ts
@@ -1,0 +1,480 @@
+/**
+ * Bar series renderer: draws each series as rectangles, grouped side by side or stacked.
+ *
+ * Extracted from the bar chart so the standalone {@link BarChart} and the mixed trend chart share one
+ * implementation — including vertical/horizontal orientation, grouped and stacked modes, the
+ * outermost-segment rounding, and the stacked single-rising-fill entry timing.
+ */
+
+import {
+    SeriesRenderer,
+} from './base';
+
+import type {
+    SeriesLabelBatch,
+} from './base';
+
+import type {
+    BarSeriesContext,
+    BarSeriesLike,
+} from './context';
+
+import {
+    ANIMATION_REFERENCE,
+    exitElement,
+    stagger,
+} from '../animation';
+
+import type {
+    ResolvedAnimation,
+} from '../animation';
+
+import {
+    createDataLabel,
+} from '../labels';
+
+import type {
+    DataLabelSpec,
+} from '../labels';
+
+import {
+    applyHoverHighlight,
+} from '../interaction';
+
+import {
+    computeStackOffset,
+    resolveAccessor,
+} from '../data';
+
+import type {
+    BandScale,
+    BorderRadius,
+    Group,
+    Rect,
+    RectState,
+} from '@ripl/core';
+
+import {
+    createGroup,
+    createRect,
+    queryAll,
+    scaleBand,
+    setColorAlpha,
+} from '@ripl/core';
+
+import {
+    arrayJoin,
+    typeIsFunction,
+} from '@ripl/utilities';
+
+/** The opacity applied to a bar's fill at rest (full opacity is used on hover). */
+const REST_ALPHA = 0.78;
+
+/** The geometry of a single bar: its element id, value, and rect state. */
+interface BarState {
+    id: string;
+    value: number;
+    state: RectState;
+}
+
+/** Entry timing for one stacked segment, so the column reveals as a single rising fill. */
+interface EntryTiming {
+    delayFraction: number;
+    durationFraction: number;
+    columnIndex: number;
+}
+
+/** Per-render precompute for the bar renderer. */
+interface BarPrepared<TData> {
+    series: BarSeriesLike<TData>[];
+    horizontal: boolean;
+    stacked: boolean;
+    baseline: number;
+    cornerRadius: number;
+    /** Grouping sub-scale (offsets each series within a category slot); undefined when stacked. */
+    seriesScale?: BandScale<string>;
+    /** Category key → its index in the data (column order). */
+    keyIndex: Map<string, number>;
+    /** Per-column positive/negative totals, for stacked rounding and entry timing. */
+    columnTotals: Map<string, { pos: number;
+        neg: number; }>;
+    /** Entry timing per stacked segment id, populated as bars are built. */
+    entryTiming: Map<string, EntryTiming>;
+}
+
+/** Renders bar series (grouped or stacked rectangles) for a host chart. */
+export class BarSeriesRenderer<TData> extends SeriesRenderer<BarSeriesLike<TData>, TData, BarSeriesContext<TData>, BarPrepared<TData>> {
+
+    private _seriesValue(series: BarSeriesLike<TData>, item: TData): number {
+        return resolveAccessor<TData, number>(series.value)(item);
+    }
+
+    private _seriesLabel(series: BarSeriesLike<TData>, item: TData): string {
+        return typeIsFunction(series.label) ? series.label(item) : series.label;
+    }
+
+    private _stackOffset(prepared: BarPrepared<TData>, current: BarSeriesLike<TData>, item: TData): number {
+        if (!prepared.stacked) {
+            return 0;
+        }
+
+        return computeStackOffset(prepared.series, current, item, (srs, dataItem) => this._seriesValue(srs, dataItem));
+    }
+
+    /** The index of the last same-sign series contributing to a column (its outermost segment). */
+    private _outermostStackIndex(item: TData, positive: boolean, prepared: BarPrepared<TData>): number {
+        let outer = -1;
+
+        prepared.series.forEach((srs, index) => {
+            const value = this._seriesValue(srs, item);
+
+            if (value === 0) {
+                return;
+            }
+
+            if ((value >= 0) === positive) {
+                outer = index;
+            }
+        });
+
+        return outer;
+    }
+
+    private _stackedBorderRadius(series: BarSeriesLike<TData>, item: TData, value: number, prepared: BarPrepared<TData>): number | BorderRadius {
+        const positive = value >= 0;
+        const { cornerRadius, horizontal } = prepared;
+
+        if (prepared.series.indexOf(series) !== this._outermostStackIndex(item, positive, prepared)) {
+            return 0;
+        }
+
+        if (horizontal) {
+            return positive
+                ? [0, cornerRadius, cornerRadius, 0]
+                : [cornerRadius, 0, 0, cornerRadius];
+        }
+
+        return positive
+            ? [cornerRadius, cornerRadius, 0, 0]
+            : [0, 0, cornerRadius, cornerRadius];
+    }
+
+    private _getBarState(series: BarSeriesLike<TData>, item: TData, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): BarState {
+        const { categoryScale, valueScale } = ctx;
+        const { horizontal, stacked, baseline, cornerRadius, seriesScale } = prepared;
+        const value = this._seriesValue(series, item);
+        const key = ctx.getKey(item);
+        const color = ctx.getColor(series.id);
+        const stackOffset = this._stackOffset(prepared, series, item);
+
+        let x: number;
+        let y: number;
+        let width: number;
+        let height: number;
+
+        if (horizontal) {
+            if (stacked) {
+                y = categoryScale(key);
+                height = categoryScale.bandwidth;
+                x = valueScale(value >= 0 ? stackOffset : value + stackOffset);
+                width = Math.abs(valueScale(0) - valueScale(Math.abs(value)));
+            } else {
+                y = categoryScale(key) + (seriesScale ? seriesScale(series.id) : 0);
+                height = seriesScale ? seriesScale.bandwidth : categoryScale.bandwidth;
+                x = Math.min(baseline, valueScale(value));
+                width = Math.abs(valueScale(value) - baseline);
+            }
+        } else if (stacked) {
+            x = categoryScale(key);
+            width = categoryScale.bandwidth;
+            y = valueScale(value >= 0 ? value + stackOffset : stackOffset);
+            height = Math.abs(valueScale(0) - valueScale(Math.abs(value)));
+        } else {
+            x = categoryScale(key) + (seriesScale ? seriesScale(series.id) : 0);
+            width = seriesScale ? seriesScale.bandwidth : categoryScale.bandwidth;
+            y = valueScale(Math.max(0, value));
+            height = Math.abs(baseline - valueScale(value));
+        }
+
+        const borderRadius = stacked ? this._stackedBorderRadius(series, item, value, prepared) : cornerRadius;
+
+        if (stacked) {
+            const totals = prepared.columnTotals.get(key);
+            const columnTotal = value >= 0 ? (totals?.pos ?? 0) : (totals?.neg ?? 0);
+
+            prepared.entryTiming.set(`${series.id}-${key}`, {
+                delayFraction: columnTotal > 0 ? Math.abs(stackOffset) / columnTotal : 0,
+                durationFraction: columnTotal > 0 ? Math.abs(value) / columnTotal : 1,
+                columnIndex: prepared.keyIndex.get(key) ?? 0,
+            });
+        }
+
+        return {
+            id: `${series.id}-${key}`,
+            value,
+            state: {
+                fill: color,
+                x,
+                y,
+                width,
+                height,
+                borderRadius,
+            } as RectState,
+        };
+    }
+
+    private _anchorFor(state: RectState, prepared: BarPrepared<TData>): () => { x: number;
+        y: number; } {
+        return () => (prepared.horizontal
+            ? {
+                x: state.x + state.width,
+                y: state.y + state.height / 2,
+            }
+            : {
+                x: state.x + state.width / 2,
+                y: state.y,
+            });
+    }
+
+    /** The collapsed geometry an entering/exiting bar grows from (the chart baseline). */
+    private _collapsed(prepared: BarPrepared<TData>): Partial<RectState> {
+        return prepared.horizontal
+            ? {
+                x: prepared.baseline,
+                width: 0,
+            }
+            : {
+                y: prepared.baseline,
+                height: 0,
+            };
+    }
+
+    /** A stacked segment collapses to its own lower edge so the column reveals as one rising fill. */
+    private _collapsedEntry(series: BarSeriesLike<TData>, item: TData, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): Partial<RectState> {
+        if (!prepared.stacked) {
+            return this._collapsed(prepared);
+        }
+
+        const stackOffset = this._stackOffset(prepared, series, item);
+
+        return prepared.horizontal
+            ? {
+                x: ctx.valueScale(stackOffset),
+                width: 0,
+            }
+            : {
+                y: ctx.valueScale(stackOffset),
+                height: 0,
+            };
+    }
+
+    private _attachHover(bar: Rect, series: BarSeriesLike<TData>, item: TData, key: string, value: number, anchor: () => { x: number;
+        y: number; }, ctx: BarSeriesContext<TData>): void {
+        const restFill = bar.fill as string;
+
+        const payload = (point: { x: number;
+            y: number; }) => ({
+            x: point.x,
+            y: point.y,
+            xValue: key,
+            yValue: value,
+            seriesId: series.id,
+        });
+
+        applyHoverHighlight(bar, {
+            renderer: ctx.renderer,
+            animation: () => ctx.resolveAnimation(ANIMATION_REFERENCE.hover),
+            tooltip: ctx.tooltip,
+            anchor,
+            content: () => `${this._seriesLabel(series, item)}: ${ctx.formatValue(value)}`,
+            highlight: { fill: setColorAlpha(restFill, 1) },
+            restore: { fill: restFill },
+            onEnter: point => ctx.emit('enter', payload(point)),
+            onLeave: point => ctx.emit('leave', payload(point)),
+            onClick: point => ctx.emit('click', payload(point)),
+        });
+    }
+
+    private _createBar(series: BarSeriesLike<TData>, item: TData, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): Rect {
+        const { id, value, state } = this._getBarState(series, item, ctx, prepared);
+        const restFill = setColorAlpha(state.fill as string, REST_ALPHA);
+
+        const bar = createRect({
+            id,
+            ...state,
+            ...this._collapsedEntry(series, item, ctx, prepared),
+            fill: restFill,
+            data: {
+                ...state,
+                fill: restFill,
+            },
+        });
+
+        this._attachHover(bar, series, item, ctx.getKey(item), value, this._anchorFor(state, prepared), ctx);
+
+        return bar;
+    }
+
+    private _labelSpec(series: BarSeriesLike<TData>, item: TData, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): DataLabelSpec {
+        const { id, value, state } = this._getBarState(series, item, ctx, prepared);
+        const point = this._anchorFor(state, prepared)();
+
+        return {
+            id: `${id}-label`,
+            x: point.x,
+            y: point.y,
+            anchor: ctx.dataLabels.anchor,
+            content: ctx.formatValue(value),
+            font: ctx.dataLabels.font,
+            fill: ctx.dataLabels.fontColor,
+        };
+    }
+
+    protected prepare(series: BarSeriesLike<TData>[], ctx: BarSeriesContext<TData>): BarPrepared<TData> {
+        const horizontal = ctx.orientation === 'horizontal';
+        const stacked = ctx.stacked;
+
+        const seriesScale = stacked
+            ? undefined
+            : scaleBand(series.map(srs => srs.id), [0, ctx.categoryScale.bandwidth], { innerPadding: 0.1 });
+
+        const keyIndex = new Map<string, number>(ctx.data.map((item, index) => [ctx.getKey(item), index]));
+        const columnTotals = new Map<string, { pos: number;
+            neg: number; }>();
+
+        ctx.data.forEach(item => {
+            let pos = 0;
+            let neg = 0;
+
+            series.forEach(srs => {
+                const value = this._seriesValue(srs, item);
+
+                if (value >= 0) {
+                    pos += value;
+                } else {
+                    neg += -value;
+                }
+            });
+
+            columnTotals.set(ctx.getKey(item), {
+                pos,
+                neg,
+            });
+        });
+
+        return {
+            series,
+            horizontal,
+            stacked,
+            baseline: ctx.valueScale(0),
+            cornerRadius: ctx.borderRadius,
+            seriesScale,
+            keyIndex,
+            columnTotals,
+            entryTiming: new Map(),
+        };
+    }
+
+    protected buildSeriesGroup(series: BarSeriesLike<TData>, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): Group {
+        return createGroup({
+            id: series.id,
+            children: [
+                ...ctx.data.map(item => this._createBar(series, item, ctx, prepared)),
+                ...(ctx.dataLabels.visible ? ctx.data.map(item => createDataLabel(this._labelSpec(series, item, ctx, prepared))) : []),
+            ],
+        });
+    }
+
+    protected updateSeriesGroup(series: BarSeriesLike<TData>, group: Group, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>, batch: SeriesLabelBatch): Group {
+        const bars = group.getElementsByType('rect') as Rect[];
+        const exitAnimation = ctx.resolveAnimation(ANIMATION_REFERENCE.exit);
+
+        const {
+            left: barEntries,
+            inner: barUpdates,
+            right: barExits,
+        } = arrayJoin(ctx.data, bars, (item, bar) => bar.id === `${series.id}-${ctx.getKey(item)}`);
+
+        barExits.forEach(bar => exitElement(ctx.renderer, bar, exitAnimation, {
+            ...this._collapsed(prepared),
+            opacity: 0,
+        }));
+
+        barEntries.forEach(item => group.add(this._createBar(series, item, ctx, prepared)));
+
+        barUpdates.forEach(([item, bar]) => {
+            const { value, state } = this._getBarState(series, item, ctx, prepared);
+            const restFill = setColorAlpha(state.fill as string, REST_ALPHA);
+
+            bar.data = {
+                ...state,
+                fill: restFill,
+            };
+
+            this._attachHover(bar, series, item, ctx.getKey(item), value, this._anchorFor(state, prepared), ctx);
+        });
+
+        this.reconcileLabels(
+            group,
+            ctx,
+            exitAnimation,
+            item => `${series.id}-${ctx.getKey(item)}-label`,
+            item => this._labelSpec(series, item, ctx, prepared),
+            batch
+        );
+
+        return group;
+    }
+
+    protected exitSeries(group: Group, ctx: BarSeriesContext<TData>, exitAnimation: ResolvedAnimation, prepared: BarPrepared<TData>): void {
+        const exits = (group.getElementsByType('rect') as Rect[]).map(bar => exitElement(ctx.renderer, bar, exitAnimation, {
+            ...this._collapsed(prepared),
+            opacity: 0,
+        }));
+
+        void Promise.all(exits).then(() => group.destroy());
+    }
+
+    protected entryTransitions(groups: Group[], ctx: BarSeriesContext<TData>, enter: ResolvedAnimation, prepared: BarPrepared<TData>): Promise<unknown>[] {
+        const bars = (queryAll(groups, 'rect') as Rect[])
+            .sort((a, b) => (prepared.horizontal ? a.y - b.y : a.x - b.x));
+
+        const categoryCount = Math.max(1, prepared.keyIndex.size);
+
+        return [
+            ctx.renderer.transition(bars, (element, index, length) => {
+                // Stacked: each column fills as one rising unit — segments are timed by their position
+                // in the stack so the fill front sweeps the whole column once, in colour order.
+                if (prepared.stacked) {
+                    const timing = prepared.entryTiming.get(element.id);
+                    const columnDelay = stagger(timing?.columnIndex ?? 0, categoryCount, enter.duration) * 0.4;
+
+                    return {
+                        duration: Math.max((timing?.durationFraction ?? 1) * enter.duration, 80),
+                        delay: columnDelay + (timing?.delayFraction ?? 0) * enter.duration,
+                        ease: enter.ease,
+                        state: element.data as RectState,
+                    };
+                }
+
+                return {
+                    duration: enter.duration,
+                    delay: stagger(index, length, enter.duration),
+                    ease: enter.ease,
+                    state: element.data as RectState,
+                };
+            }),
+        ];
+    }
+
+    protected updateTransitions(groups: Group[], ctx: BarSeriesContext<TData>, update: ResolvedAnimation): Promise<unknown>[] {
+        return [
+            ctx.renderer.transition(queryAll(groups, 'rect') as Rect[], element => ({
+                duration: update.duration,
+                ease: update.ease,
+                state: element.data as RectState,
+            })),
+        ];
+    }
+
+}

--- a/packages/charts/src/core/series/base.ts
+++ b/packages/charts/src/core/series/base.ts
@@ -1,0 +1,295 @@
+/**
+ * Base class for the series renderers.
+ *
+ * Owns the pipeline every multi-series chart repeated by hand: join the incoming series against the
+ * persisted groups, animate exits out, build entering groups, key-reconcile updating groups, add the
+ * entering groups to the plot, assign paint order, and run the enter/update/label transitions. Each
+ * concrete renderer (line, area, bar) supplies only the geometry-specific pieces via the abstract
+ * hooks — the shared marker-hover wiring and the data-label reconcile live here so all three (and the
+ * trend chart that composes them) stay identical.
+ */
+
+import type {
+    SeriesEventPhase,
+    SeriesInteractionEvent,
+    SeriesRenderContext,
+} from './context';
+
+import {
+    ANIMATION_REFERENCE,
+    exitElement,
+} from '../animation';
+
+import type {
+    ResolvedAnimation,
+} from '../animation';
+
+import {
+    applyHoverHighlight,
+} from '../interaction';
+
+import {
+    createDataLabel,
+    resolveDataLabelLayout,
+} from '../labels';
+
+import type {
+    DataLabelSpec,
+} from '../labels';
+
+import type {
+    Circle,
+    Group,
+    Text,
+    TextState,
+} from '@ripl/core';
+
+import {
+    arrayJoin,
+} from '@ripl/utilities';
+
+/** Accumulates labels added or repositioned during an update pass so they can be transitioned together. */
+export interface SeriesLabelBatch {
+    /** Labels newly added to existing series groups (fade in). */
+    entering: Text[];
+    /** Labels on existing markers/bars that moved (tween to their new position). */
+    updating: Text[];
+}
+
+/**
+ * Shared enter/update/exit renderer for a single series *type*. Holds the series groups between
+ * renders so data joins reconcile against them.
+ *
+ * @typeParam TSeries - The series option shape this renderer draws.
+ * @typeParam TData - The type of each data item in the dataset.
+ * @typeParam TContext - The render context this renderer needs (widens {@link SeriesRenderContext}).
+ * @typeParam TPrepared - Per-render precompute passed to every hook (stacking tables, sub-scales, …).
+ */
+export abstract class SeriesRenderer<
+    TSeries extends { id: string },
+    TData,
+    TContext extends SeriesRenderContext<TData>,
+    TPrepared = void
+> {
+
+    protected _groups: Group[] = [];
+
+    /** The series groups from the most recent render, in `[…entering, …updating]` order. */
+    public get groups(): Group[] {
+        return this._groups;
+    }
+
+    /**
+     * Renders `series` against the persisted groups and returns once the entry/update/label
+     * transitions settle. The groups are populated synchronously before the returned promise, so a
+     * host can read {@link groups} immediately (e.g. to register legend highlighting across several
+     * renderers) without awaiting.
+     */
+    public render(series: TSeries[], ctx: TContext): Promise<Group[]> {
+        const exitAnimation = ctx.resolveAnimation(ANIMATION_REFERENCE.exit);
+
+        const {
+            left: entries,
+            inner: updates,
+            right: exits,
+        } = arrayJoin(series, this._groups, 'id');
+
+        const prepared = this.prepare(series, ctx);
+
+        exits.forEach(group => this.exitSeries(group, ctx, exitAnimation, prepared));
+
+        const batch: SeriesLabelBatch = {
+            entering: [],
+            updating: [],
+        };
+
+        const entryGroups = entries.map(srs => this.buildSeriesGroup(srs, ctx, prepared));
+        const updateGroups = updates.map(([srs, group]) => this.updateSeriesGroup(srs, group, ctx, prepared, batch));
+
+        ctx.addContent(entryGroups);
+
+        this._groups = [
+            ...entryGroups,
+            ...updateGroups,
+        ];
+
+        this.orderGroups(series, ctx, prepared);
+
+        const enter = ctx.resolveAnimation(ANIMATION_REFERENCE.enter);
+        const update = ctx.resolveAnimation(ANIMATION_REFERENCE.update);
+
+        return Promise.all([
+            ...this.entryTransitions(entryGroups, ctx, enter, prepared),
+            ...this.updateTransitions(updateGroups, ctx, update, prepared),
+            ...this.labelTransitions(entryGroups, batch, enter, update, ctx),
+        ]).then(() => this._groups);
+    }
+
+    /** Computes per-render precompute shared by all hooks. Defaults to nothing. */
+    protected prepare(series: TSeries[], ctx: TContext): TPrepared {
+        return undefined as TPrepared;
+    }
+
+    /** Builds a group of marks (at their start state, targets stashed on `data`) for an entering series. */
+    protected abstract buildSeriesGroup(series: TSeries, ctx: TContext, prepared: TPrepared): Group;
+
+    /** Reconciles the marks of an existing series group against the new data (enter/update/exit marks). */
+    protected abstract updateSeriesGroup(series: TSeries, group: Group, ctx: TContext, prepared: TPrepared, batch: SeriesLabelBatch): Group;
+
+    /** The entry transitions for the newly built groups. */
+    protected abstract entryTransitions(groups: Group[], ctx: TContext, enter: ResolvedAnimation, prepared: TPrepared): Promise<unknown>[];
+
+    /** The update transitions for the reconciled groups. */
+    protected abstract updateTransitions(groups: Group[], ctx: TContext, update: ResolvedAnimation, prepared: TPrepared): Promise<unknown>[];
+
+    /** Animates a removed series' marks out and destroys the group. Overridable for type-specific collapse. */
+    protected exitSeries(group: Group, ctx: TContext, exitAnimation: ResolvedAnimation, prepared: TPrepared): void {
+        const exits = group.graph(false).map(element => exitElement(ctx.renderer, element, exitAnimation));
+        void Promise.all(exits).then(() => group.destroy());
+    }
+
+    /**
+     * Assigns each group an explicit z-index from `ctx.zIndexBase` (in series order) so a mixed chart
+     * can layer this renderer's series between other types. No-op for standalone charts (no base set),
+     * which keep their natural insertion order.
+     */
+    protected orderGroups(series: TSeries[], ctx: TContext, prepared: TPrepared): void {
+        if (ctx.zIndexBase === undefined) {
+            return;
+        }
+
+        const rankById = new Map(series.map((srs, index) => [srs.id, index]));
+
+        this._groups.forEach(group => {
+            group.zIndex = ctx.zIndexBase! + (rankById.get(group.id) ?? 0);
+        });
+    }
+
+    /** Wires the shared hover highlight + tooltip + interaction events onto a point marker. */
+    protected attachMarkerHover(marker: Circle, ctx: SeriesRenderContext<TData>, spec: {
+        seriesId: string;
+        key: string;
+        value: number;
+        label: string;
+        radius: number;
+        highlightColor: string;
+    }): void {
+        const payload = (point: { x: number;
+            y: number; }): SeriesInteractionEvent => ({
+            x: point.x,
+            y: point.y,
+            xValue: spec.key,
+            yValue: spec.value,
+            seriesId: spec.seriesId,
+        });
+
+        applyHoverHighlight(marker, {
+            renderer: ctx.renderer,
+            animation: () => ctx.resolveAnimation(ANIMATION_REFERENCE.hover),
+            tooltip: ctx.tooltip,
+            anchor: () => ({
+                x: marker.cx,
+                y: marker.cy,
+            }),
+            content: () => `${spec.label}: ${ctx.formatValue(spec.value)}`,
+            highlight: {
+                fill: spec.highlightColor,
+                radius: spec.radius + 2,
+            },
+            restore: {
+                fill: '#FFFFFF',
+                radius: spec.radius,
+            },
+            onEnter: point => ctx.emit('enter', payload(point)),
+            onLeave: point => ctx.emit('leave', payload(point)),
+            onClick: point => ctx.emit('click', payload(point)),
+        });
+    }
+
+    /**
+     * Reconciles a series group's data labels against the new data (enter/update/exit), collecting the
+     * entering and updating labels into `batch` for the shared {@link labelTransitions}.
+     */
+    protected reconcileLabels(
+        group: Group,
+        ctx: SeriesRenderContext<TData>,
+        exitAnimation: ResolvedAnimation,
+        labelId: (item: TData) => string,
+        buildSpec: (item: TData) => DataLabelSpec,
+        batch: SeriesLabelBatch
+    ): void {
+        const labels = group.getElementsByType('text') as Text[];
+
+        if (!ctx.dataLabels.visible) {
+            labels.forEach(label => exitElement(ctx.renderer, label, exitAnimation, { opacity: 0 }));
+            return;
+        }
+
+        const {
+            left: entries,
+            inner: updates,
+            right: exits,
+        } = arrayJoin(ctx.data, labels, (item, label) => label.id === labelId(item));
+
+        exits.forEach(label => exitElement(ctx.renderer, label, exitAnimation, { opacity: 0 }));
+
+        entries.forEach(item => {
+            const label = createDataLabel(buildSpec(item));
+            group.add(label);
+            batch.entering.push(label);
+        });
+
+        updates.forEach(([item, label]) => {
+            const spec = buildSpec(item);
+            const layout = resolveDataLabelLayout(spec);
+
+            label.content = spec.content;
+            label.data = {
+                x: layout.x,
+                y: layout.y,
+                opacity: 1,
+            } as Partial<TextState>;
+
+            batch.updating.push(label);
+        });
+    }
+
+    /** The transitions that fade entry labels in and move updated labels to their refreshed positions. */
+    protected labelTransitions(
+        entryGroups: Group[],
+        batch: SeriesLabelBatch,
+        enter: ResolvedAnimation,
+        update: ResolvedAnimation,
+        ctx: SeriesRenderContext<TData>
+    ): Promise<unknown>[] {
+        const entryLabels = entryGroups.flatMap(group => group.getElementsByType('text') as Text[]);
+        const transitions: Promise<unknown>[] = [];
+
+        if (entryLabels.length > 0) {
+            transitions.push(ctx.renderer.transition(entryLabels, {
+                duration: enter.duration,
+                ease: enter.ease,
+                state: { opacity: 1 },
+            }));
+        }
+
+        if (batch.entering.length > 0) {
+            transitions.push(ctx.renderer.transition(batch.entering, {
+                duration: update.duration,
+                ease: update.ease,
+                state: { opacity: 1 },
+            }));
+        }
+
+        if (batch.updating.length > 0) {
+            transitions.push(ctx.renderer.transition(batch.updating, element => ({
+                duration: update.duration,
+                ease: update.ease,
+                state: element.data as Partial<TextState>,
+            })));
+        }
+
+        return transitions;
+    }
+
+}

--- a/packages/charts/src/core/series/base.ts
+++ b/packages/charts/src/core/series/base.ts
@@ -10,7 +10,6 @@
  */
 
 import type {
-    SeriesEventPhase,
     SeriesInteractionEvent,
     SeriesRenderContext,
 } from './context';
@@ -126,7 +125,7 @@ export abstract class SeriesRenderer<
     }
 
     /** Computes per-render precompute shared by all hooks. Defaults to nothing. */
-    protected prepare(series: TSeries[], ctx: TContext): TPrepared {
+    protected prepare(_series: TSeries[], _ctx: TContext): TPrepared {
         return undefined as TPrepared;
     }
 
@@ -143,7 +142,7 @@ export abstract class SeriesRenderer<
     protected abstract updateTransitions(groups: Group[], ctx: TContext, update: ResolvedAnimation, prepared: TPrepared): Promise<unknown>[];
 
     /** Animates a removed series' marks out and destroys the group. Overridable for type-specific collapse. */
-    protected exitSeries(group: Group, ctx: TContext, exitAnimation: ResolvedAnimation, prepared: TPrepared): void {
+    protected exitSeries(group: Group, ctx: TContext, exitAnimation: ResolvedAnimation, _prepared: TPrepared): void {
         const exits = group.graph(false).map(element => exitElement(ctx.renderer, element, exitAnimation));
         void Promise.all(exits).then(() => group.destroy());
     }
@@ -153,7 +152,7 @@ export abstract class SeriesRenderer<
      * can layer this renderer's series between other types. No-op for standalone charts (no base set),
      * which keep their natural insertion order.
      */
-    protected orderGroups(series: TSeries[], ctx: TContext, prepared: TPrepared): void {
+    protected orderGroups(series: TSeries[], ctx: TContext, _prepared: TPrepared): void {
         if (ctx.zIndexBase === undefined) {
             return;
         }

--- a/packages/charts/src/core/series/context.ts
+++ b/packages/charts/src/core/series/context.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared context and series shapes for the series-renderer layer.
+ *
+ * A {@link SeriesRenderContext} bundles everything a series renderer needs from its host chart —
+ * the resolved scales, plot rectangle, colour lookup, animation resolver, tooltip, formatter, and
+ * the callbacks for adding marks and emitting interaction events — so that the line/area/bar
+ * geometry can be shared verbatim between the standalone charts and the mixed trend chart. Each
+ * renderer widens the context with the extra inputs its geometry needs (an x point scale for
+ * line/area, a category band scale for bars).
+ */
+
+import type {
+    NumericAccessor,
+} from '../data';
+
+import type {
+    ResolvedAnimation,
+} from '../animation';
+
+import type {
+    ChartArea,
+} from '../layout';
+
+import type {
+    ChartDataLabelsOptions,
+    LineStyle,
+} from '../options';
+
+import type {
+    Tooltip,
+} from '../../components/tooltip';
+
+import type {
+    BandScale,
+    Element,
+    PolylineRenderer,
+    Scale,
+    Renderer,
+} from '@ripl/core';
+
+import type {
+    OneOrMore,
+} from '@ripl/utilities';
+
+/** Which phase of a pointer interaction produced a series event. */
+export type SeriesEventPhase = 'enter' | 'leave' | 'click';
+
+/** Normalised payload emitted for a mark (marker or bar) interaction, mapped by the host to its own event names. */
+export interface SeriesInteractionEvent {
+    /** The x coordinate (in chart pixels) of the interacted mark. */
+    x: number;
+    /** The y coordinate (in chart pixels) of the interacted mark. */
+    y: number;
+    /** The category key of the interacted mark. */
+    xValue: string;
+    /** The numeric value of the interacted mark. */
+    yValue: number;
+    /** The id of the series the mark belongs to. */
+    seriesId: string;
+}
+
+/**
+ * The host-chart state a series renderer draws against. Built fresh each render by the owning chart
+ * and passed to the renderer, so renderers hold no reference to the chart itself.
+ *
+ * @typeParam TData - The type of each data item in the dataset.
+ */
+export interface SeriesRenderContext<TData> {
+    /** The dataset being plotted, shared by every series. */
+    data: TData[];
+    /** Resolves each data item to its category key (the value plotted along the x axis). */
+    getKey: (item: TData) => string;
+    /** The value scale mapping a numeric value to its y pixel position. */
+    yScale: Scale;
+    /** The plot rectangle marks are drawn into. */
+    plot: ChartArea;
+    /** The y pixel position of the value baseline (`yScale(0)`). */
+    baseline: number;
+    /** The renderer driving transitions. */
+    renderer: Renderer;
+    /** The shared hover tooltip, when the chart has one. */
+    tooltip?: Tooltip;
+    /** Resolves a series id to its palette (or explicit) colour. */
+    getColor: (seriesId: string) => string;
+    /** Resolves the chart's animation for a given reference duration. */
+    resolveAnimation: (reference?: number) => ResolvedAnimation;
+    /** Formats a numeric value for tooltips and data labels. */
+    formatValue: (value: unknown) => string;
+    /** The resolved data-label options for the chart. */
+    dataLabels: ChartDataLabelsOptions;
+    /** Adds entering marks to the chart's plot-clipped content container. */
+    addContent: (elements: OneOrMore<Element>) => void;
+    /** Emits a normalised interaction event, which the host maps to its typed event map. */
+    emit: (phase: SeriesEventPhase, event: SeriesInteractionEvent) => void;
+    /**
+     * Base z-index for this renderer's series groups. When set (mixed charts), the renderer assigns
+     * each group an explicit z-index from this base so cross-type paint order is deterministic; when
+     * omitted (standalone charts) groups keep their natural insertion order.
+     */
+    zIndexBase?: number;
+}
+
+/** Context for the {@link LineSeriesRenderer}: adds the categorical x point scale. */
+export interface LineSeriesContext<TData> extends SeriesRenderContext<TData> {
+    /** The point scale mapping a category key to its x pixel position. */
+    xScale: Scale<string>;
+}
+
+/** Context for the {@link AreaSeriesRenderer}: adds the x point scale and the stack toggle. */
+export interface AreaSeriesContext<TData> extends SeriesRenderContext<TData> {
+    /** The point scale mapping a category key to its x pixel position. */
+    xScale: Scale<string>;
+    /** Whether area series are stacked cumulatively instead of overlaid. */
+    stacked: boolean;
+}
+
+/** Context for the {@link BarSeriesRenderer}: adds the category band scale, value scale, orientation, and stacking. */
+export interface BarSeriesContext<TData> extends SeriesRenderContext<TData> {
+    /** The band scale mapping a category key to its slot on the categorical axis. */
+    categoryScale: BandScale<string>;
+    /** The continuous scale mapping a value to its position along the value axis (y for vertical bars, x for horizontal). */
+    valueScale: Scale;
+    /** Whether bars run vertically (default) or horizontally. */
+    orientation: 'vertical' | 'horizontal';
+    /** Whether bar series are stacked into a single column instead of grouped side by side. */
+    stacked: boolean;
+    /** Corner radius in pixels applied to each bar. */
+    borderRadius: number;
+}
+
+/** The line/area series fields the line renderer reads. Both the standalone and trend option shapes satisfy it. */
+export interface LineSeriesLike<TData> {
+    /** Unique identifier for the series. */
+    id: string;
+    /** Explicit series colour; falls back to the generated palette when omitted. */
+    color?: string;
+    /** Accessor for the series' value at each data item, or a constant applied to every item. */
+    value: NumericAccessor<TData> | number;
+    /** Series name shown in the legend and tooltips (or a per-item function). */
+    label: string | ((item: TData) => string);
+    /** Renderer used to draw the line (e.g. straight or curved); defaults to straight segments. */
+    lineType?: PolylineRenderer;
+    /** Width in pixels of the series line. */
+    lineWidth?: number;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
+    lineStyle?: LineStyle;
+    /** Show point markers along the line. Defaults to `true`. */
+    markers?: boolean;
+    /** Radius in pixels of each point marker. Defaults to 3. */
+    markerRadius?: number;
+}
+
+/** The area series fields the area renderer reads (line fields plus a fill opacity). */
+export interface AreaSeriesLike<TData> extends LineSeriesLike<TData> {
+    /** Fill opacity of the area band. Defaults to 0.3. */
+    opacity?: number;
+}
+
+/** The bar series fields the bar renderer reads. */
+export interface BarSeriesLike<TData> {
+    /** Unique identifier for the series. */
+    id: string;
+    /** Explicit series colour; falls back to the generated palette when omitted. */
+    color?: string;
+    /** Accessor for the series' value at each data item, or a constant applied to every item. */
+    value: NumericAccessor<TData> | number;
+    /** Series name shown in the legend and tooltips (or a per-item function). */
+    label: string | ((item: TData) => string);
+}

--- a/packages/charts/src/core/series/context.ts
+++ b/packages/charts/src/core/series/context.ts
@@ -34,8 +34,8 @@ import type {
     BandScale,
     Element,
     PolylineRenderer,
-    Scale,
     Renderer,
+    Scale,
 } from '@ripl/core';
 
 import type {

--- a/packages/charts/src/core/series/line-series.ts
+++ b/packages/charts/src/core/series/line-series.ts
@@ -1,0 +1,289 @@
+/**
+ * Line series renderer: draws each series as a polyline with optional point markers.
+ *
+ * Extracted verbatim from the line chart so the standalone {@link LineChart} and the mixed trend
+ * chart share one implementation — including the progressive draw-on entry, the staggered marker
+ * pop-in, and the key-reconciled point morph that keeps curves curved across add/remove.
+ */
+
+import {
+    SeriesRenderer,
+} from './base';
+
+import type {
+    SeriesLabelBatch,
+} from './base';
+
+import type {
+    LineSeriesContext,
+    LineSeriesLike,
+} from './context';
+
+import {
+    ANIMATION_REFERENCE,
+    exitElement,
+    stagger,
+} from '../animation';
+
+import {
+    resolveLineDash,
+} from '../options';
+
+import {
+    createDataLabel,
+} from '../labels';
+
+import type {
+    DataLabelSpec,
+} from '../labels';
+
+import {
+    correspondence,
+    keysDiffer,
+} from '../morph';
+
+import {
+    resolveAccessor,
+} from '../data';
+
+import type {
+    Circle,
+    CircleState,
+    Group,
+    Point,
+    Polyline,
+    PolylineState,
+} from '@ripl/core';
+
+import {
+    createCircle,
+    createGroup,
+    createPolyline,
+    interpolatePath,
+    interpolatePoints,
+} from '@ripl/core';
+
+import type {
+    ResolvedAnimation,
+} from '../animation';
+
+import {
+    arrayJoin,
+    typeIsFunction,
+} from '@ripl/utilities';
+
+/** The geometry of a single line marker: its element id, raw value, point, and rest circle state. */
+interface MarkerState {
+    id: string;
+    value: number;
+    point: Point;
+    state: CircleState;
+}
+
+/** Renders line series (polyline + markers) for a host chart. */
+export class LineSeriesRenderer<TData> extends SeriesRenderer<LineSeriesLike<TData>, TData, LineSeriesContext<TData>> {
+
+    /** Previous ordered data keys per series, used to key-reconcile the line morph across add/remove. */
+    private _morphKeys = new Map<string, string[]>();
+
+    private _seriesLabel(series: LineSeriesLike<TData>, item: TData): string {
+        return typeIsFunction(series.label) ? series.label(item) : series.label;
+    }
+
+    private _markerState(series: LineSeriesLike<TData>, item: TData, ctx: LineSeriesContext<TData>): MarkerState {
+        const value = resolveAccessor<TData, number>(series.value)(item);
+        const key = ctx.getKey(item);
+        const x = ctx.xScale(key);
+        const y = ctx.yScale(value);
+        const color = ctx.getColor(series.id);
+        // A hidden marker rests at radius 0 (the toggle animates it in/out on update).
+        const radius = series.markers === false ? 0 : (series.markerRadius ?? 3);
+
+        return {
+            id: `${series.id}-${key}`,
+            value,
+            point: [x, y],
+            state: {
+                fill: '#FFFFFF',
+                stroke: color,
+                lineWidth: 2,
+                cx: x,
+                cy: y,
+                radius,
+            },
+        };
+    }
+
+    private _attachHover(marker: Circle, series: LineSeriesLike<TData>, item: TData, value: number, state: CircleState, key: string, ctx: LineSeriesContext<TData>): void {
+        if (series.markers === false) {
+            marker.pointerEvents = 'none';
+            return;
+        }
+
+        this.attachMarkerHover(marker, ctx, {
+            seriesId: series.id,
+            key,
+            value,
+            label: this._seriesLabel(series, item),
+            radius: series.markerRadius ?? 3,
+            highlightColor: state.stroke as string,
+        });
+    }
+
+    private _buildMarker(series: LineSeriesLike<TData>, item: TData, ctx: LineSeriesContext<TData>): { point: Point;
+        marker: Circle; } {
+        const { id, value, point, state } = this._markerState(series, item, ctx);
+
+        const marker = createCircle({
+            id,
+            ...state,
+            radius: 0,
+            data: state,
+        });
+
+        this._attachHover(marker, series, item, value, state, ctx.getKey(item), ctx);
+
+        return {
+            point,
+            marker,
+        };
+    }
+
+    private _labelSpec(series: LineSeriesLike<TData>, item: TData, ctx: LineSeriesContext<TData>): DataLabelSpec {
+        const { id, value, point } = this._markerState(series, item, ctx);
+
+        return {
+            id: `${id}-label`,
+            x: point[0],
+            y: point[1],
+            anchor: ctx.dataLabels.anchor,
+            content: ctx.formatValue(value),
+            font: ctx.dataLabels.font,
+            fill: ctx.dataLabels.fontColor,
+            offset: (series.markerRadius ?? 3) + 4,
+        };
+    }
+
+    protected buildSeriesGroup(series: LineSeriesLike<TData>, ctx: LineSeriesContext<TData>): Group {
+        const color = ctx.getColor(series.id);
+        const items = ctx.data.map(item => this._buildMarker(series, item, ctx));
+
+        const line = createPolyline({
+            id: `${series.id}-line`,
+            lineWidth: series.lineWidth ?? 2,
+            stroke: color,
+            lineDash: resolveLineDash(series.lineStyle),
+            points: items.map(item => item.point),
+            renderer: series.lineType,
+        });
+
+        this._morphKeys.set(series.id, ctx.data.map(ctx.getKey));
+
+        return createGroup({
+            id: series.id,
+            children: [
+                line,
+                ...items.map(item => item.marker),
+                ...(ctx.dataLabels.visible ? ctx.data.map(item => createDataLabel(this._labelSpec(series, item, ctx))) : []),
+            ],
+        });
+    }
+
+    protected updateSeriesGroup(series: LineSeriesLike<TData>, group: Group, ctx: LineSeriesContext<TData>, _prepared: void, batch: SeriesLabelBatch): Group {
+        const line = group.getElementsByType('polyline')[0] as Polyline;
+        const markers = group.getElementsByType('circle') as Circle[];
+
+        // Apply the curve renderer + dash directly (not via the transition, which would snap them).
+        line.renderer = series.lineType;
+        line.lineDash = resolveLineDash(series.lineStyle);
+
+        const newKeys = ctx.data.map(ctx.getKey);
+        const targetPoints = ctx.data.map(item => this._markerState(series, item, ctx).point);
+        const prevKeys = this._morphKeys.get(series.id);
+
+        // When the key set changes, match points by identity so a curved line keeps its shape.
+        line.data = {
+            points: prevKeys && keysDiffer(prevKeys, newKeys)
+                ? interpolatePoints(line.points, targetPoints, {
+                    resolveKeys: () => correspondence(prevKeys, newKeys),
+                })
+                : targetPoints,
+        };
+
+        this._morphKeys.set(series.id, newKeys);
+
+        const exitAnimation = ctx.resolveAnimation(ANIMATION_REFERENCE.exit);
+
+        const {
+            left: markerEntries,
+            inner: markerUpdates,
+            right: markerExits,
+        } = arrayJoin(ctx.data, markers, (item, marker) => marker.id === `${series.id}-${ctx.getKey(item)}`);
+
+        markerExits.forEach(marker => exitElement(ctx.renderer, marker, exitAnimation, {
+            radius: 0,
+            opacity: 0,
+        }));
+
+        markerEntries.forEach(item => group.add(this._buildMarker(series, item, ctx).marker));
+
+        markerUpdates.forEach(([item, marker]) => {
+            const { state, value } = this._markerState(series, item, ctx);
+            marker.data = state;
+            this._attachHover(marker, series, item, value, state, ctx.getKey(item), ctx);
+        });
+
+        this.reconcileLabels(
+            group,
+            ctx,
+            exitAnimation,
+            item => `${series.id}-${ctx.getKey(item)}-label`,
+            item => this._labelSpec(series, item, ctx),
+            batch
+        );
+
+        return group;
+    }
+
+    protected entryTransitions(groups: Group[], ctx: LineSeriesContext<TData>, enter: ResolvedAnimation): Promise<unknown>[] {
+        return groups.flatMap(group => {
+            const markers = group.getElementsByType('circle') as Circle[];
+            const line = group.getElementsByType('polyline')[0] as Polyline;
+
+            return [
+                ctx.renderer.transition(line, {
+                    duration: enter.duration,
+                    ease: enter.ease,
+                    state: { points: interpolatePath(line.points) },
+                }),
+                ctx.renderer.transition(markers, (element, index, length) => ({
+                    duration: enter.duration,
+                    delay: stagger(index, length, enter.duration),
+                    ease: enter.ease,
+                    state: element.data as CircleState,
+                })),
+            ];
+        });
+    }
+
+    protected updateTransitions(groups: Group[], ctx: LineSeriesContext<TData>, update: ResolvedAnimation): Promise<unknown>[] {
+        return groups.flatMap(group => {
+            const markers = group.getElementsByType('circle') as Circle[];
+            const line = group.getElementsByType('polyline')[0] as Polyline;
+
+            return [
+                ctx.renderer.transition(line, {
+                    duration: update.duration,
+                    ease: update.ease,
+                    state: line.data as PolylineState,
+                }),
+                ctx.renderer.transition(markers, element => ({
+                    duration: update.duration,
+                    ease: update.ease,
+                    state: element.data as CircleState,
+                })),
+            ];
+        });
+    }
+
+}

--- a/packages/charts/test/box-plot.test.ts
+++ b/packages/charts/test/box-plot.test.ts
@@ -1,0 +1,129 @@
+import {
+    afterEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createBoxPlotChart,
+} from '../src';
+
+import type {
+    Element,
+    Group,
+} from '@ripl/core';
+
+polyfillPath2D();
+
+/** jsdom measures every element as 0×0; give the canvas a real size so the layout has room. */
+function mockCanvasSize(width: number, height: number): void {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+/** Reaches into a chart's scene to inspect the rendered element graph. */
+function sceneOf(chart: unknown): Group {
+    return (chart as { scene: Group }).scene;
+}
+
+interface Score {
+    group: string;
+    score: number;
+}
+
+const SCORES: Score[] = [
+    ...[10, 20, 30, 40, 100].map(score => ({
+        group: 'A',
+        score,
+    })),
+    ...[15, 25, 35, 45, 55].map(score => ({
+        group: 'B',
+        score,
+    })),
+];
+
+describe('BoxPlotChart animations', () => {
+
+    test('Should stash each box\'s final geometry on `data` so entry can grow it from the median', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createBoxPlotChart<Score>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: SCORES,
+            group: 'group',
+            value: 'score',
+        });
+
+        await chart.render();
+
+        const box = sceneOf(chart).getElementById('A-box') as unknown as { data?: { height: number; }; };
+
+        // The box carries a `data` snapshot of its full geometry — the candlestick-style entry grows
+        // from a collapsed median toward this stashed height.
+        expect(box.data).toBeDefined();
+        expect(box.data!.height).toBeGreaterThan(0);
+
+        chart.destroy();
+    });
+
+    test('Should tween boxes in place on update rather than clearing and rebuilding them', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createBoxPlotChart<Score>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: SCORES,
+            group: 'group',
+            value: 'score',
+        });
+
+        await chart.render();
+
+        const boxBefore = sceneOf(chart).getElementById('A-box') as Element | undefined;
+        expect(boxBefore).toBeDefined();
+
+        // Same categories, shifted values.
+        const next = SCORES.map(item => ({
+            ...item,
+            score: item.score + 5,
+        }));
+
+        chart.update({
+            data: next,
+        });
+
+        await chart.render();
+
+        const boxAfter = sceneOf(chart).getElementById('A-box') as Element | undefined;
+
+        // The same element instance survives the update — it is reconciled and transitioned to the new
+        // geometry, not cleared and rebuilt (which teleported the boxes with no animation).
+        expect(boxAfter).toBe(boxBefore);
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/box-plot.test.ts
+++ b/packages/charts/test/box-plot.test.ts
@@ -78,7 +78,7 @@ describe('BoxPlotChart animations', () => {
 
         await chart.render();
 
-        const box = sceneOf(chart).getElementById('A-box') as unknown as { data?: { height: number; }; };
+        const box = sceneOf(chart).getElementById('A-box') as unknown as { data?: { height: number } };
 
         // The box carries a `data` snapshot of its full geometry — the candlestick-style entry grows
         // from a collapsed median toward this stashed height.

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -62,6 +62,28 @@ function plotOf(chart: unknown): { x: number;
         height: number; }; })._navPlot;
 }
 
+/** The geometry of a rendered rect element. */
+interface RectBox {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/** Reads a rect element's geometry by id (asserting it exists). */
+function rectOf(chart: unknown, id: string): RectBox {
+    const rect = sceneOf(chart).getElementById(id) as unknown as RectBox | undefined;
+    expect(rect).toBeDefined();
+    return rect!;
+}
+
+/** Reads a polyline element's points by id (asserting it exists). */
+function pointsOf(chart: unknown, id: string): [number, number][] {
+    const element = sceneOf(chart).getElementById(id) as unknown as { points: [number, number][] } | undefined;
+    expect(element).toBeDefined();
+    return element!.points;
+}
+
 interface Row {
     month: string;
     a: number;
@@ -424,6 +446,227 @@ describe('Overview navigator strip', () => {
         expect(chart.navigator).toBeDefined();
 
         chart.destroy();
+    });
+
+    test('Grouped bars stay inside the strip and sit side by side', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createBarChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+                {
+                    id: 'b',
+                    label: 'B',
+                    value: 'b',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const strip = rectOf(chart, 'navigator-strip');
+        const last = DATA.length - 1;
+
+        // No bleed: the leftmost sub-bar of the first category and the rightmost of the last category
+        // both sit inside the strip rectangle.
+        const first = rectOf(chart, 'navigator-overview-a-bar-0');
+        const lastBar = rectOf(chart, `navigator-overview-b-bar-${last}`);
+
+        expect(first.x).toBeGreaterThanOrEqual(strip.x - 1e-6);
+        expect(lastBar.x + lastBar.width).toBeLessThanOrEqual(strip.x + strip.width + 1e-6);
+
+        // Grouped: the two series sit side by side in category 0 — disjoint, equal width, not overlapping.
+        const aBar = rectOf(chart, 'navigator-overview-a-bar-0');
+        const bBar = rectOf(chart, 'navigator-overview-b-bar-0');
+
+        expect(aBar.x).not.toBe(bBar.x);
+        expect(aBar.x + aBar.width).toBeLessThanOrEqual(bBar.x + 1e-6);
+        expect(Math.abs(aBar.width - bBar.width)).toBeLessThan(1e-6);
+
+        chart.destroy();
+    });
+
+    test('Stacked bars share a column and stack rather than group', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createBarChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            mode: 'stacked',
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+                {
+                    id: 'b',
+                    label: 'B',
+                    value: 'b',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const aBar = rectOf(chart, 'navigator-overview-a-bar-0');
+        const bBar = rectOf(chart, 'navigator-overview-b-bar-0');
+
+        // Same main position and full band width — one stacked column, not side-by-side.
+        expect(aBar.x).toBeCloseTo(bBar.x, 6);
+        expect(aBar.width).toBeCloseTo(bBar.width, 6);
+
+        // Bottom strip: values grow upward, so `b` sits on top of `a` — b's lower edge meets a's upper
+        // edge, and `a` (anchored at the baseline) extends lower than `b`.
+        expect(Math.abs((bBar.y + bBar.height) - aBar.y)).toBeLessThan(1e-6);
+        expect(aBar.y + aBar.height).toBeGreaterThan(bBar.y + bBar.height);
+
+        chart.destroy();
+    });
+
+    test('Trend line marks are centred over the bars in the band layout', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const trend = createTrendChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'bar',
+                    type: 'bar',
+                    label: 'Bar',
+                    value: 'a',
+                },
+                {
+                    id: 'line',
+                    type: 'line',
+                    label: 'Line',
+                    value: 'b',
+                },
+            ],
+        });
+
+        await trend.render();
+
+        const bar0 = rectOf(trend, 'navigator-overview-bar-bar-0');
+        const linePoints = pointsOf(trend, 'navigator-overview-line');
+
+        // The line's first vertex sits at the first category's band centre — directly over the bar.
+        expect(linePoints[0][0]).toBeCloseTo(bar0.x + bar0.width / 2, 6);
+
+        trend.destroy();
+
+        // A standalone line chart keeps edge-to-edge marks: its first vertex is at the strip's start.
+        const line = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await line.render();
+
+        const strip = rectOf(line, 'navigator-strip');
+
+        expect(pointsOf(line, 'navigator-overview-a')[0][0]).toBeCloseTo(strip.x, 6);
+
+        line.destroy();
+    });
+
+    test('Stacked area series accumulate; unstacked areas overlap', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        // `b` < `a`, so a stacked `b` (a + b) sits ABOVE `a`, but an unstacked `b` sits below it.
+        const data: Row[] = MONTHS.map(month => ({
+            month,
+            a: 100,
+            b: 50,
+        }));
+
+        const stacked = createAreaChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            stacked: true,
+            data,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+                {
+                    id: 'b',
+                    label: 'B',
+                    value: 'b',
+                },
+            ],
+        });
+
+        await stacked.render();
+
+        // Bottom strip: values grow upward (smaller y = higher). Stacked `b` (150) is above `a` (100).
+        expect(pointsOf(stacked, 'navigator-overview-b-line')[0][1])
+            .toBeLessThan(pointsOf(stacked, 'navigator-overview-a-line')[0][1]);
+
+        stacked.destroy();
+
+        const overlapping = createAreaChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            stacked: false,
+            data,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+                {
+                    id: 'b',
+                    label: 'B',
+                    value: 'b',
+                },
+            ],
+        });
+
+        await overlapping.render();
+
+        // Unstacked: each area is drawn from the baseline, so `b` (50) is below `a` (100).
+        expect(pointsOf(overlapping, 'navigator-overview-b-line')[0][1])
+            .toBeGreaterThan(pointsOf(overlapping, 'navigator-overview-a-line')[0][1]);
+
+        overlapping.destroy();
     });
 
 });

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -1,0 +1,429 @@
+import {
+    afterEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createAreaChart,
+    createBarChart,
+    createLineChart,
+    createTrendChart,
+} from '../src';
+
+import type {
+    Group,
+} from '@ripl/core';
+
+polyfillPath2D();
+
+/**
+ * jsdom measures every element as 0×0, which collapses the plot rect. Give the canvas a real size so
+ * the layout produces a meaningful plot/strip geometry to assert against.
+ */
+function mockCanvasSize(width: number, height: number): void {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+/** Reaches into a chart's scene to inspect the rendered element graph. */
+function sceneOf(chart: unknown): Group {
+    return (chart as { scene: Group }).scene;
+}
+
+/** The plot rectangle the chart last rendered into (used to bound pan/zoom). */
+function plotOf(chart: unknown): { x: number;
+    y: number;
+    width: number;
+    height: number; } {
+    return (chart as { _navPlot: { x: number;
+        y: number;
+        width: number;
+        height: number; }; })._navPlot;
+}
+
+interface Row {
+    month: string;
+    a: number;
+    b: number;
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May'];
+const DATA: Row[] = MONTHS.map((month, index) => ({
+    month,
+    a: (index + 1) * 100,
+    b: (index + 1) * 40,
+}));
+
+describe('Overview navigator strip', () => {
+
+    test('Line chart draws a per-series polyline in the strip when overview is on', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const scene = sceneOf(chart);
+
+        expect(scene.getElementById('__navigator-strip')).toBeDefined();
+        expect(scene.getElementById('navigator-overview-a')?.type).toBe('polyline');
+
+        chart.destroy();
+    });
+
+    test('Area chart draws a filled band plus a top line per series', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createAreaChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const scene = sceneOf(chart);
+        const fill = scene.getElementById('navigator-overview-a-fill');
+        const line = scene.getElementById('navigator-overview-a-line');
+
+        expect(fill?.type).toBe('polyline');
+        expect(line?.type).toBe('polyline');
+        // The band is a filled polygon, not an auto-stroked line.
+        expect((fill as unknown as { autoStroke: boolean }).autoStroke).toBe(false);
+
+        chart.destroy();
+    });
+
+    test('Bar chart draws one silhouette rect per datum', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createBarChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const scene = sceneOf(chart);
+
+        for (let index = 0; index < DATA.length; index++) {
+            expect(scene.getElementById(`navigator-overview-a-bar-${index}`)?.type).toBe('rect');
+        }
+
+        // Exactly one rect per datum — no extras.
+        expect(scene.getElementById(`navigator-overview-a-bar-${DATA.length}`)).toBeUndefined();
+
+        chart.destroy();
+    });
+
+    test('Mixed trend strip renders each series by its own type', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createTrendChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'area',
+                    type: 'area',
+                    label: 'Area',
+                    value: 'a',
+                },
+                {
+                    id: 'bar',
+                    type: 'bar',
+                    label: 'Bar',
+                    value: 'b',
+                },
+                {
+                    id: 'line',
+                    type: 'line',
+                    label: 'Line',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const scene = sceneOf(chart);
+
+        // Area → filled band + line; bar → one rect per datum; line → a single polyline.
+        expect(scene.getElementById('navigator-overview-area-fill')?.type).toBe('polyline');
+        expect(scene.getElementById('navigator-overview-area-line')?.type).toBe('polyline');
+        expect(scene.getElementById('navigator-overview-bar-bar-0')?.type).toBe('rect');
+        expect(scene.getElementById(`navigator-overview-bar-bar-${DATA.length - 1}`)?.type).toBe('rect');
+        expect(scene.getElementById('navigator-overview-line')?.type).toBe('polyline');
+
+        chart.destroy();
+    });
+
+    test('Vertical bar gets a wide bottom strip; horizontal bar gets a tall side strip', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const vertical = createBarChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            orientation: 'vertical',
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await vertical.render();
+
+        const verticalStrip = sceneOf(vertical).getElementById('navigator-strip') as unknown as { width: number;
+            height: number; };
+
+        // Category on x → a bottom bar spanning the plot width.
+        expect(verticalStrip.width).toBeGreaterThan(verticalStrip.height);
+
+        vertical.destroy();
+
+        const horizontal = createBarChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            orientation: 'horizontal',
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await horizontal.render();
+
+        const horizontalStrip = sceneOf(horizontal).getElementById('navigator-strip') as unknown as { width: number;
+            height: number; };
+
+        // Category on y → a side bar spanning the plot height.
+        expect(horizontalStrip.height).toBeGreaterThan(horizontalStrip.width);
+
+        horizontal.destroy();
+    });
+
+    test('Windowing clips the category (x) axis but never the value (y) axis', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const findClip = (group: { children: { clip?: boolean;
+            pointerEvents?: string; }[]; }) =>
+            group.children.find(child => child.clip !== undefined && child.pointerEvents === 'none');
+
+        const axisGroups = sceneOf(chart).queryAll<Group>('.chart-axis');
+        const clipped = axisGroups.filter(group => findClip(group)?.clip === true);
+
+        // Both axes exist, but only the sliding category (x) axis is masked — the value axis is held at
+        // the full extent, so its min/max labels are never bisected.
+        expect(axisGroups.length).toBe(2);
+        expect(clipped.length).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('Zoom is clamped so you cannot zoom out past the full data extent (k >= 1)', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        chart.navigator!.setTransform({
+            k: 0.25,
+            x: 0,
+            y: 0,
+        });
+
+        // Clamped up to the identity view — the full dataset is the furthest-out you can go.
+        expect(chart.navigator!.transform.k).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('Pan is clamped to the data edges along the category axis', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        const plot = plotOf(chart);
+        const k = 2;
+
+        // Scroll hard past the right edge — clamps to the lower translate bound (origin+size)(1-k).
+        chart.navigator!.setTransform({
+            k,
+            x: -100000,
+            y: 0,
+        });
+
+        expect(chart.navigator!.transform.x).toBeCloseTo((plot.x + plot.width) * (1 - k), 4);
+
+        // Scroll hard past the left edge — clamps to the upper translate bound origin(1-k).
+        chart.navigator!.setTransform({
+            k,
+            x: 100000,
+            y: 0,
+        });
+
+        expect(chart.navigator!.transform.x).toBeCloseTo(plot.x * (1 - k), 4);
+
+        chart.destroy();
+    });
+
+    test('No strip is drawn unless the overview is opted in, and it appears when toggled on', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        // Off by default: no strip, no navigator.
+        expect(sceneOf(chart).getElementById('__navigator-strip')).toBeUndefined();
+        expect(chart.navigator).toBeUndefined();
+
+        chart.update({
+            overview: true,
+        } as Partial<Parameters<typeof createLineChart<Row>>[1]>);
+
+        await chart.render();
+
+        // Toggled on: the strip is drawn and the shared navigator exists to drive it.
+        expect(sceneOf(chart).getElementById('__navigator-strip')).toBeDefined();
+        expect(chart.navigator).toBeDefined();
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/stock.test.ts
+++ b/packages/charts/test/stock.test.ts
@@ -1,0 +1,143 @@
+import {
+    afterEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createStockChart,
+} from '../src';
+
+import type {
+    Group,
+} from '@ripl/core';
+
+polyfillPath2D();
+
+/** jsdom measures every element as 0×0; give the canvas a real size so the layout has room. */
+function mockCanvasSize(width: number, height: number): void {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+/** Reaches into a chart's scene to inspect the rendered element graph. */
+function sceneOf(chart: unknown): Group {
+    return (chart as { scene: Group }).scene;
+}
+
+interface Candle {
+    date: string;
+    o: number;
+    h: number;
+    l: number;
+    c: number;
+    v: number;
+}
+
+const CANDLES: Candle[] = [
+    {
+        date: 'd1',
+        o: 100,
+        h: 108,
+        l: 98,
+        c: 105,
+        v: 12000,
+    },
+    {
+        date: 'd2',
+        o: 105,
+        h: 110,
+        l: 103,
+        c: 104,
+        v: 9800,
+    },
+    {
+        date: 'd3',
+        o: 104,
+        h: 112,
+        l: 102,
+        c: 111,
+        v: 15000,
+    },
+];
+
+describe('StockChart volume toggle', () => {
+
+    test('Should render the volume sub-chart when volume data is supplied', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createStockChart<Candle>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: CANDLES,
+            key: 'date',
+            open: 'o',
+            high: 'h',
+            low: 'l',
+            close: 'c',
+            volume: 'v',
+            showVolume: true,
+        });
+
+        await chart.render();
+
+        expect(sceneOf(chart).getElementById('volume')).toBeDefined();
+
+        chart.destroy();
+    });
+
+    test('Should tear down the volume group when volume is toggled off', async () => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createStockChart<Candle>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: CANDLES,
+            key: 'date',
+            open: 'o',
+            high: 'h',
+            low: 'l',
+            close: 'c',
+            volume: 'v',
+            showVolume: true,
+        });
+
+        await chart.render();
+        expect(sceneOf(chart).getElementById('volume')).toBeDefined();
+
+        chart.update({
+            showVolume: false,
+        });
+
+        await chart.render();
+
+        // The orphaned volume group is destroyed so the candlesticks reclaim the space cleanly.
+        expect(sceneOf(chart).getElementById('volume')).toBeUndefined();
+        expect((chart as unknown as { _volumeGroup: unknown })._volumeGroup).toBeUndefined();
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/stock.test.ts
+++ b/packages/charts/test/stock.test.ts
@@ -47,37 +47,37 @@ function sceneOf(chart: unknown): Group {
 
 interface Candle {
     date: string;
-    o: number;
-    h: number;
-    l: number;
-    c: number;
-    v: number;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    volume: number;
 }
 
 const CANDLES: Candle[] = [
     {
         date: 'd1',
-        o: 100,
-        h: 108,
-        l: 98,
-        c: 105,
-        v: 12000,
+        open: 100,
+        high: 108,
+        low: 98,
+        close: 105,
+        volume: 12000,
     },
     {
         date: 'd2',
-        o: 105,
-        h: 110,
-        l: 103,
-        c: 104,
-        v: 9800,
+        open: 105,
+        high: 110,
+        low: 103,
+        close: 104,
+        volume: 9800,
     },
     {
         date: 'd3',
-        o: 104,
-        h: 112,
-        l: 102,
-        c: 111,
-        v: 15000,
+        open: 104,
+        high: 112,
+        low: 102,
+        close: 111,
+        volume: 15000,
     },
 ];
 
@@ -92,11 +92,11 @@ describe('StockChart volume toggle', () => {
             animation: false,
             data: CANDLES,
             key: 'date',
-            open: 'o',
-            high: 'h',
-            low: 'l',
-            close: 'c',
-            volume: 'v',
+            open: 'open',
+            high: 'high',
+            low: 'low',
+            close: 'close',
+            volume: 'volume',
             showVolume: true,
         });
 
@@ -116,11 +116,11 @@ describe('StockChart volume toggle', () => {
             animation: false,
             data: CANDLES,
             key: 'date',
-            open: 'o',
-            high: 'h',
-            low: 'l',
-            close: 'c',
-            volume: 'v',
+            open: 'open',
+            high: 'high',
+            low: 'low',
+            close: 'close',
+            volume: 'volume',
             showVolume: true,
         });
 

--- a/packages/charts/test/trend.test.ts
+++ b/packages/charts/test/trend.test.ts
@@ -1,0 +1,275 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createAreaChart,
+    createTrendChart,
+} from '../src';
+
+import type {
+    Element,
+    Group,
+} from '@ripl/core';
+
+polyfillPath2D();
+
+interface Row {
+    period: string;
+    revenue: number;
+    cost: number;
+    units: number;
+    target: number;
+}
+
+const DATA: Row[] = [
+    {
+        period: 'Q1',
+        revenue: 400,
+        cost: 40,
+        units: 20,
+        target: 100,
+    },
+    {
+        period: 'Q2',
+        revenue: 300,
+        cost: 30,
+        units: 25,
+        target: 110,
+    },
+    {
+        period: 'Q3',
+        revenue: 200,
+        cost: 50,
+        units: 15,
+        target: 90,
+    },
+];
+
+/** Reaches into a chart's scene to inspect the rendered element graph. */
+function sceneOf(chart: unknown): Group {
+    return (chart as unknown as { scene: Group }).scene;
+}
+
+/** The paint-order z-index of a series group by id. */
+function zIndexOf(chart: unknown, id: string): number {
+    const element = sceneOf(chart).getElementById(id);
+
+    expect(element).toBeDefined();
+
+    return element!.zIndex;
+}
+
+/** Fires a synthetic click on a scene element (as the hover wiring would). */
+function clickElement(element: Element, x: number, y: number): void {
+    (element as unknown as { emit: (type: string, data: unknown) => void }).emit('click', {
+        x,
+        y,
+    });
+}
+
+describe('TrendChart', () => {
+
+    function createMixedTrend(overrides: Record<string, unknown> = {}) {
+        return createTrendChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'period',
+            series: [
+                {
+                    id: 'revenue',
+                    type: 'area',
+                    label: 'Revenue',
+                    value: 'revenue',
+                },
+                {
+                    id: 'cost',
+                    type: 'area',
+                    label: 'Cost',
+                    value: 'cost',
+                },
+                {
+                    id: 'units',
+                    type: 'bar',
+                    label: 'Units',
+                    value: 'units',
+                },
+                {
+                    id: 'target',
+                    type: 'line',
+                    label: 'Target',
+                    value: 'target',
+                },
+            ],
+            ...overrides,
+        });
+    }
+
+    test('Should render a mixed line/bar/area chart into a canvas', async () => {
+        mockCanvasContext();
+
+        const target = document.createElement('div');
+        const chart = createTrendChart<Row>(target, {
+            animation: false,
+            data: DATA,
+            key: 'period',
+            series: [
+                {
+                    id: 'revenue',
+                    type: 'area',
+                    label: 'Revenue',
+                    value: 'revenue',
+                },
+                {
+                    id: 'units',
+                    type: 'bar',
+                    label: 'Units',
+                    value: 'units',
+                },
+                {
+                    id: 'target',
+                    type: 'line',
+                    label: 'Target',
+                    value: 'target',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        expect(target.querySelector('canvas')).not.toBeNull();
+        expect(sceneOf(chart).getElementById('__plot-content')).toBeDefined();
+
+        chart.destroy();
+    });
+
+    test('Should paint back-to-front area -> bar -> line, largest area at the back', async () => {
+        mockCanvasContext();
+
+        const chart = createMixedTrend();
+
+        await chart.render();
+
+        const revenue = zIndexOf(chart, 'revenue'); // area, Σ = 900 (largest)
+        const cost = zIndexOf(chart, 'cost'); // area, Σ = 120 (smaller)
+        const units = zIndexOf(chart, 'units'); // bar
+        const target = zIndexOf(chart, 'target'); // line
+
+        // Largest area furthest back, smaller area in front of it, both behind bars, bars behind lines.
+        expect(revenue).toBeLessThan(cost);
+        expect(cost).toBeLessThan(units);
+        expect(units).toBeLessThan(target);
+
+        chart.destroy();
+    });
+
+    test('Should stack same-type series without throwing', async () => {
+        mockCanvasContext();
+
+        const chart = createMixedTrend({ stacked: true });
+
+        await expect(chart.render()).resolves.not.toThrow();
+        expect(sceneOf(chart).getElementById('revenue')).toBeDefined();
+
+        chart.destroy();
+    });
+
+    test('Should emit enriched bar events with seriesId, xValue and yValue', async () => {
+        mockCanvasContext();
+
+        const chart = createMixedTrend();
+
+        await chart.render();
+
+        const events: unknown[] = [];
+        chart.on('barclick', event => events.push(event.data));
+
+        const bar = sceneOf(chart).getElementById('units-Q1');
+        expect(bar).toBeDefined();
+
+        clickElement(bar!, 12, 34);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            seriesId: 'units',
+            xValue: 'Q1',
+            yValue: 20,
+        });
+
+        chart.destroy();
+    });
+
+    test('Should create a navigator the overview strip can drive when overview is enabled', async () => {
+        mockCanvasContext();
+
+        const chart = createMixedTrend({ overview: true });
+
+        await chart.render();
+
+        expect(chart.navigator).toBeDefined();
+        // The strip drives the shared transform; windowing to the first half zooms x by 2.
+        expect(() => chart.navigator?.setTransform({
+            k: 2,
+            x: 0,
+            y: 0,
+        })).not.toThrow();
+        expect(chart.navigator?.transform.k).toBe(2);
+
+        chart.destroy();
+    });
+
+    test('Should not create a navigator without the overview strip or a navigator option', async () => {
+        mockCanvasContext();
+
+        const chart = createMixedTrend();
+
+        await chart.render();
+
+        expect(chart.navigator).toBeUndefined();
+
+        chart.destroy();
+    });
+
+});
+
+describe('AreaChart paint ordering', () => {
+
+    test('Should paint the largest area at the back', async () => {
+        mockCanvasContext();
+
+        const chart = createAreaChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'period',
+            series: [
+                {
+                    id: 'revenue',
+                    label: 'Revenue',
+                    value: 'revenue', // Σ = 900 (largest)
+                },
+                {
+                    id: 'cost',
+                    label: 'Cost',
+                    value: 'cost', // Σ = 120 (smaller)
+                },
+            ],
+        });
+
+        await chart.render();
+
+        // Largest area sits furthest back (lowest z-index) so the smaller area stays visible.
+        expect(zIndexOf(chart, 'revenue')).toBeLessThan(zIndexOf(chart, 'cost'));
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/visual/gallery.ts
+++ b/packages/charts/test/visual/gallery.ts
@@ -722,6 +722,7 @@ interface TrendRow {
     id: string;
     australia: number;
     sweden: number;
+    norway: number;
     greatBritain: number;
 }
 
@@ -729,31 +730,36 @@ const TREND_DATA: TrendRow[] = [
     {
         id: '2018',
         australia: 30,
-        sweden: 20,
+        sweden: 48,
+        norway: 18,
         greatBritain: 45,
     },
     {
         id: '2019',
         australia: 45,
-        sweden: 35,
+        sweden: 62,
+        norway: 22,
         greatBritain: 50,
     },
     {
         id: '2020',
         australia: 25,
-        sweden: 40,
+        sweden: 55,
+        norway: 15,
         greatBritain: 38,
     },
     {
         id: '2021',
         australia: 55,
-        sweden: 30,
+        sweden: 70,
+        norway: 26,
         greatBritain: 60,
     },
     {
         id: '2022',
         australia: 40,
-        sweden: 50,
+        sweden: 66,
+        norway: 20,
         greatBritain: 52,
     },
 ];
@@ -762,20 +768,27 @@ createTrendChart(mount('trend'), {
     animation: false,
     title: 'Trend — Mixed series',
     legend: true,
+    overview: true,
     data: TREND_DATA,
     key: 'id',
     series: [
+        {
+            type: 'area',
+            id: 'sweden',
+            label: 'Sweden',
+            value: 'sweden',
+        },
+        {
+            type: 'area',
+            id: 'norway',
+            label: 'Norway',
+            value: 'norway',
+        },
         {
             type: 'bar',
             id: 'australia',
             label: 'Australia',
             value: 'australia',
-        },
-        {
-            type: 'bar',
-            id: 'sweden',
-            label: 'Sweden',
-            value: 'sweden',
         },
         {
             type: 'line',

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -88,6 +88,14 @@ const SVG_STYLE_MAP = {
         middle: 'middle',
         bottom: 'text-after-edge',
     } as Record<TextBaseline, string>,
+    // `dominant-baseline` is the property browsers actually honour on a <text> element (unlike
+    // `alignment-baseline`, which only applies to <tspan>/<textPath>). Without it, SVG text falls
+    // back to the alphabetic baseline, mispositioning every label and clipping rotated titles.
+    dominantBaseline: {
+        top: 'text-before-edge',
+        middle: 'central',
+        bottom: 'text-after-edge',
+    } as Record<TextBaseline, string>,
 } as Record<keyof Styles, Record<string, string>>;
 
 function createSVGElement<TTag extends keyof SVGElementTagNameMap>(tag: TTag) {
@@ -634,6 +642,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             fontKerning: this.currentState.fontKerning,
             textAnchor: this.currentState.textAlign,
             alignmentBaseline: this.currentState.textBaseline,
+            dominantBaseline: this.currentState.textBaseline,
             opacity: this.currentState.opacity.toString(),
             zIndex: (this.currentState.zIndex || '').toString(),
             // Shadow properties (shadowBlur/Color/OffsetX/OffsetY) are intentionally not mapped: SVG


### PR DESCRIPTION
## Summary

This change introduces a new **TrendChart** that mixes line, bar, and area series on shared axes, and refactors the series rendering logic into reusable components. The line, area, and bar charts now delegate their geometry to extracted `SeriesRenderer` subclasses, enabling code sharing with the new trend chart while maintaining identical behavior in all three standalone charts.

## Key Changes

- **New TrendChart** (`packages/charts/src/charts/trend.ts`): A mixed cartesian chart supporting line, bar, and area series with configurable stacking, an optional navigator strip for windowing the x-range, and wheel/drag pan-zoom on the plot.

- **Series Renderer Extraction**:
  - `SeriesRenderer` base class (`packages/charts/src/core/series/base.ts`): Owns the shared enter/update/exit pipeline, marker hover wiring, and data-label reconciliation.
  - `LineSeriesRenderer` (`packages/charts/src/core/series/line-series.ts`): Polyline + markers with progressive draw-on entry and staggered marker pop-in.
  - `AreaSeriesRenderer` (`packages/charts/src/core/series/area-series.ts`): Filled bands with left→right reveal, key-reconciled morph, and largest-at-back paint ordering.
  - `BarSeriesRenderer` (`packages/charts/src/core/series/bar-series.ts`): Grouped or stacked rectangles with outermost-segment rounding and stacked single-rising-fill entry.

- **Series Context** (`packages/charts/src/core/series/context.ts`): Unified context and series shapes passed to renderers, decoupling geometry from chart-specific logic.

- **Navigator Component** (`packages/charts/src/components/navigator.ts`): Draggable window strip beneath the plot for selecting the visible x-range, with DOM pointer listeners for drag tracking.

- **LineChart, AreaChart, BarChart Refactoring**: Each now uses its corresponding `SeriesRenderer`, removing ~400 lines of duplicated geometry code while preserving all existing behavior and events.

- **Paint Order**: TrendChart renders series back-to-front as **area → bar → line** so lines never hide behind fills or bars; unstacked areas are drawn largest-first so smaller areas stay visible.

- **Stacking & Windowing**: TrendChart supports same-type series stacking and optional navigator-driven x-range windowing with in-plot wheel/drag pan-zoom.

## Notable Implementation Details

- The `SeriesRenderer` base class handles the full enter/update/exit lifecycle, marker hover + tooltip wiring, and data-label reconciliation, so all three chart types (and the trend chart) stay synchronized.
- Series context is widened by each renderer subclass (e.g., `LineSeriesContext` adds `xScale` and `yScale`; `BarSeriesContext` adds `categoryScale` and `orientation`).
- The navigator strip owns no transform math—it reports the selected window as fractions `[start, end]` of the domain; the host chart converts that to a navigator transform.
- All public API members (interfaces, options, event maps) are fully documented per project conventions.

https://claude.ai/code/session_014M32DBTFoGeP75dwiuDkFv