### PR TITLE
charts: unify option naming, consolidate formatNumber, fix demo UX

### DIFF
--- a/app/src/.vitepress/components/example.vue
+++ b/app/src/.vitepress/components/example.vue
@@ -8,7 +8,6 @@
             ]" />
             <slot name="header"></slot>
             <div class="ripl-example__actions">
-                <RiplExportButton v-if="context" :context="context" />
                 <button
                     v-if="$slots.config"
                     class="ripl-example__config-button"
@@ -22,6 +21,7 @@
                     </svg>
                     <span>Customize</span>
                 </button>
+                <RiplExportButton v-if="context" :context="context" />
             </div>
         </div>
         <div class="ripl-example__root">
@@ -265,7 +265,13 @@ onUnmounted(cleanup);
 
     .ripl-example__root {
         position: relative;
-        aspect-ratio: 16 / 9;
+        aspect-ratio: 4 / 3;
+    }
+
+    @media (min-width: 640px) {
+        .ripl-example__root {
+            aspect-ratio: 16 / 9;
+        }
     }
 
     .ripl-example__mount {

--- a/app/src/charts/area.md
+++ b/app/src/charts/area.md
@@ -114,7 +114,7 @@ function getSeries() {
         id: s.id,
         value: s.id,
         label: s.label,
-        opacity: 0.3,
+        fillOpacity: 0.3,
         lineType: lineType.value,
         lineStyle: lineStyle.value,
         markers: markers.value,
@@ -217,11 +217,11 @@ createAreaChart('#container', {
         { id: 'desktop',
             value: 'desktop',
             label: 'Desktop',
-            opacity: 0.4 },
+            fillOpacity: 0.4 },
         { id: 'mobile',
             value: 'mobile',
             label: 'Mobile',
-            opacity: 0.4 },
+            fillOpacity: 0.4 },
     ],
 });
 ```
@@ -236,12 +236,12 @@ createAreaChart('#container', {
         { id: 'desktop',
             value: 'desktop',
             label: 'Desktop',
-            opacity: 0.2,
+            fillOpacity: 0.2,
             lineType: 'monotoneX' },
         { id: 'mobile',
             value: 'mobile',
             label: 'Mobile',
-            opacity: 0.6,
+            fillOpacity: 0.6,
             lineType: 'step' },
     ],
 });
@@ -250,7 +250,7 @@ createAreaChart('#container', {
 ## Options
 
 - **`data`** — The data array
-- **`series`** — Array of series with `id`, `value`, `label`, optional `color`, `opacity`, `lineType`, `lineStyle` (`'solid'` \| `'dashed'` \| `'dotted'` \| custom dash array), `lineWidth`, `markers`
+- **`series`** — Array of series with `id`, `value`, `label`, optional `color`, `fillOpacity`, `lineType`, `lineStyle` (`'solid'` \| `'dashed'` \| `'dotted'` \| custom dash array), `lineWidth`, `markers`
 - **`key`** — Key accessor for data points
 - **`stacked`** — Stack series on top of each other (default `false`)
 - **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines (default `true`)

--- a/app/src/charts/bar.md
+++ b/app/src/charts/bar.md
@@ -101,7 +101,7 @@ const { contextChanged, chart } = useRiplChart(context => {
     return createBarChart(context, {
         data,
         key: 'month',
-        mode: stacked.value ? 'stacked' : 'grouped',
+        stacked: stacked.value,
         orientation: horizontal.value ? 'horizontal' : 'vertical',
         padding: { top: 30, right: 20, bottom: 30, left: 20 },
         series: getSeries(),
@@ -112,7 +112,7 @@ const { contextChanged, chart } = useRiplChart(context => {
 
 function apply() {
     chart.value?.update({
-        mode: stacked.value ? 'stacked' : 'grouped',
+        stacked: stacked.value,
         orientation: horizontal.value ? 'horizontal' : 'vertical',
         series: getSeries(),
         overview: overview.value,
@@ -155,7 +155,7 @@ import {
 const chart = createBarChart('#container', {
     data: [/* ... */],
     key: 'quarter',
-    mode: 'grouped',        // 'grouped' | 'stacked'
+    stacked: false,          // set true to stack series
     orientation: 'vertical', // 'vertical' | 'horizontal'
     series: [
         { id: 'sales', value: 'sales', label: 'Sales' },
@@ -194,7 +194,7 @@ Bars for each series sit side-by-side within each category:
 createBarChart('#container', {
     data,
     key: 'month',
-    mode: 'grouped',
+    stacked: false,
     series: [
         { id: 'sales',
             value: 'sales',
@@ -214,7 +214,7 @@ Bars stack on top of each other, showing cumulative totals:
 createBarChart('#container', {
     data,
     key: 'month',
-    mode: 'stacked',
+    stacked: true,
     series: [
         { id: 'sales',
             value: 'sales',
@@ -248,7 +248,7 @@ createBarChart('#container', {
 - **`data`** — The data array
 - **`series`** — Array of series with `id`, `value`, `label`, and optional `color`
 - **`key`** — Key accessor for categories
-- **`mode`** — `'grouped'` (default) or `'stacked'`
+- **`stacked`** — `false` (grouped, default) or `true` (stacked)
 - **`orientation`** — `'vertical'` (default) or `'horizontal'`
 - **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines (default `true`)
 - **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend

--- a/app/src/charts/box-plot.md
+++ b/app/src/charts/box-plot.md
@@ -59,7 +59,7 @@ let data = generateData();
 const { contextChanged, chart } = useRiplChart(context => {
     return createBoxPlotChart(context, {
         data,
-        group: 'region',
+        key: 'region',
         value: 'latency',
         categories: REGIONS,
         padding: { top: 20, right: 20, bottom: 40, left: 40 },
@@ -92,20 +92,20 @@ import {
 
 const chart = createBoxPlotChart('#container', {
     data: [/* ... */],
-    group: 'region',
+    key: 'region',
     value: 'latency',
 });
 ```
 
 ## Data Format
 
-Each item contributes one numeric value to a category. The chart groups items by the `group`
+Each item contributes one numeric value to a category. The chart groups items by the `key`
 accessor and summarises the `value` accessor per group — no pre-aggregation required.
 
 ## Options
 
 - **`data`** — The data array
-- **`group`** — Accessor for the category (field name or function)
+- **`key`** — Accessor for the category (field name or function)
 - **`value`** — Accessor for the numeric value (field name or function)
 - **`categories`** — Explicit category order (default: first-seen order)
 - **`color`** — Box colour (default: first palette colour)

--- a/app/src/charts/funnel.md
+++ b/app/src/charts/funnel.md
@@ -92,6 +92,6 @@ const chart = createFunnelChart('#container', {
 - **`key`** — Unique key accessor
 - **`value`** — Value accessor (determines bar width)
 - **`label`** — Label accessor (displayed inside bars)
-- **`color`** — Optional color accessor
+- **`colorBy`** — Optional per-item color accessor
 - **`gap`** — Gap between segments in pixels (default `4`)
 - **`borderRadius`** — Segment corner radius (default `4`)

--- a/app/src/charts/gantt.md
+++ b/app/src/charts/gantt.md
@@ -164,7 +164,7 @@ chart.update({ data: newData });
 - **`label`** — Label accessor for y-axis task names
 - **`start`** — Start date accessor
 - **`end`** — End date accessor
-- **`color`** — Optional color accessor per task
+- **`colorBy`** — Optional color accessor per task
 - **`progress`** — Optional progress accessor (0–1)
 - **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines
 - **`tooltip`** — `boolean | ChartTooltipOptions` — Show/configure tooltips

--- a/app/src/charts/gauge.md
+++ b/app/src/charts/gauge.md
@@ -60,14 +60,14 @@ const config = useChartConfig({
 const { contextChanged, chart } = useRiplChart(context => {
     return createGaugeChart(context, {
         value: value.value,
-        min: 0,
-        max: 100,
+        minValue: 0,
+        maxValue: 100,
         label: 'Performance',
         color: color.value,
-        formatValue: v => `${v}%`,
+        format: v => `${v}%`,
         tickCount: tickCount.value,
         showTickLabels: true,
-        formatTickLabel: v => `${v}%`,
+        formatTick: v => `${v}%`,
         padding: { top: 20, right: 20, bottom: 20, left: 20 },
         ...buildCommonOptions(config),
     });
@@ -99,10 +99,10 @@ import {
 
 const chart = createGaugeChart('#container', {
     value: 72,
-    min: 0,
-    max: 100,
+    minValue: 0,
+    maxValue: 100,
     label: 'Performance',
-    formatValue: v => `${v}%`,
+    format: v => `${v}%`,
 });
 
 // Update value
@@ -117,7 +117,7 @@ chart.update({ value: 85 });
 - **`label`** — Label displayed below the value
 - **`color`** — Gauge fill color (default pastel blue)
 - **`trackColor`** — Background track color (default `#e5e7eb`)
-- **`formatValue`** — Custom value formatter function
+- **`format`** — Custom value formatter function
 - **`tickCount`** — Number of tick marks along the arc (default `5`, set to `0` to hide)
 - **`showTickLabels`** — Whether to show value labels at each tick (default `true`)
-- **`formatTickLabel`** — Custom formatter for tick labels
+- **`formatTick`** — Custom formatter for tick labels

--- a/app/src/charts/getting-started.md
+++ b/app/src/charts/getting-started.md
@@ -94,7 +94,7 @@ chart.update({
 You can update any option — not just data:
 
 ```ts
-chart.update({ mode: 'stacked' });
+chart.update({ stacked: true });
 chart.update({ orientation: 'horizontal' });
 chart.update({ legend: true });
 ```

--- a/app/src/charts/heatmap.md
+++ b/app/src/charts/heatmap.md
@@ -70,12 +70,12 @@ let data = generateData();
 const { contextChanged, chart } = useRiplChart(context => {
     return createHeatmapChart(context, {
         data,
-        xBy: 'hour',
-        yBy: 'day',
+        keyX: 'hour',
+        keyY: 'day',
         value: 'value',
         xCategories: HOURS,
         yCategories: DAYS,
-        colorRange: [lowColor.value, highColor.value],
+        colors: [lowColor.value, highColor.value],
         padding: { top: 20, right: 20, bottom: 40, left: 20 },
         ...buildCommonOptions(config),
     });
@@ -83,7 +83,7 @@ const { contextChanged, chart } = useRiplChart(context => {
 
 function apply() {
     chart.value?.update({
-        colorRange: [lowColor.value, highColor.value],
+        colors: [lowColor.value, highColor.value],
         ...buildCommonOptions(config),
     });
 }
@@ -106,8 +106,8 @@ import {
 
 const chart = createHeatmapChart('#container', {
     data: [/* ... */],
-    xBy: 'hour',
-    yBy: 'day',
+    keyX: 'hour',
+    keyY: 'day',
     value: 'value',
     xCategories: ['9am', '10am', '11am'],
     yCategories: ['Mon', 'Tue', 'Wed'],
@@ -117,10 +117,10 @@ const chart = createHeatmapChart('#container', {
 ## Options
 
 - **`data`** — The data array (one item per cell)
-- **`xBy`** — Accessor for the x-axis category
-- **`yBy`** — Accessor for the y-axis category
+- **`keyX`** — Accessor for the x-axis category
+- **`keyY`** — Accessor for the y-axis category
 - **`value`** — Accessor for the cell value
 - **`xCategories`** — Ordered list of x-axis categories
 - **`yCategories`** — Ordered list of y-axis categories
-- **`colorRange`** — Tuple of `[lowColor, highColor]` hex strings
+- **`colors`** — Tuple of `[lowColor, highColor]` hex strings
 - **`borderRadius`** — Cell corner radius (default `2`)

--- a/app/src/charts/packed-circle.md
+++ b/app/src/charts/packed-circle.md
@@ -140,6 +140,6 @@ const data = [
 - **`key`** — Unique key accessor for each circle
 - **`value`** — Numeric value accessor; encoded as the circle's area
 - **`label`** — Optional label accessor (defaults to `key`)
-- **`color`** — Optional per-circle color accessor
+- **`colorBy`** — Optional per-circle color accessor
 - **`format`** — Value formatter for tooltips
 - **`padding`**, **`title`**, **`animation`** — Standard chart options

--- a/app/src/charts/polar-area.md
+++ b/app/src/charts/polar-area.md
@@ -186,8 +186,8 @@ Every segment spans the same angle — only the radius varies with `value`.
 - **`key`** — Key accessor for each segment (a field name or a function)
 - **`value`** — Numeric value accessor; encoded as the segment radius
 - **`label`** — Label accessor for each segment
-- **`color`** — Optional per-segment color accessor (otherwise a palette color is assigned)
-- **`innerRadiusRatio`** — Inner radius as a ratio of the chart size (`0`–`1`, default `0.15`)
+- **`colorBy`** — Optional per-segment color accessor (otherwise a palette color is assigned)
+- **`innerRadius`** — Inner radius as a fraction of the chart size (`0`–`1`, default `0.15`)
 - **`maxRadiusRatio`** — Maximum outer radius as a ratio of the chart size (`0`–`0.5`, default `0.45`)
 - **`padAngle`** — Padding angle between segments in radians (default `0.02`)
 - **`levels`** — Number of concentric grid rings (default `4`)

--- a/app/src/charts/polar-scatter.md
+++ b/app/src/charts/polar-scatter.md
@@ -76,7 +76,7 @@ const { contextChanged, chart } = useRiplChart(context => {
     return createPolarScatterChart(context, {
         data: samples,
         series: getSeries(),
-        maxRadiusValue: 100,
+        maxValue: 100,
         format: v => `${v} km/h`,
         padding: { top: 20, right: 20, bottom: 20, left: 20 },
         ...buildCommonOptions(config),
@@ -140,7 +140,7 @@ const chart = createPolarScatterChart('#container', {
             radius: 'speed',
             sizeBy: 'gust' },
     ],
-    maxRadiusValue: 100,
+    maxValue: 100,
 });
 ```
 
@@ -186,7 +186,7 @@ const series = [
 
 - **`data`** — The data array
 - **`series`** — Array of series with `id`, `label`, `angle` (degrees accessor), `radius` (value accessor), optional `color`, `sizeBy`, `minRadius`, `maxRadius`
-- **`maxRadiusValue`** — Value mapped to the outer ring (defaults to the data maximum)
+- **`maxValue`** — Value mapped to the outer ring (defaults to the data maximum)
 - **`levels`** — Number of concentric value rings (default `4`)
 - **`angleTicks`** — Number of angular spokes/labels (default `8`)
 - **`legend`** — `boolean | ChartLegendOptions` — Series legend (shown by default for multiple series)

--- a/app/src/charts/radar.md
+++ b/app/src/charts/radar.md
@@ -79,7 +79,7 @@ function getSeries() {
         id: s.id,
         value: s.id,
         label: s.label,
-        opacity: 0.25,
+        fillOpacity: 0.25,
         color: config.colors[s.id],
     }));
 }
@@ -87,7 +87,7 @@ function getSeries() {
 const { contextChanged, chart } = useRiplChart(context => {
     return createRadarChart(context, {
         data,
-        axes: currentAxes(),
+        categories: currentAxes(),
         levels: levels.value,
         padding: { top: 30, right: 30, bottom: 30, left: 30 },
         series: getSeries(),
@@ -97,7 +97,7 @@ const { contextChanged, chart } = useRiplChart(context => {
 
 function apply() {
     chart.value?.update({
-        axes: currentAxes(),
+        categories: currentAxes(),
         data,
         levels: levels.value,
         series: getSeries(),
@@ -117,7 +117,7 @@ function addAxis() {
     if (axisCount < AXIS_POOL.length) {
         axisCount++;
         data = generateData();
-        chart.value?.update({ axes: currentAxes(), data });
+        chart.value?.update({ categories: currentAxes(), data });
     }
 }
 
@@ -125,7 +125,7 @@ function removeAxis() {
     if (axisCount > 3) {
         axisCount--;
         data = generateData();
-        chart.value?.update({ axes: currentAxes(), data });
+        chart.value?.update({ categories: currentAxes(), data });
     }
 }
 </script>
@@ -139,7 +139,7 @@ import {
 
 const chart = createRadarChart('#container', {
     data: [/* ... */],
-    axes: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck', 'Agility'],
+    categories: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck', 'Agility'],
     series: [
         { id: 'player1', value: 'player1', label: 'Player 1' },
     ],
@@ -164,7 +164,7 @@ const data = [
 ];
 ```
 
-The `axes` option lists axis labels, and each series references a numeric field via `value`.
+The `categories` option lists axis labels, and each series references a numeric field via `value`.
 
 ## Variants
 
@@ -173,7 +173,7 @@ The `axes` option lists axis labels, and each series references a numeric field 
 ```ts
 createRadarChart('#container', {
     data,
-    axes: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck'],
+    categories: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck'],
     series: [
         { id: 'player1',
             value: 'player1',
@@ -187,18 +187,18 @@ createRadarChart('#container', {
 ```ts
 createRadarChart('#container', {
     data,
-    axes: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck'],
+    categories: ['Speed', 'Strength', 'Defense', 'Magic', 'Luck'],
     levels: 10,
     maxValue: 100,
     series: [
         { id: 'player1',
             value: 'player1',
             label: 'Player 1',
-            opacity: 0.3 },
+            fillOpacity: 0.3 },
         { id: 'player2',
             value: 'player2',
             label: 'Player 2',
-            opacity: 0.3 },
+            fillOpacity: 0.3 },
     ],
 });
 ```
@@ -206,8 +206,8 @@ createRadarChart('#container', {
 ## Options
 
 - **`data`** — The data array (one item per axis)
-- **`axes`** — Array of axis labels
-- **`series`** — Array of series with `id`, `value`, `label`, optional `color` and `opacity`
+- **`categories`** — Array of axis labels
+- **`series`** — Array of series with `id`, `value`, `label`, optional `color` and `fillOpacity`
 - **`maxValue`** — Maximum value for the scale (auto-computed if omitted)
 - **`levels`** — Number of concentric grid levels (default `5`)
 - **`legend`** — `boolean | ChartLegendOptions` — Show/configure legend

--- a/app/src/charts/radial-bar.md
+++ b/app/src/charts/radial-bar.md
@@ -137,7 +137,7 @@ const data = [
 - **`key`** — Category accessor (a field name or a function)
 - **`value`** — Numeric value accessor; encoded as the arc length
 - **`label`** — Optional label accessor (defaults to `key`)
-- **`color`** — Optional per-category color accessor
+- **`colorBy`** — Optional per-category color accessor
 - **`maxValue`** — Value mapped to a full sweep (defaults to the data maximum)
 - **`innerRadius`** — Inner hole radius as a ratio of the chart size (default `0.2`)
 - **`range`** — Angular sweep of a full-value bar in degrees (default `360`)

--- a/app/src/charts/realtime.md
+++ b/app/src/charts/realtime.md
@@ -51,8 +51,8 @@ const speed = ref('300');
 let intervalId: ReturnType<typeof setInterval> | null = null;
 
 const seriesMeta = [
-    { id: 'cpu', label: 'CPU %', showArea: true, areaOpacity: 0.15 },
-    { id: 'memory', label: 'Memory %', showArea: true, areaOpacity: 0.15 },
+    { id: 'cpu', label: 'CPU %', showArea: true, fillOpacity: 0.15 },
+    { id: 'memory', label: 'Memory %', showArea: true, fillOpacity: 0.15 },
     { id: 'network', label: 'Network MB/s', showArea: false, lineWidth: 1.5 },
 ];
 
@@ -77,7 +77,7 @@ function getSeries() {
         id: s.id,
         label: s.label,
         showArea: s.showArea,
-        areaOpacity: s.areaOpacity,
+        fillOpacity: s.fillOpacity,
         lineWidth: s.lineWidth,
         color: config.colors[s.id],
     }));
@@ -182,7 +182,7 @@ chart.clear();
 
 ## Options
 
-- **`series`** — Array of series with `id`, `label`, optional `color`, `lineType`, `lineWidth`, `showArea`, `areaOpacity`
+- **`series`** — Array of series with `id`, `label`, optional `color`, `lineType`, `lineWidth`, `showArea`, `fillOpacity`
 - **`windowSize`** — Maximum visible data points (default `60`)
 - **`transitionDuration`** — Transition duration per update in ms (default `300`)
 - **`grid`** — `boolean | ChartGridOptions` — Show/configure grid lines (default `true`)

--- a/app/src/charts/shared-options.md
+++ b/app/src/charts/shared-options.md
@@ -113,8 +113,14 @@ createLineChart('#container', {
 | `font` | `string` | `'12px sans-serif'` | Label font |
 | `fontColor` | `string` | `'#777777'` | Label color |
 | `title` | `string` | — | Axis title text |
-| `value` | `keyof TData \| (item: TData) => any` | — | Custom value accessor |
-| `format` | `'number' \| 'percentage' \| 'date' \| 'string' \| (value) => string` | — | Label formatter |
+| `format` | `'number' \| 'percentage' \| 'date' \| 'string' \| Intl.NumberFormat options \| (value) => string` | — | Label formatter |
+| `scale` | `'linear' \| 'log' \| 'pow' \| 'sqrt'` | `'linear'` | Value-axis scale family |
+| `nice` | `boolean \| number` | `true` | Expand the domain to tick-aligned bounds |
+| `ticks` | `number` | `10` | Target number of ticks and grid lines |
+| `min` | `number` | — | Explicit lower bound (overrides the data extent) |
+| `max` | `number` | — | Explicit upper bound (overrides the data extent) |
+| `base` | `number` | `10` | Log base (when `scale: 'log'`) |
+| `exponent` | `number` | `1` | Power exponent (when `scale: 'pow'`) |
 
 ### Y-Axis Options
 
@@ -135,6 +141,9 @@ axis: {
     ],
 }
 ```
+
+> [!NOTE]
+> A secondary y-axis is on the 1.0 roadmap — today only the first y-axis in the array is rendered.
 
 ### Format Types
 

--- a/app/src/charts/treemap.md
+++ b/app/src/charts/treemap.md
@@ -92,6 +92,6 @@ const chart = createTreemapChart('#container', {
 - **`key`** — Unique key accessor
 - **`value`** — Value accessor (determines rectangle area)
 - **`label`** — Label accessor (displayed inside cells)
-- **`color`** — Optional color accessor
+- **`colorBy`** — Optional per-item color accessor
 - **`gap`** — Gap between cells in pixels (default `3`)
 - **`borderRadius`** — Cell corner radius (default `4`)

--- a/app/src/charts/trend.md
+++ b/app/src/charts/trend.md
@@ -100,7 +100,7 @@ function getSeries(): TrendChartSeriesOptions<SalesRow>[] {
         label: s.label,
         value: s.value,
         color: config.colors[s.id],
-        ...(s.type === 'area' ? { opacity: 0.25 } : {}),
+        ...(s.type === 'area' ? { fillOpacity: 0.25 } : {}),
         ...(s.type === 'bar' ? {} : { lineType: lineType.value }),
     })) as TrendChartSeriesOptions<SalesRow>[];
 }
@@ -252,7 +252,7 @@ createTrendChart('#container', {
 - **`data`** — The data array shared by all series
 - **`series`** — Array of series, each a discriminated union on `type`:
   - **`type: 'line'`** — `id`, `value`, `label`, optional `color`, `lineType`, `lineWidth`, `lineStyle` (`'solid'` \| `'dashed'` \| `'dotted'` \| custom dash array), `markers`, `markerRadius`
-  - **`type: 'area'`** — as line, plus `opacity` (fill opacity, default `0.3`); unstacked areas paint largest-first
+  - **`type: 'area'`** — as line, plus `fillOpacity` (fill opacity, default `0.3`); unstacked areas paint largest-first
   - **`type: 'bar'`** — `id`, `value`, `label`, optional `color`
 - **`key`** — Key accessor for the categorical x-axis
 - **`stacked`** — Stack same-type series (default `false`)

--- a/app/src/demos/product-analytics/components/error-rate-gauge.vue
+++ b/app/src/demos/product-analytics/components/error-rate-gauge.vue
@@ -51,14 +51,14 @@ function buildChart() {
 
     const options = {
         value,
-        min: 0,
-        max: 5,
+        minValue: 0,
+        maxValue: 5,
         label: 'Error Rate',
         color: errorColor(value),
-        formatValue: (v: number) => `${v.toFixed(2)}%`,
+        format: (v: number) => `${v.toFixed(2)}%`,
         tickCount: 5,
         showTickLabels: true,
-        formatTickLabel: (v: number) => `${v}%`,
+        formatTick: (v: number) => `${v}%`,
         padding: {
             top: 20,
             right: 20,

--- a/app/src/demos/product-analytics/components/feature-adoption-chart.vue
+++ b/app/src/demos/product-analytics/components/feature-adoption-chart.vue
@@ -63,7 +63,7 @@ function buildChart() {
         },
         grid: true,
         legend: true,
-        mode: 'grouped' as const,
+        stacked: false,
         borderRadius: 4,
         // Show the count on top of each bar, and format axis/tooltip values as whole numbers.
         labels: true,

--- a/app/src/demos/product-analytics/components/retention-heatmap.vue
+++ b/app/src/demos/product-analytics/components/retention-heatmap.vue
@@ -50,12 +50,12 @@ function buildChart() {
 
     const options = {
         data,
-        xBy: 'week' as const,
-        yBy: 'cohort' as const,
+        keyX: 'week' as const,
+        keyY: 'cohort' as const,
         value: 'retention' as const,
         xCategories: weeks,
         yCategories: cohorts,
-        colorRange: ['#dbeafe', '#1d4ed8'] as [string, string],
+        colors: ['#dbeafe', '#1d4ed8'] as [string, string],
         borderRadius: 4,
         axis: {
             x: { title: 'Weeks Since Signup' },

--- a/packages/charts/ROADMAP.md
+++ b/packages/charts/ROADMAP.md
@@ -1,0 +1,190 @@
+# @ripl/charts — 1.0 Gap Analysis & Roadmap
+
+This document tracks Ripl's charting library toward a 1.0 release: a feature-gap
+analysis against the leading general-purpose charting libraries (Chart.js, Apache
+ECharts, Highcharts), the cross-chart consistency audit, and the prioritized work
+remaining. It is the reference for anyone picking up the next slice of 1.0 work.
+
+## Where Ripl already stands
+
+Ripl ships an unusually broad surface for a pre-1.0 library:
+
+- **25 chart types** — bar, line, area, scatter, histogram, box-plot, trend
+  (bar+line+area combo), pie/donut, polar-area, radial-bar, radar, gauge,
+  polar-scatter, sunburst, funnel, treemap, packed-circle, heatmap, chord,
+  sankey, arc-diagram, force-directed, stock (OHLC/candlestick), realtime.
+- **11+ D3-class scales** in `@ripl/core` — continuous (linear), band, point,
+  ordinal, discrete, diverging, logarithmic, power/sqrt, quantile, quantize,
+  threshold, time — plus sequential/diverging **colour** scales with perceptual
+  schemes (viridis/plasma/inferno/magma/cividis/turbo, RdBu, BrBG).
+- **Multi-backend rendering** behind one `Context` — Canvas, SVG, Terminal, and
+  experimental WebGL/WebGPU. This exceeds Chart.js (canvas-only) and matches or
+  edges ECharts (canvas+svg) and Highcharts (svg).
+- **Path-morphing animation**, a pan/zoom/brush `Navigator`, and a statistics
+  layer (binning, box-plot stats, linear regression, KDE, rollup, stacking).
+
+So the barrier to a credible 1.0 is **depth and consistency**, not breadth.
+
+## Feature gap analysis vs Chart.js / ECharts / Highcharts
+
+Legend: ✅ strong · 🟡 partial / not-exposed · ❌ missing. The **Status** column
+notes where this repo now stands after the 1.0 consistency work (see
+[Completed](#completed-1.0-consistency-work)) and which roadmap item closes the gap.
+
+| Capability | Ripl | Chart.js | ECharts | Highcharts | Status |
+|---|---|---|---|---|---|
+| Chart-type breadth | ✅ 25 incl. exotic | 🟡 core + plugins | ✅ | ✅ | ✅ done |
+| Multi-backend (canvas/svg/terminal/webgpu) | ✅ unique | ❌ canvas | 🟡 canvas+svg | 🟡 svg | ✅ done |
+| Scale types available | ✅ 11 + colour | 🟡 | ✅ | ✅ | ✅ done |
+| **Configurable axis scale** (log/time/pow/nice/min-max/ticks) | 🟡→✅ | ✅ | ✅ | ✅ | ✅ done (A4) |
+| Multiple / secondary axes | ❌ typed, unimplemented | ✅ | ✅ | ✅ | ⏳ A6 |
+| Stacking / **100%-stacked** | ✅ / ❌ | ✅/✅ | ✅/✅ | ✅/✅ | ⏳ B4 |
+| Legends (present + interactive toggle) | 🟡 | ✅ | ✅ | ✅ | ⏳ A7 |
+| Shared axis-pointer tooltip | 🟡 per-element | 🟡 | ✅ | ✅ | ⏳ B4 |
+| Data labels | 🟡 uneven | 🟡 (plugin) | ✅ | ✅ | ⏳ A7/B4 |
+| **Annotations** (reference lines / bands / markers) | ❌ | 🟡 (plugin) | ✅ | ✅ | ⏳ B2 |
+| Zoom / pan / data-zoom | ✅ Navigator | 🟡 (plugin) | ✅ | ✅ | ✅ done |
+| **Theming / dark mode** | ❌ (docs only) | 🟡 | ✅ built-in | ✅ | ⏳ B1 |
+| **Accessibility** (ARIA / keyboard / patterns) | ❌ | 🟡 | ✅ | ✅ module | ⏳ B3 |
+| Export (png / svg / …) | ✅ | 🟡 | ✅ | ✅ | ✅ done |
+| Animation | ✅ path-morphing | ✅ | ✅ | ✅ | ✅ done |
+| Formatting / i18n | 🟡→✅ Intl | 🟡 | ✅ | ✅ | ✅ mostly (A2) |
+| Responsive demos | 🟡→✅ | ✅ | ✅ | ✅ | ✅ done (A1) |
+| Real-time / streaming | ✅ realtime chart | 🟡 | 🟡 | 🟡 | ✅ done |
+| **API consistency across chart types** | ❌→✅ | ✅ | ✅ | ✅ | ✅ done (A3) |
+
+**Headline 1.0 gaps:** cross-chart consistency (done), configurable axes (done),
+theming/dark mode (B1), annotations (B2), multiple axes (A6), and accessibility
+(B3 — objectively the largest gap; scoped post-1.0).
+
+## Completed 1.0 consistency work
+
+Landed on `claude/ripl-chart-gap-analysis-rmiuy1`:
+
+- **A1 — Demo UX.** The docs demo wrapper (`app/.../example.vue`) now right-aligns
+  the Export button and uses a mobile-first aspect ratio (`4/3` on phones, `16/9`
+  at ≥640px) so charts aren't squashed on small screens.
+- **A2 — Formatting foundation.** Removed the duplicate charts-local `formatNumber`
+  in favour of the Intl-based `@ripl/utilities` one; widened `ValueFormatInput` to
+  accept Intl number-format options (`{ style: 'currency', currency: 'USD' }`,
+  `{ notation: 'compact' }`, …) on any `format`/axis `format`.
+- **A3 — Option-naming unification** (breaking, see [Migration](#migration--breaking-changes)).
+- **A4 — Configurable scales + axes.** Every axis accepts `scale`
+  (`linear`/`log`/`pow`/`sqrt`), `nice`, `ticks`, `min`, `max`, `base`, `exponent`
+  via `core/scales.ts` (`createValueScale`, `axisTickCount`). The hard-coded
+  `ticks(10)` is gone from bar/line/area/scatter/box-plot.
+- **A7 (partial) — ColorLegend.** The previously-orphaned `ColorLegend` is wired
+  into `heatmap` (gradient legend, `legend?` toggle) and heatmap gained a
+  `format?` hook.
+
+## Migration — breaking changes
+
+Ripl is pre-1.0, so option naming was unified with a **clean break** (no aliases).
+Update call sites as follows:
+
+| Chart | Before | After |
+|---|---|---|
+| box-plot | `group` | `key` |
+| heatmap | `xBy` / `yBy` | `keyX` / `keyY` |
+| heatmap | `colorRange` | `colors` |
+| radar | `axes: string[]` | `categories: string[]` |
+| pie, polar-area, radial-bar, treemap, funnel, packed-circle, gantt | per-item `color` (accessor) | `colorBy` |
+| polar-scatter | `maxRadiusValue` | `maxValue` |
+| gauge | `min` / `max` | `minValue` / `maxValue` |
+| gauge | `formatValue` / `formatTickLabel` | `format` / `formatTick` (now `ValueFormatInput`) |
+| polar-area | `innerRadiusRatio` | `innerRadius` (0–1 fraction) |
+| bar | `mode: 'grouped' \| 'stacked'` | `stacked?: boolean` (`BarChartMode` removed) |
+| area, radar, trend, realtime | series `opacity` / `areaOpacity` | series `fillOpacity` |
+
+Retained (intentionally, documented as exceptions): scatter series `xBy`/`yBy`
+(numeric position accessors, not category keys); network-chart `source`/`target`
+and node `id`/`group`; hierarchical node `color` fields; `upColor`/`downColor`
+(stock), `trackColor` (gauge, radial-bar), `todayColor` (gantt).
+
+## Roadmap — remaining 1.0 work
+
+Ordered by priority. Each item's detailed design lives in the implementation plan;
+this is the executable summary.
+
+### A5 — Class-hierarchy consolidation (stock / gantt / realtime)
+
+Only 7 of the axis charts extend `CartesianChart`; **stock**, **gantt**, and
+**realtime** extend `Chart` and hand-roll axis/grid/crosshair/tooltip wiring, so
+they miss the navigator, overview strip, plot clipping, configurable scales (A4),
+and formatting for free.
+
+- Extract `createChartAxes(scene, renderer, axis, setup)` from `setupCartesian`
+  (a no-op refactor first, as a regression guard).
+- Migrate **stock** and **gantt** onto `CartesianChart` (candles/wicks/volume and
+  task-bars/today-marker move into `addPlotContent`; bespoke scales retained).
+- Helper-share for **realtime** (sliding-window) and **heatmap** (dual categorical)
+  — they call `createChartAxes` directly rather than fully inheriting.
+- **Risk:** regressions in bespoke rendering — verify candles/task-bars visually.
+
+### A6 — Multiple / secondary axes
+
+`ChartAxisOptions.y` is already typed as an array but every consumer collapses to
+`y[0]`. Implement a real secondary y-axis:
+
+- `ChartYAxisItemOptions` gains `id?`; bar/line/area/scatter series gain
+  `axis?: number | string`.
+- `CartesianChart` holds `yAxes: ChartYAxis[]` with a `get yAxis()` shim (single-axis
+  charts stay inert), groups series by axis, computes a per-axis extent + scale, and
+  reserves a right-hand band for the secondary axis.
+- **Risk:** layout collision between a right-side second axis and a right-positioned
+  legend; per-axis extent isolation. Land `line` first, then area/bar/scatter.
+
+### A7 (remaining) — Legend completeness
+
+Add a `legend?` option where it's missing and meaningful:
+
+- Category `Legend` (via `Chart.reserveLegend`, mirroring `pie`) on **funnel**,
+  **treemap**, **packed-circle**, and node-group legends on **sankey**,
+  **arc-diagram**, **force-directed**.
+- Single-value / single-distribution charts (gauge, histogram, box-plot, stock,
+  gantt) legitimately omit a categorical legend.
+- Consider **interactive legends** (click to toggle a series) — currently only
+  hover-dim highlighting is supported.
+
+### Formatting completeness
+
+Add a `format?: ValueFormatInput` hook (as done for heatmap) to **stock**,
+**gantt**, **sankey**, and **realtime**, routing their value/tooltip/axis text
+through `resolveValueFormat(options.format)` instead of the current fixed
+2-decimal formatting.
+
+### B1 — Theming + dark mode (1.0 must-have)
+
+- New `core/theme.ts`: a `Theme` (categorical palette; sequential/diverging schemes;
+  background; text/axis/grid/tick colours; tooltip styling; font) + registry, with
+  built-in `lightTheme`/`darkTheme` (reuse `core/color/schemes.ts`).
+- `createXChart(target, { theme: 'light' | 'dark' | 'auto' | Theme })`; the base
+  `Chart` threads the theme into the *currently hardcoded* defaults (axis
+  `fontColor: '#777'`, tooltip colours, grid colour, the 12-colour palette).
+- Global `setDefaultTheme(theme)`; `'auto'` follows `prefers-color-scheme`.
+
+### B2 — Annotations layer (1.0 must-have)
+
+- New `components/annotation.ts`: **reference line** (value on x/y + label),
+  **band/region** (`from`/`to` on an axis — threshold/target zones), **point marker**.
+- Expose `annotations?: ChartAnnotation[]` on `CartesianChartOptions`; resolve through
+  axis scales, clip to the plot, animate on update, track pan/zoom via the Navigator.
+- Parity with ECharts `markLine`/`markArea`/`markPoint` and Highcharts
+  `plotLines`/`plotBands`.
+
+### B3 — Accessibility (post-1.0; largest objective gap)
+
+- ARIA: root `role="img"`/`figure` + `aria-label`/description; optional
+  visually-hidden data-table fallback for screen readers.
+- Keyboard nav: focusable series/points, arrow traversal, Enter → existing `click`.
+- Colorblind: pattern/decal fill generator + CVD-safe default palette (cividis/viridis
+  are already available).
+
+### B4 — Smaller primitive gaps (opportunistic)
+
+Radial/angular scale (`scaleRadial`) so polar charts stop hand-rolling; `scaleSymlog`
+and a UTC time scale; an optional d3-format specifier parser; a marker-symbol set
+(star/cross/triangle/diamond/wye) beyond `Circle`; a **100%-stacked** helper
+(extend `computeStackOffset`); time-series **downsampling** (LTTB) for realtime/large
+data; an expanded easing set (sine/expo/circ/bounce); a moving-average/smoothing data
+transform; a shared/synced axis-pointer tooltip.

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -97,7 +97,7 @@ export interface AreaChartSeriesOptions<TData> {
     /** Width in pixels of the series line. */
     lineWidth?: number;
     /** Fill opacity of the area band. Defaults to 0.3. */
-    opacity?: number;
+    fillOpacity?: number;
     /** Show point markers at each data value. Defaults to true. */
     markers?: boolean;
 }

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -35,6 +35,11 @@ import {
 } from '../core/data';
 
 import {
+    axisTickCount,
+    createValueScale,
+} from '../core/scales';
+
+import {
     AreaSeriesRenderer,
 } from '../core/series/area-series';
 
@@ -66,7 +71,6 @@ import type {
 import {
     Box,
     getExtent,
-    scaleContinuous,
 } from '@ripl/core';
 
 import {
@@ -264,7 +268,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             const right = area.x + area.width;
             const bottom = area.y + area.height;
 
-            this._yScale = scaleContinuous(dataExtent, [bottom, top], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, dataExtent, [bottom, top]);
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds = new Box(top, left, bottom, right);
 
@@ -276,7 +280,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
 
             const xAxisBox = this.xAxis.getBoundingBox();
 
-            this._yScale = scaleContinuous(dataExtent, [xAxisBox.top, top], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, dataExtent, [xAxisBox.top, top]);
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds.bottom = xAxisBox.top;
 
@@ -293,7 +297,7 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             };
 
             this.clipPlot(plot);
-            this.renderGrid([], this._yScale.ticks(10).map(tick => this._yScale(tick)), plot);
+            this.renderGrid([], this._yScale.ticks(axisTickCount(this.yAxisOptions)).map(tick => this._yScale(tick)), plot);
             this.setupCrosshair(plot);
 
             const seriesRender = this._series.render(series, this._seriesContext(plot));

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -71,8 +71,6 @@ import {
 
 /** Whether bars are laid out vertically (default) or horizontally. */
 export type BarChartOrientation = 'vertical' | 'horizontal';
-/** Whether multiple series are drawn side by side (`grouped`) or accumulated into one column (`stacked`). */
-export type BarChartMode = 'grouped' | 'stacked';
 
 /** Maps a pointer interaction phase to the corresponding bar-chart event name. */
 const BAR_EVENTS = {
@@ -103,8 +101,8 @@ export interface BarChartOptions<TData = unknown> extends CartesianChartOptions<
     key: keyof TData | ((item: TData) => string);
     /** Whether bars run vertically (default) or horizontally. */
     orientation?: BarChartOrientation;
-    /** Whether multiple series are grouped side by side (default) or stacked. */
-    mode?: BarChartMode;
+    /** Whether multiple series are stacked into a single bar per category (`true`) or grouped side by side (default `false`). */
+    stacked?: boolean;
     /** Background grid configuration (`true`/`false` or detailed grid options). */
     grid?: ChartGridInput;
     /** Hover tooltip configuration (`true`/`false` or detailed tooltip options). */
@@ -178,7 +176,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
     }
 
     private get _isStacked() {
-        return this.options.mode === 'stacked';
+        return this.options.stacked === true;
     }
 
     /** Bar charts window their category axis: y when horizontal (side strip), x otherwise (bottom strip). */

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -30,6 +30,11 @@ import {
 } from '../core/data';
 
 import {
+    axisTickCount,
+    createValueScale,
+} from '../core/scales';
+
+import {
     BarSeriesRenderer,
 } from '../core/series/bar-series';
 
@@ -62,7 +67,6 @@ import {
     Box,
     getExtent,
     scaleBand,
-    scaleContinuous,
 } from '@ripl/core';
 
 import {
@@ -271,7 +275,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
             if (this._isHorizontal) {
                 // Categories on Y, values on X.
-                const valueScale = scaleContinuous(dataExtent, [left, right], { padToTicks: 10 });
+                const valueScale = createValueScale(this.xAxisOptions, dataExtent, [left, right]);
 
                 this.xAxis.scale = valueScale;
                 this.xAxis.bounds = new Box(top, left, bottom, right);
@@ -288,7 +292,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
                 const yAxisBox = this.yAxis.getBoundingBox();
 
-                const adjustedValueScale = scaleContinuous(dataExtent, [yAxisBox.right, right], { padToTicks: 10 });
+                const adjustedValueScale = createValueScale(this.xAxisOptions, dataExtent, [yAxisBox.right, right]);
                 this.xAxis.scale = adjustedValueScale;
                 this.xAxis.bounds = new Box(top, yAxisBox.right, bottom, right);
 
@@ -307,7 +311,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
                 this.clipPlot(horizontalPlot);
 
                 this.renderGrid(
-                    adjustedValueScale.ticks(10).map(tick => adjustedValueScale(tick)),
+                    adjustedValueScale.ticks(axisTickCount(this.xAxisOptions)).map(tick => adjustedValueScale(tick)),
                     [],
                     horizontalPlot
                 );
@@ -325,7 +329,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             }
 
             // Categories on X, values on Y.
-            const valueScale = scaleContinuous(dataExtent, [bottom, top], { padToTicks: 10 });
+            const valueScale = createValueScale(this.yAxisOptions, dataExtent, [bottom, top]);
 
             this.yAxis.scale = valueScale;
             this.yAxis.bounds = new Box(top, left, bottom, right);
@@ -342,7 +346,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
             const xAxisBox = this.xAxis.getBoundingBox();
 
-            const adjustedValueScale = scaleContinuous(dataExtent, [xAxisBox.top, top], { padToTicks: 10 });
+            const adjustedValueScale = createValueScale(this.yAxisOptions, dataExtent, [xAxisBox.top, top]);
             this.yAxis.scale = adjustedValueScale;
             this.yAxis.bounds = new Box(top, left, xAxisBox.top, right);
 
@@ -362,7 +366,7 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
 
             this.renderGrid(
                 [],
-                adjustedValueScale.ticks(10).map(tick => adjustedValueScale(tick)),
+                adjustedValueScale.ticks(axisTickCount(this.yAxisOptions)).map(tick => adjustedValueScale(tick)),
                 verticalPlot
             );
 

--- a/packages/charts/src/charts/box-plot.ts
+++ b/packages/charts/src/charts/box-plot.ts
@@ -40,6 +40,11 @@ import {
 } from '../core/data';
 
 import {
+    axisTickCount,
+    createValueScale,
+} from '../core/scales';
+
+import {
     boxplotStats,
     rollup,
 } from '../core/statistics';
@@ -69,7 +74,6 @@ import {
     createLine,
     createRect,
     getExtent,
-    scaleContinuous,
     setColorAlpha,
 } from '@ripl/core';
 
@@ -377,9 +381,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
             const right = area.x + area.width;
             const bottom = area.y + area.height;
 
-            const valueScale = scaleContinuous(valueExtent, [bottom, top], {
-                nice: true,
-            });
+            const valueScale = createValueScale(this.yAxisOptions, valueExtent, [bottom, top]);
 
             this.yAxis.scale = valueScale;
             this.yAxis.bounds = new Box(top, left, bottom, right);
@@ -392,9 +394,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
 
             const xAxisBox = this.xAxis.getBoundingBox();
 
-            const adjustedValueScale = scaleContinuous(valueExtent, [xAxisBox.top, top], {
-                nice: true,
-            });
+            const adjustedValueScale = createValueScale(this.yAxisOptions, valueExtent, [xAxisBox.top, top]);
             this.yAxis.scale = adjustedValueScale;
             this.yAxis.bounds = new Box(top, left, xAxisBox.top, right);
 
@@ -416,7 +416,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
 
             this.renderGrid(
                 [],
-                viewedValueScale.ticks(10).map(tick => viewedValueScale(tick)),
+                viewedValueScale.ticks(axisTickCount(this.yAxisOptions)).map(tick => viewedValueScale(tick)),
                 plot
             );
 

--- a/packages/charts/src/charts/box-plot.ts
+++ b/packages/charts/src/charts/box-plot.ts
@@ -85,7 +85,7 @@ export interface BoxPlotChartOptions<TData = unknown> extends CartesianChartOpti
     /** The dataset summarised by the chart. */
     data: TData[];
     /** Accessor for the category each value belongs to. */
-    group: keyof TData | ((item: TData) => string);
+    key: keyof TData | ((item: TData) => string);
     /** Accessor for the numeric value to summarise. */
     value: NumericAccessor<TData>;
     /** Explicit category order (defaults to first-seen order in the data). */
@@ -347,7 +347,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
         return super.render(async () => {
             const {
                 data,
-                group,
+                key,
                 value,
                 categories,
             } = this.options;
@@ -360,7 +360,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
             ]);
             this.prepareAxes();
 
-            const getGroup = resolveAccessor<TData, string>(group);
+            const getGroup = resolveAccessor<TData, string>(key);
             const getValue = resolveAccessor<TData, number>(value);
             const color = this.getSeriesColor('boxplot');
 
@@ -660,7 +660,7 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
  *         { team: 'A', score: 91 },
  *         { team: 'B', score: 74 },
  *     ],
- *     group: 'team',
+ *     key: 'team',
  *     value: 'score',
  * });
  * ```

--- a/packages/charts/src/charts/funnel.ts
+++ b/packages/charts/src/charts/funnel.ts
@@ -31,6 +31,10 @@ import {
 } from '../core/animation';
 
 import {
+    resolveColorBy,
+} from '../core/color';
+
+import {
     Tooltip,
 } from '../components/tooltip';
 
@@ -69,8 +73,8 @@ export interface FunnelChartOptions<TData = unknown> extends BaseChartOptions {
     value: NumericAccessor<TData>;
     /** Accessor for each segment's display label. */
     label: keyof TData | ((item: TData) => string);
-    /** Accessor for an explicit per-segment colour; falls back to the generated palette. */
-    color?: keyof TData | ((item: TData) => string);
+    /** Optional per-item colour accessor; falls back to the generated palette. */
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Vertical gap in pixels between segments. Defaults to 4. */
     gap?: number;
     /** Corner radius in pixels applied to each segment. Defaults to 4. */
@@ -136,7 +140,7 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
                 key,
                 value,
                 label,
-                color,
+                colorBy,
                 gap = 4,
                 borderRadius = 4,
             } = this.options;
@@ -148,12 +152,7 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const getLabel = typeIsFunction(label) ? label : (item: any) => item[label] as string;
 
-            let getColor: ((item: TData) => string) | undefined;
-
-            if (color) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                getColor = typeIsFunction(color) ? color : (item: any) => item[color] as string;
-            }
+            const getColor = resolveColorBy<TData>(colorBy);
 
             // Find max value for width scaling
             let maxValue = 0;
@@ -175,14 +174,14 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
             // updates instead of being reassigned from the generator on every render.
             this.resolveSeriesColors(data.map(item => ({
                 id: getKey(item),
-                color: getColor ? getColor(item) : undefined,
+                color: getColor(item),
             })));
 
             const calculations = data.map((item, index) => {
                 const itemKey = getKey(item);
                 const itemValue = getValue(item);
                 const itemLabel = getLabel(item);
-                const itemColor = getColor ? getColor(item) : undefined;
+                const itemColor = getColor(item);
                 const widthRatio = itemValue / (maxValue || 1);
                 const segmentWidth = availableWidth * widthRatio;
                 const x = area.x + (availableWidth - segmentWidth) / 2;

--- a/packages/charts/src/charts/gantt.ts
+++ b/packages/charts/src/charts/gantt.ts
@@ -34,6 +34,10 @@ import {
 } from '../core/animation';
 
 import {
+    resolveColorBy,
+} from '../core/color';
+
+import {
     ChartXAxis,
     ChartYAxis,
 } from '../components/axis';
@@ -86,8 +90,8 @@ export interface GanttChartOptions<TData = unknown> extends BaseChartOptions {
     start: keyof TData | ((item: TData) => Date);
     /** Accessor for each task's end date. */
     end: keyof TData | ((item: TData) => Date);
-    /** Accessor for an explicit per-task colour; falls back to the generated palette. */
-    color?: keyof TData | ((item: TData) => string);
+    /** Optional per-item colour accessor; falls back to the generated palette. */
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Accessor for each task's completion ratio (0–1), drawn as a progress overlay. */
     progress?: NumericAccessor<TData>;
     /** Background grid configuration (`true`/`false` or detailed grid options). */
@@ -224,13 +228,13 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
             data,
             start: startAccessor,
             end: endAccessor,
-            color: colorAccessor,
+            colorBy,
             progress: progressAccessor,
         } = this.options;
 
         const getStart = this._getAccessor<Date>(startAccessor);
         const getEnd = this._getAccessor<Date>(endAccessor);
-        const getColor = colorAccessor ? this._getAccessor<string>(colorAccessor) : undefined;
+        const getColor = resolveColorBy<TData>(colorBy);
         const getProgress = progressAccessor ? this._getAccessor<number>(progressAccessor) : undefined;
         const borderRadius = this.options.borderRadius ?? 3;
 
@@ -240,9 +244,7 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
             const start = getStart(item);
             const end = getEnd(item);
 
-            const color = getColor
-                ? getColor(item)
-                : this.getSeriesColor(key);
+            const color = getColor(item) ?? this.getSeriesColor(key);
 
             const x = timeScale(start);
             const width = Math.max(timeScale(end) - timeScale(start), 2);

--- a/packages/charts/src/charts/gauge.ts
+++ b/packages/charts/src/charts/gauge.ts
@@ -6,8 +6,12 @@ import {
     Chart,
 } from '../core/chart';
 
+import type {
+    ValueFormatInput,
+} from '../core/options';
+
 import {
-    formatNumber,
+    resolveValueFormat,
 } from '../core/options';
 
 import {
@@ -51,26 +55,26 @@ import {
 
 /** Options for configuring a {@link GaugeChart}. */
 export interface GaugeChartOptions extends BaseChartOptions {
-    /** The value displayed by the gauge (clamped to `min`–`max`). */
+    /** The value displayed by the gauge (clamped to `minValue`–`maxValue`). */
     value: number;
     /** Lower bound of the gauge scale. Defaults to 0. */
-    min?: number;
+    minValue?: number;
     /** Upper bound of the gauge scale. Defaults to 100. */
-    max?: number;
+    maxValue?: number;
     /** Optional descriptive text shown below the value. */
     label?: string;
     /** Colour of the value arc. */
     color?: string;
     /** Colour of the background track arc. */
     trackColor?: string;
-    /** Format function for the central value display. */
-    formatValue?: (value: number) => string;
+    /** How the central value display is formatted — a built-in format type, Intl number-format options, or a custom function. */
+    format?: ValueFormatInput;
     /** Number of tick marks along the gauge arc. Defaults to 5. Set to 0 to hide. */
     tickCount?: number;
     /** Whether to show value labels at each tick. Defaults to true. */
     showTickLabels?: boolean;
-    /** Format function for tick labels */
-    formatTickLabel?: (value: number) => string;
+    /** How tick labels are formatted. Defaults to {@link GaugeChartOptions.format}. */
+    formatTick?: ValueFormatInput;
 }
 
 /** Payload emitted for gauge value interaction events. */
@@ -133,12 +137,12 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
         return super.render(async (scene, renderer) => {
             const {
                 value,
-                min = 0,
-                max = 100,
+                minValue = 0,
+                maxValue = 100,
                 label,
                 color = DEFAULT_COLOR,
                 trackColor = DEFAULT_TRACK_COLOR,
-                formatValue,
+                format,
             } = this.options;
 
             const layout = this.createLayout();
@@ -154,9 +158,9 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
             // Gauge spans from -135deg to +135deg (270 degrees total)
             const startAngle = Math.PI * 0.75;
             const endAngle = Math.PI * 2.25;
-            const range = max - min;
-            const clampedValue = clamp(value, min, max);
-            const valueAngle = startAngle + ((clampedValue - min) / range) * (endAngle - startAngle);
+            const range = maxValue - minValue;
+            const clampedValue = clamp(value, minValue, maxValue);
+            const valueAngle = startAngle + ((clampedValue - minValue) / range) * (endAngle - startAngle);
 
             const isEntry = !this._group;
 
@@ -226,7 +230,8 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
 
             // --- Value text ---
             // Format a (possibly fractional, mid-animation) value, capping precision at 2 decimals.
-            const formatDisplay = (v: number) => (formatValue ? formatValue(roundTo(v, 2)) : formatNumber(v));
+            const resolveDisplay = resolveValueFormat(format);
+            const formatDisplay = (v: number) => resolveDisplay(roundTo(v, 2));
             // The value the text counts up/down *from* on a data update (the previously shown value).
             const displayFrom = this._currentValue ?? clampedValue;
             const displayValue = formatDisplay(clampedValue);
@@ -298,7 +303,7 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
             // --- Tick marks and labels --- reconciled via arrayJoin so tick count can change.
             const tickCount = this.options.tickCount ?? 5;
             const showTickLabels = this.options.showTickLabels !== false;
-            const formatTickLabel = this.options.formatTickLabel;
+            const formatTick = resolveValueFormat(this.options.formatTick ?? this.options.format);
 
             // Ticks only move when the centre/radius/count/label-visibility changes — not on a plain
             // value update — so a value change animates only the arc and the centre number.
@@ -317,7 +322,7 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
             const tickGeometry = (i: number) => {
                 const t = i / tickCount;
                 const tickAngle = startAngle + t * (endAngle - startAngle);
-                const tickValue = min + t * range;
+                const tickValue = minValue + t * range;
 
                 return {
                     tickAngle,
@@ -390,7 +395,7 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
                     x: cx + labelRadius * Math.cos(tickAngle),
                     y: cy + labelRadius * Math.sin(tickAngle),
                     textAlign,
-                    content: formatTickLabel ? formatTickLabel(tickValue) : formatNumber(tickValue),
+                    content: formatTick(tickValue),
                 };
             };
 
@@ -519,8 +524,8 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
  * ```ts
  * createGaugeChart(target, {
  *     value: 68,
- *     min: 0,
- *     max: 100,
+ *     minValue: 0,
+ *     maxValue: 100,
  *     label: 'CPU',
  * });
  * ```

--- a/packages/charts/src/charts/heatmap.ts
+++ b/packages/charts/src/charts/heatmap.ts
@@ -13,6 +13,7 @@ import {
 import type {
     ChartAxisInput,
     ChartTooltipInput,
+    ValueFormatInput,
 } from '../core/options';
 
 import {
@@ -21,7 +22,12 @@ import {
     normalizeTooltip,
     normalizeYAxisItem,
     resolveFormatLabel,
+    resolveValueFormat,
 } from '../core/options';
+
+import type {
+    ChartArea,
+} from '../core/layout';
 
 import {
     applyHoverHighlight,
@@ -39,6 +45,14 @@ import {
 import {
     Tooltip,
 } from '../components/tooltip';
+
+import type {
+    ColorLegendOptions,
+} from '../components/color-legend';
+
+import {
+    ColorLegend,
+} from '../components/color-legend';
 
 import type {
     Context,
@@ -60,7 +74,6 @@ import {
 
 import {
     arrayJoin,
-    formatNumber,
     typeIsFunction,
 } from '@ripl/utilities';
 
@@ -82,6 +95,10 @@ export interface HeatmapChartOptions<TData = unknown> extends BaseChartOptions {
     colors?: string[];
     /** Corner radius in pixels applied to each cell. Defaults to 2. */
     borderRadius?: number;
+    /** Gradient colour legend showing the value→colour scale. Shown by default; pass `false` to hide, or an options object to customise. */
+    legend?: boolean | ColorLegendOptions;
+    /** How cell values are formatted in the tooltip and legend — a built-in format type, Intl options, or a custom function. */
+    format?: ValueFormatInput;
     /** Hover tooltip configuration (`true`/`false` or detailed tooltip options). */
     tooltip?: ChartTooltipInput;
     /** Axis configuration for the x and y axes. */
@@ -129,6 +146,7 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
     private _xAxis!: ChartXAxis;
     private _yAxis!: ChartYAxis;
     private _tooltip!: Tooltip;
+    private _colorLegend?: ColorLegend;
 
     constructor(target: string | HTMLElement | Context, options: HeatmapChartOptions<TData>) {
         super(target, options);
@@ -214,6 +232,32 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
 
             const layout = this.createLayout();
             this.reserveTitle(layout);
+
+            const legendOption = this.options.legend;
+
+            let legendRegion: ChartArea | undefined;
+
+            if (legendOption !== false) {
+                const legendOptions: ColorLegendOptions = {
+                    format: resolveValueFormat(this.options.format),
+                    ...(typeof legendOption === 'object' ? legendOption : {}),
+                };
+
+                if (this._colorLegend) {
+                    this._colorLegend.setScale(colorScale);
+                    this._colorLegend.setOptions(legendOptions);
+                } else {
+                    this._colorLegend = new ColorLegend({
+                        scene: this.scene,
+                        renderer: this.renderer,
+                        scale: colorScale,
+                        options: legendOptions,
+                    });
+                }
+
+                legendRegion = layout.reserveBottom(this._colorLegend.measure());
+            }
+
             const area = layout.area;
             const top = area.y;
             const left = area.x;
@@ -415,6 +459,10 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
                 state: element.data as RectState,
             }));
 
+            if (legendRegion) {
+                this._colorLegend?.render(legendRegion);
+            }
+
             return Promise.all([
                 this._xAxis.render(),
                 this._yAxis.render(),
@@ -448,7 +496,7 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
                 x: cell.x + cell.width / 2,
                 y: cell.y,
             }),
-            content: () => `${cell.xLabel}, ${cell.yLabel}: ${formatNumber(cell.value, { precision: 2 })}`,
+            content: () => `${cell.xLabel}, ${cell.yLabel}: ${resolveValueFormat(this.options.format)(cell.value)}`,
             highlight: { opacity: 0.8 },
             restore: { opacity: 1 },
             onEnter: point => this.emit('cellenter', payload(point)),

--- a/packages/charts/src/charts/heatmap.ts
+++ b/packages/charts/src/charts/heatmap.ts
@@ -16,7 +16,6 @@ import type {
 } from '../core/options';
 
 import {
-    formatNumber,
     normalizeAxis,
     normalizeAxisItem,
     normalizeTooltip,
@@ -61,6 +60,7 @@ import {
 
 import {
     arrayJoin,
+    formatNumber,
     typeIsFunction,
 } from '@ripl/utilities';
 
@@ -69,9 +69,9 @@ export interface HeatmapChartOptions<TData = unknown> extends BaseChartOptions {
     /** The dataset rendered as a grid of cells. */
     data: TData[];
     /** Accessor for each item's x-axis category. */
-    xBy: keyof TData | ((item: TData) => string);
+    keyX: keyof TData | ((item: TData) => string);
     /** Accessor for each item's y-axis category. */
-    yBy: keyof TData | ((item: TData) => string);
+    keyY: keyof TData | ((item: TData) => string);
     /** Accessor for each cell's numeric value (drives its colour). */
     value: NumericAccessor<TData>;
     /** Ordered list of categories along the x axis. */
@@ -79,7 +79,7 @@ export interface HeatmapChartOptions<TData = unknown> extends BaseChartOptions {
     /** Ordered list of categories along the y axis. */
     yCategories: string[];
     /** Colour stops (low→high) interpolated across the value extent; also accepts a built-in palette. */
-    colorRange?: string[];
+    colors?: string[];
     /** Corner radius in pixels applied to each cell. Defaults to 2. */
     borderRadius?: number;
     /** Hover tooltip configuration (`true`/`false` or detailed tooltip options). */
@@ -179,19 +179,19 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
         return super.render(async () => {
             const {
                 data,
-                xBy,
-                yBy,
+                keyX,
+                keyY,
                 value: valueBy,
                 xCategories,
                 yCategories,
-                colorRange,
+                colors,
                 borderRadius = 2,
             } = this.options;
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getX = typeIsFunction(xBy) ? xBy : (item: any) => item[xBy] as string;
+            const getX = typeIsFunction(keyX) ? keyX : (item: any) => item[keyX] as string;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getY = typeIsFunction(yBy) ? yBy : (item: any) => item[yBy] as string;
+            const getY = typeIsFunction(keyY) ? keyY : (item: any) => item[keyY] as string;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const getValue = typeIsFunction(valueBy) ? valueBy : (item: any) => item[valueBy] as number;
 
@@ -208,9 +208,9 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
 
             const valueRange = maxVal - minVal || 1;
 
-            // A sequential colour scale over the value extent. `colorRange` may be two colours (the
+            // A sequential colour scale over the value extent. `colors` may be two colours (the
             // default low→high pair) or any number of stops, including a built-in `COLOR_SCHEME_*` palette.
-            const colorScale = scaleSequential(colorRange ?? DEFAULT_COLOR_RANGE, [minVal, minVal + valueRange]);
+            const colorScale = scaleSequential(colors ?? DEFAULT_COLOR_RANGE, [minVal, minVal + valueRange]);
 
             const layout = this.createLayout();
             this.reserveTitle(layout);
@@ -448,7 +448,7 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
                 x: cell.x + cell.width / 2,
                 y: cell.y,
             }),
-            content: () => `${cell.xLabel}, ${cell.yLabel}: ${formatNumber(cell.value)}`,
+            content: () => `${cell.xLabel}, ${cell.yLabel}: ${formatNumber(cell.value, { precision: 2 })}`,
             highlight: { opacity: 0.8 },
             restore: { opacity: 1 },
             onEnter: point => this.emit('cellenter', payload(point)),
@@ -470,8 +470,8 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
  *         { day: 'Mon', hour: '10', load: 30 },
  *         { day: 'Tue', hour: '9', load: 18 },
  *     ],
- *     xBy: 'hour',
- *     yBy: 'day',
+ *     keyX: 'hour',
+ *     keyY: 'day',
  *     value: 'load',
  *     xCategories: ['9', '10'],
  *     yCategories: ['Mon', 'Tue'],

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -34,6 +34,11 @@ import {
 } from '../core/data';
 
 import {
+    axisTickCount,
+    createValueScale,
+} from '../core/scales';
+
+import {
     LineSeriesRenderer,
 } from '../core/series/line-series';
 
@@ -65,7 +70,6 @@ import type {
 import {
     Box,
     getExtent,
-    scaleContinuous,
 } from '@ripl/core';
 
 import {
@@ -251,7 +255,7 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
             const bottom = area.y + area.height;
 
             // Provisional value scale to measure the y-axis width.
-            this._yScale = scaleContinuous(dataExtent, [bottom, top], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, dataExtent, [bottom, top]);
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds = new Box(top, left, bottom, right);
 
@@ -263,7 +267,7 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
             const xAxisBox = this.xAxis.getBoundingBox();
 
-            this._yScale = scaleContinuous(dataExtent, [xAxisBox.top, top], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, dataExtent, [xAxisBox.top, top]);
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds.bottom = xAxisBox.top;
 
@@ -283,7 +287,7 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
 
             this.renderGrid(
                 [],
-                this._yScale.ticks(10).map(tick => this._yScale(tick)),
+                this._yScale.ticks(axisTickCount(this.yAxisOptions)).map(tick => this._yScale(tick)),
                 plot
             );
 

--- a/packages/charts/src/charts/packed-circle.ts
+++ b/packages/charts/src/charts/packed-circle.ts
@@ -35,6 +35,10 @@ import {
     resolveAccessor,
 } from '../core/data';
 
+import {
+    resolveColorBy,
+} from '../core/color';
+
 import type {
     PackCircle,
 } from '../core/pack';
@@ -82,8 +86,8 @@ export interface PackedCircleChartOptions<TData = unknown> extends BaseChartOpti
     value: NumericAccessor<TData>;
     /** Accessor for each circle's display label; defaults to the item's key. */
     label?: keyof TData | ((item: TData) => string);
-    /** Accessor for an explicit per-circle colour; falls back to the generated palette. */
-    color?: keyof TData | ((item: TData) => string);
+    /** Optional per-item colour accessor; falls back to the generated palette. */
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Format applied to values shown as text (e.g. tooltips). */
     format?: ValueFormatInput;
 }
@@ -181,13 +185,13 @@ export class PackedCircleChart<TData = unknown> extends Chart<PackedCircleChartO
                 key,
                 value,
                 label,
-                color,
+                colorBy,
             } = this.options;
 
             const getKey = resolveAccessor<TData, string>(key);
             const getValue = resolveAccessor<TData, number>(value);
             const getLabel = label !== undefined ? resolveAccessor<TData, string>(label) : getKey;
-            const getColor = (item: TData): string | undefined => (color ? resolveAccessor<TData, string>(color)(item) : undefined);
+            const getColor = resolveColorBy<TData>(colorBy);
 
             this.resolveSeriesColors(data.map(item => ({
                 id: getKey(item),

--- a/packages/charts/src/charts/pie.ts
+++ b/packages/charts/src/charts/pie.ts
@@ -39,6 +39,10 @@ import {
 } from '../core/data';
 
 import {
+    resolveColorBy,
+} from '../core/color';
+
+import {
     Tooltip,
 } from '../components/tooltip';
 
@@ -91,7 +95,7 @@ export interface PieChartOptions<TData = unknown> extends BaseChartOptions {
     /** Accessor for each item's display label (shown in the legend and segment labels). */
     label: keyof TData | ((item: TData) => string);
     /** Optional accessor for a per-item colour override (otherwise a palette colour is generated). */
-    color?: keyof TData | ((item: TData) => string);
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Inner hole radius (donut). A value `<= 1` is a fraction of the outer radius; larger values are absolute pixels. Defaults to 0 (a solid pie). */
     innerRadius?: number;
     /** Legend configuration. Shown by default; pass `false` to hide. */
@@ -158,12 +162,12 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
 
     public async render() {
         return super.render((scene, renderer) => {
-            const { data, key, value, label, color } = this.options;
+            const { data, key, value, label, colorBy } = this.options;
 
             const getKey = resolveAccessor<TData, string>(key);
             const getValue = resolveAccessor<TData, number>(value);
             const getLabel = resolveAccessor<TData, string>(label);
-            const getColor = (item: TData): string | undefined => (color ? resolveAccessor<TData, string>(color)(item) : undefined);
+            const getColor = resolveColorBy<TData>(colorBy);
 
             const labels = normalizeSegmentLabels(this.options.labels);
 

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -17,7 +17,6 @@ import type {
 } from '../core/options';
 
 import {
-    formatNumber,
     normalizeSegmentLabels,
     resolveValueFormat,
 } from '../core/options';
@@ -77,6 +76,7 @@ import {
 
 import {
     arrayJoin,
+    formatNumber,
     typeIsFunction,
 } from '@ripl/utilities';
 
@@ -94,9 +94,9 @@ export interface PolarAreaChartOptions<TData = unknown> extends BaseChartOptions
     /** Accessor for each item's display label (shown in the legend and segment labels). */
     label: keyof TData | ((item: TData) => string);
     /** Optional accessor for a per-item colour override (otherwise a palette colour is generated). */
-    color?: keyof TData | ((item: TData) => string);
-    /** Inner radius ratio (0 - 1). Defaults to 0.15 */
-    innerRadiusRatio?: number;
+    colorBy?: keyof TData | ((item: TData) => string);
+    /** Inner radius as a fraction of the chart size (0 - 1). Defaults to 0.15 */
+    innerRadius?: number;
     /** Maximum radius ratio (0 - 0.5). Defaults to 0.45 (similar to pie chart). */
     maxRadiusRatio?: number;
     /** Padding angle between segments in radians. Defaults to 0.02 */
@@ -253,7 +253,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
 
         const newLabels = labelEntries.map(level => {
             const levelRadius = innerRadius + radiusStep * level;
-            const levelValue = formatNumber((maxValue / levels) * level);
+            const levelValue = formatNumber((maxValue / levels) * level, { precision: 2 });
 
             const label = createText({
                 id: `polar-ring-label-${level}`,
@@ -277,7 +277,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
 
         labelUpdates.forEach(([level, label]) => {
             const levelRadius = innerRadius + radiusStep * level;
-            const levelValue = formatNumber((maxValue / levels) * level);
+            const levelValue = formatNumber((maxValue / levels) * level, { precision: 2 });
 
             label.content = levelValue;
             label.data = {
@@ -374,8 +374,8 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 key,
                 value,
                 label,
-                color,
-                innerRadiusRatio = 0.15,
+                colorBy,
+                innerRadius = 0.15,
                 maxRadiusRatio = 0.45,
                 padAngle = 0.02,
                 levels = 4,
@@ -394,7 +394,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const getLabel = typeIsFunction(label) ? label : (item: any) => item[label] as string;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const getColor = typeIsFunction(color) ? color : (item: any) => item[color] as string;
+            const getColor = typeIsFunction(colorBy) ? colorBy : (item: any) => item[colorBy] as string;
 
             // Register each segment in the shared colour map so legend swatches and segments share
             // stable palette colours (honouring any explicit per-item colour).
@@ -425,7 +425,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             const centerY = area.y + area.height / 2;
 
             const maxValue = maxOf(data, getValue) ?? 0;
-            const valueScale = scaleContinuous([0, maxValue], [size * innerRadiusRatio, size * maxRadiusRatio], { clamp: true });
+            const valueScale = scaleContinuous([0, maxValue], [size * innerRadius, size * maxRadiusRatio], { clamp: true });
 
             const angleStep = TAU / data.length;
             const startOffset = -TAU / 4; // Start at 12 o'clock similar to PieChart
@@ -433,7 +433,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             const gridTransition = this._drawGrid(
                 centerX,
                 centerY,
-                size * innerRadiusRatio,
+                size * innerRadius,
                 size * maxRadiusRatio,
                 maxValue,
                 levels,
@@ -451,7 +451,6 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 const cy = centerY;
                 const startAngle = startOffset + index * angleStep;
                 const endAngle = startAngle + angleStep;
-                const innerRadius = size * innerRadiusRatio;
                 const radius = valueScale(v);
 
                 return {
@@ -465,7 +464,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     endAngle,
                     padAngle,
                     radius,
-                    innerRadius,
+                    innerRadius: size * innerRadius,
                     item,
                 };
             });

--- a/packages/charts/src/charts/polar-scatter.ts
+++ b/packages/charts/src/charts/polar-scatter.ts
@@ -96,8 +96,8 @@ export interface PolarScatterChartOptions<TData = unknown> extends BaseChartOpti
     data: TData[];
     /** The series to render, each mapping the data to angle/radius positions. */
     series: PolarScatterSeriesOptions<TData>[];
-    /** Maximum radial value (defaults to the largest radius value in the data). */
-    maxRadiusValue?: number;
+    /** The value mapped to the outer radius (defaults to the largest radius value in the data). */
+    maxValue?: number;
     /** Number of concentric value rings. Defaults to 4. */
     levels?: number;
     /** Number of angular spokes/labels around the circle. Defaults to 8. */
@@ -395,9 +395,9 @@ export class PolarScatterChart<TData = unknown> extends Chart<PolarScatterChartO
             // Radial value scale: 0 at the centre, the data max (or override) at the outer ring.
             const radiusValues = series.flatMap(srs => data.map(resolveAccessor<TData, number>(srs.radius)));
             const [, dataMax] = radiusValues.length ? getExtent(radiusValues, functionIdentity) : [0, 1];
-            const maxRadiusValue = this.options.maxRadiusValue ?? (dataMax > 0 ? dataMax : 1);
+            const maxValue = this.options.maxValue ?? (dataMax > 0 ? dataMax : 1);
 
-            this._radialScale = scaleContinuous([0, maxRadiusValue], [0, gridRadius], { clamp: true });
+            this._radialScale = scaleContinuous([0, maxValue], [0, gridRadius], { clamp: true });
 
             this._drawGrid(cx, cy, gridRadius, levels, angleTicks);
 

--- a/packages/charts/src/charts/radar.ts
+++ b/packages/charts/src/charts/radar.ts
@@ -77,7 +77,7 @@ export interface RadarChartSeriesOptions<TData> {
     /** Accessor for each data item's value on the series' axis. */
     value: NumericAccessor<TData>;
     /** Fill opacity of the series' area polygon. Defaults to 0.25. */
-    opacity?: number;
+    fillOpacity?: number;
 }
 
 /** Options for configuring a {@link RadarChart}. */
@@ -87,7 +87,7 @@ export interface RadarChartOptions<TData = unknown> extends BaseChartOptions {
     /** The series to overlay, each rendered as a filled polygon. */
     series: RadarChartSeriesOptions<TData>[];
     /** Axis labels arranged clockwise around the chart, one per data item. */
-    axes: string[];
+    categories: string[];
     /** Maximum value mapped to the outer ring (defaults to the largest value across all series). */
     maxValue?: number;
     /** Number of concentric grid rings. Defaults to 5. */
@@ -152,10 +152,10 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
         this.init();
     }
 
-    private _drawGrid(cx: number, cy: number, radius: number, axes: string[], levels: number) {
+    private _drawGrid(cx: number, cy: number, radius: number, categories: string[], levels: number) {
         const isEntry = !this._gridGroup;
         const animDuration = this.getAnimationDuration(800);
-        const angleStep = TAU / axes.length;
+        const angleStep = TAU / categories.length;
 
         if (isEntry) {
             this._gridGroup = createGroup({
@@ -171,7 +171,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
             const levelRadius = (radius / levels) * level;
             const points: Point[] = [];
 
-            for (let i = 0; i <= axes.length; i++) {
+            for (let i = 0; i <= categories.length; i++) {
                 const angle = i * angleStep - TAU / 4;
                 points.push([
                     cx + levelRadius * Math.cos(angle),
@@ -224,7 +224,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
         ];
 
         // --- Radial axis lines ---
-        const axisIndices = axes.map((_, i) => i);
+        const axisIndices = categories.map((_, i) => i);
 
         const axisEnd = (index: number): Point => {
             const angle = index * angleStep - TAU / 4;
@@ -326,7 +326,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
                 id: `radar-label-${idx}`,
                 x: labelX,
                 y: labelY,
-                content: axes[idx] ?? '',
+                content: categories[idx] ?? '',
                 fill: '#6b7280',
                 font: '11px sans-serif',
                 textAlign,
@@ -347,7 +347,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
         labelUpdates.forEach(([idx, label]) => {
             const { labelX, labelY, textAlign } = labelProps(idx);
 
-            label.content = axes[idx] ?? '';
+            label.content = categories[idx] ?? '';
             label.textAlign = textAlign;
             label.data = {
                 x: labelX,
@@ -384,10 +384,10 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
         const {
             data,
             series,
-            axes,
+            categories,
         } = this.options;
 
-        const angleStep = TAU / axes.length;
+        const angleStep = TAU / categories.length;
 
         const {
             left: seriesEntries,
@@ -411,14 +411,14 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
                 return {
                     point: [x, y] as Point,
                     value,
-                    axisLabel: axes[index] ?? '',
+                    axisLabel: categories[index] ?? '',
                 };
             });
         };
 
         const seriesEntryGroups = seriesEntries.map(srs => {
             const color = this.getSeriesColor(srs.id);
-            const opacity = srs.opacity ?? 0.25;
+            const fillOpacity = srs.fillOpacity ?? 0.25;
             const pointsData = getSeriesPoints(srs);
 
             const closedPoints = [
@@ -428,7 +428,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
 
             const area = createPolyline({
                 id: `${srs.id}-area`,
-                fill: setColorAlpha(color, opacity),
+                fill: setColorAlpha(color, fillOpacity),
                 stroke: color,
                 lineWidth: 2,
                 points: closedPoints.map(() => [cx, cy] as Point),
@@ -554,7 +554,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
     public async render() {
         return super.render(async () => {
             const {
-                axes,
+                categories,
                 series,
                 maxValue,
                 levels = 5,
@@ -596,7 +596,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
                 });
             }
 
-            const gridTransition = this._drawGrid(cx, cy, radius, axes, levels);
+            const gridTransition = this._drawGrid(cx, cy, radius, categories, levels);
             const seriesTransition = this._drawSeries(cx, cy, radius, computedMax);
 
             return Promise.all([gridTransition, seriesTransition]);
@@ -648,7 +648,7 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
  * @example
  * ```ts
  * createRadarChart(target, {
- *     axes: ['Speed', 'Power', 'Range', 'Agility'],
+ *     categories: ['Speed', 'Power', 'Range', 'Agility'],
  *     data: [
  *         { axis: 'Speed', modelA: 80 },
  *         { axis: 'Power', modelA: 60 },

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -79,7 +79,7 @@ export interface RadialBarChartOptions<TData = unknown> extends BaseChartOptions
     /** Optional accessor for each item's display label (defaults to its key). */
     label?: keyof TData | ((item: TData) => string);
     /** Optional accessor for a per-item colour override (otherwise a palette colour is generated). */
-    color?: keyof TData | ((item: TData) => string);
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Maximum value mapped to a full sweep (defaults to the largest value in the data). */
     maxValue?: number;
     /** Inner hole radius as a ratio of the chart size (0–1). Defaults to 0.2. */
@@ -190,7 +190,7 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
                 key,
                 value,
                 label,
-                color,
+                colorBy,
                 innerRadius = 0.2,
                 range = 360,
                 gap = 0.25,
@@ -203,7 +203,7 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
             const getKey = resolveAccessor<TData, string>(key);
             const getValue = resolveAccessor<TData, number>(value);
             const getLabel = label !== undefined ? resolveAccessor<TData, string>(label) : getKey;
-            const getColor = (item: TData): string | undefined => (color ? resolveAccessor<TData, string>(color)(item) : undefined);
+            const getColor = (item: TData): string | undefined => (colorBy ? resolveAccessor<TData, string>(colorBy)(item) : undefined);
 
             this.resolveSeriesColors(data.map(item => ({
                 id: getKey(item),

--- a/packages/charts/src/charts/realtime.ts
+++ b/packages/charts/src/charts/realtime.ts
@@ -86,7 +86,7 @@ export interface RealtimeChartSeriesOptions {
     /** Fill the area beneath the line. Defaults to `true`. */
     showArea?: boolean;
     /** Opacity of the area fill when `showArea` is enabled. Defaults to 0.2. */
-    areaOpacity?: number;
+    fillOpacity?: number;
 }
 
 /** Options for configuring a {@link RealtimeChart}. */
@@ -279,7 +279,7 @@ export class RealtimeChart extends Chart<RealtimeChartOptions> {
             const buffer = this._buffers.get(srs.id) || [];
             const color = this.getSeriesColor(srs.id);
             const showArea = srs.showArea !== false;
-            const areaOpacity = srs.areaOpacity ?? 0.2;
+            const fillOpacity = srs.fillOpacity ?? 0.2;
 
             // Need at least 2 points for a renderable line
             const pointCount = buffer.length;
@@ -362,7 +362,7 @@ export class RealtimeChart extends Chart<RealtimeChartOptions> {
                 if (showArea) {
                     const areaFill = createPolyline({
                         id: `${srs.id}-area`,
-                        fill: setColorAlpha(color, areaOpacity),
+                        fill: setColorAlpha(color, fillOpacity),
                         stroke: undefined,
                         points: areaPoints,
                         // Curve only the interior line points; the two baseline anchors join with

--- a/packages/charts/src/charts/sankey.ts
+++ b/packages/charts/src/charts/sankey.ts
@@ -7,10 +7,6 @@ import {
 } from '../core/chart';
 
 import {
-    formatNumber,
-} from '../core/options';
-
-import {
     applyHoverHighlight,
 } from '../core/interaction';
 
@@ -60,6 +56,7 @@ import {
 
 import {
     arrayJoin,
+    formatNumber,
 } from '@ripl/utilities';
 
 /** A directional flow between two nodes in a Sankey diagram. */
@@ -633,7 +630,7 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
                 x: anchorX,
                 y: anchorY,
             }),
-            content: () => `${link.source.label} → ${link.target.label}: ${formatNumber(link.value)}`,
+            content: () => `${link.source.label} → ${link.target.label}: ${formatNumber(link.value, { precision: 2 })}`,
             highlight: { stroke: setColorAlpha(link.color, 0.6) },
             restore: { stroke: setColorAlpha(link.color, 0.3) },
             onEnter: point => this.emit('linkenter', payload(point)),
@@ -662,7 +659,7 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
                 x: anchorX,
                 y: anchorY,
             }),
-            content: () => `${node.label}: ${formatNumber(node.value)}`,
+            content: () => `${node.label}: ${formatNumber(node.value, { precision: 2 })}`,
             highlight: { fill: node.color },
             restore: { fill: setColorAlpha(node.color, 0.8) },
             onEnter: point => this.emit('nodeenter', payload(point)),

--- a/packages/charts/src/charts/scatter.ts
+++ b/packages/charts/src/charts/scatter.ts
@@ -44,6 +44,11 @@ import {
     resolveAccessor,
 } from '../core/data';
 
+import {
+    axisTickCount,
+    createValueScale,
+} from '../core/scales';
+
 import type {
     LegendItem,
 } from '../components/legend';
@@ -568,19 +573,19 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
             const maxRadius = this._getMaxBubbleRadius();
 
             // Provisional Y scale to measure the y-axis width.
-            this._yScale = scaleContinuous(yExtent, [bottom - maxRadius, top + maxRadius], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, yExtent, [bottom - maxRadius, top + maxRadius]);
             this.yAxis.scale = this._yScale;
             this.yAxis.bounds = new Box(top, left, bottom, right);
 
             const yAxisBox = this.yAxis.getBoundingBox();
 
-            this._xScale = scaleContinuous(xExtent, [yAxisBox.right + maxRadius, right - maxRadius], { padToTicks: 10 });
+            this._xScale = createValueScale(this.xAxisOptions, xExtent, [yAxisBox.right + maxRadius, right - maxRadius]);
             this.xAxis.scale = this._xScale;
             this.xAxis.bounds = new Box(top, yAxisBox.right, bottom, right);
 
             const xAxisBox = this.xAxis.getBoundingBox();
 
-            this._yScale = scaleContinuous(yExtent, [xAxisBox.top - maxRadius, top + maxRadius], { padToTicks: 10 });
+            this._yScale = createValueScale(this.yAxisOptions, yExtent, [xAxisBox.top - maxRadius, top + maxRadius]);
 
             // Rescale the axis domains to the navigator's current pan/zoom window (no-op when the
             // chart has no navigator or the view is at rest). Geometry and axes read the same scales,
@@ -601,8 +606,8 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
             this.clipPlot(plot);
 
             this.renderGrid(
-                this._xScale.ticks(10).map(tick => this._xScale(tick)),
-                this._yScale.ticks(10).map(tick => this._yScale(tick)),
+                this._xScale.ticks(axisTickCount(this.xAxisOptions)).map(tick => this._xScale(tick)),
+                this._yScale.ticks(axisTickCount(this.yAxisOptions)).map(tick => this._yScale(tick)),
                 plot
             );
 

--- a/packages/charts/src/charts/stock.ts
+++ b/packages/charts/src/charts/stock.ts
@@ -18,7 +18,6 @@ import type {
 } from '../core/options';
 
 import {
-    formatNumber,
     normalizeAxis,
     normalizeAxisItem,
     normalizeCrosshair,
@@ -75,6 +74,7 @@ import {
 
 import {
     arrayJoin,
+    formatNumber,
     functionIdentity,
     typeIsFunction,
 } from '@ripl/utilities';
@@ -258,7 +258,7 @@ export class StockChart<TData = unknown> extends Chart<StockChartOptions<TData>,
      * so prior listeners are disposed on re-apply — calling this on every update no longer leaks.
      */
     private _attachBodyHover(body: Rect, values: CandlestickValues, color: string, anchorX: number, anchorY: number) {
-        const label = `O: ${formatNumber(values.open)}  H: ${formatNumber(values.high)}  L: ${formatNumber(values.low)}  C: ${formatNumber(values.close)}`;
+        const label = `O: ${formatNumber(values.open, { precision: 2 })}  H: ${formatNumber(values.high, { precision: 2 })}  L: ${formatNumber(values.low, { precision: 2 })}  C: ${formatNumber(values.close, { precision: 2 })}`;
 
         const payload = (point: { x: number;
             y: number; }): StockChartCandleEvent => ({

--- a/packages/charts/src/charts/treemap.ts
+++ b/packages/charts/src/charts/treemap.ts
@@ -31,6 +31,10 @@ import {
 } from '../core/animation';
 
 import {
+    resolveColorBy,
+} from '../core/color';
+
+import {
     Tooltip,
 } from '../components/tooltip';
 
@@ -67,8 +71,8 @@ export interface TreemapChartOptions<TData = unknown> extends BaseChartOptions {
     value: NumericAccessor<TData>;
     /** Accessor for each item's display label (shown inside sufficiently large cells). */
     label: keyof TData | ((item: TData) => string);
-    /** Optional accessor for a per-item colour override (otherwise a palette colour is generated). */
-    color?: keyof TData | ((item: TData) => string);
+    /** Optional per-item colour accessor; falls back to a generated palette colour. */
+    colorBy?: keyof TData | ((item: TData) => string);
     /** Gap in pixels between adjacent cells. Defaults to 3. */
     gap?: number;
     /** Corner radius in pixels applied to each cell. Defaults to 4. */
@@ -213,7 +217,7 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
                 key,
                 value,
                 label,
-                color,
+                colorBy,
                 gap = 3,
                 borderRadius = 4,
             } = this.options;
@@ -225,12 +229,7 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const getLabel = typeIsFunction(label) ? label : (item: any) => item[label] as string;
 
-            let getColor: ((item: TData) => string) | undefined;
-
-            if (color) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                getColor = typeIsFunction(color) ? color : (item: any) => item[color] as string;
-            }
+            const getColor = resolveColorBy<TData>(colorBy);
 
             const layout = this.createLayout();
             this.reserveTitle(layout);
@@ -240,7 +239,7 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
                 key: getKey(item),
                 value: getValue(item),
                 label: getLabel(item),
-                color: getColor ? getColor(item) : undefined,
+                color: getColor(item),
             }));
 
             // Resolve colours through the shared id-keyed map so they stay stable across data

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -142,7 +142,7 @@ export interface TrendChartAreaSeriesOptions<TData> extends TrendChartBaseSeries
     /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
     lineStyle?: LineStyle;
     /** Fill opacity of the area band. Defaults to 0.3. */
-    opacity?: number;
+    fillOpacity?: number;
     /** Show point markers at each data value. Defaults to `true`. */
     markers?: boolean;
 }

--- a/packages/charts/src/components/axis.ts
+++ b/packages/charts/src/components/axis.ts
@@ -6,10 +6,6 @@ import {
     ChartComponent,
 } from './_base';
 
-import {
-    formatNumber,
-} from '../core/options';
-
 import type {
     ResolvedAnimation,
 } from '../core/animation';
@@ -38,6 +34,7 @@ import {
 
 import {
     arrayJoin,
+    formatNumber,
 } from '@ripl/utilities';
 
 /** Gap (px) between axis tick labels and the axis title. */
@@ -293,7 +290,7 @@ export class ChartAxis extends ChartComponent {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected measureLabels(values: any[], producer: (metrics: TextMetrics) => number) {
         return values.reduce((output, value) => {
-            const label = this.formatLabel ? this.formatLabel(value) : formatNumber(value);
+            const label = this.formatLabel ? this.formatLabel(value) : formatNumber(value, { precision: 2 });
             const metrics = this.context.measureText(label, this.labelFont);
             return Math.max(output, producer(metrics));
         }, 0);
@@ -301,7 +298,7 @@ export class ChartAxis extends ChartComponent {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected formatTickLabel(value: any): string {
-        return this.formatLabel ? this.formatLabel(value) : formatNumber(value);
+        return this.formatLabel ? this.formatLabel(value) : formatNumber(value, { precision: 2 });
     }
 
     /** The thickness reserved for the axis title (0 when there is no title). */

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -32,10 +32,12 @@ import type {
 
 import type {
     ChartAxisInput,
+    ChartAxisItemOptions,
     ChartCrosshairInput,
     ChartGridInput,
     ChartLegendInput,
     ChartTooltipInput,
+    ChartYAxisItemOptions,
     CrosshairAxis,
 } from './options';
 
@@ -49,6 +51,10 @@ import {
     normalizeYAxisItem,
     resolveFormatLabel,
 } from './options';
+
+import {
+    axisTickCount,
+} from './scales';
 
 import type {
     ChartXAxisAlignment,
@@ -214,6 +220,10 @@ export abstract class CartesianChart<
 
     protected xAxis!: ChartXAxis;
     protected yAxis!: ChartYAxis;
+    /** Resolved x-axis options (scale type, ticks, min/max, format) captured in {@link CartesianChart.setupCartesian}. */
+    protected xAxisOptions!: ChartAxisItemOptions<TData>;
+    /** Resolved y-axis options (scale type, ticks, min/max, format) captured in {@link CartesianChart.setupCartesian}. */
+    protected yAxisOptions!: ChartYAxisItemOptions<TData>;
     protected tooltip?: Tooltip;
     protected grid?: Grid;
     protected crosshair?: Crosshair;
@@ -294,6 +304,9 @@ export abstract class CartesianChart<
         const axisOpts = normalizeAxis(this.options.axis);
         const xAxis = normalizeAxisItem(axisOpts.x);
         const yAxis = normalizeYAxisItem(Array.isArray(axisOpts.y) ? axisOpts.y[0] : axisOpts.y);
+
+        this.xAxisOptions = xAxis;
+        this.yAxisOptions = yAxis;
         const gridOpts = normalizeGrid(this.options.grid);
         const tooltipOpts = normalizeTooltip(this.options.tooltip);
         const crosshairOpts = normalizeCrosshair(this.options.crosshair, setup.crosshairAxisDefault ? { axis: setup.crosshairAxisDefault } : undefined);
@@ -337,6 +350,9 @@ export abstract class CartesianChart<
         });
 
         this.yAxis.visible = yAxis.visible;
+
+        this.xAxis.tickCount = axisTickCount(xAxis);
+        this.yAxis.tickCount = axisTickCount(yAxis);
 
         if (gridOpts.visible) {
             this.grid = new Grid({

--- a/packages/charts/src/core/color.ts
+++ b/packages/charts/src/core/color.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared colour-accessor helpers for charts.
+ *
+ * Centralises the per-item `colorBy` accessor resolution that categorical charts (pie, treemap,
+ * funnel, etc.) previously each re-implemented, so they share one consistent code path.
+ */
+
+import type {
+    Accessor,
+} from './data';
+
+import {
+    resolveAccessor,
+} from './data';
+
+/**
+ * Resolves a per-item colour accessor (`colorBy`) into a function returning each item's colour.
+ *
+ * A property key reads that field, a function is passed through, and an absent accessor yields a
+ * function returning `undefined` so callers can fall back to the series colour generator.
+ *
+ * @typeParam TData - The data-item type.
+ * @param colorBy - The `colorBy` accessor, or `undefined` when the chart has no per-item colour.
+ * @returns A function mapping a data item to its colour (or `undefined`).
+ */
+export function resolveColorBy<TData>(colorBy?: keyof TData | ((item: TData) => string)): (item: TData) => string | undefined {
+    if (colorBy === undefined) {
+        return () => undefined;
+    }
+
+    return resolveAccessor<TData, string>(colorBy as Accessor<TData, string>);
+}

--- a/packages/charts/src/core/index.ts
+++ b/packages/charts/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './chart';
 export * from './options';
+export * from './color';
 export * from './layout';
 export * from './animation';
 export * from './interaction';

--- a/packages/charts/src/core/index.ts
+++ b/packages/charts/src/core/index.ts
@@ -1,6 +1,7 @@
 export * from './chart';
 export * from './options';
 export * from './color';
+export * from './scales';
 export * from './layout';
 export * from './animation';
 export * from './interaction';

--- a/packages/charts/src/core/options.ts
+++ b/packages/charts/src/core/options.ts
@@ -464,7 +464,12 @@ export function normalizeLegend(input?: ChartLegendInput, defaults?: Partial<Cha
 /** Built-in axis label format types. */
 export type AxisFormatType = 'number' | 'percentage' | 'date' | 'string';
 
+/** The scale family an axis maps its domain through. Value axes accept `'linear'`/`'log'`/`'pow'`/`'sqrt'`; category and time axes are selected by the chart. */
+export type AxisScaleType = 'linear' | 'log' | 'pow' | 'sqrt' | 'time' | 'band' | 'point';
+
 /** Options for a single axis (x or y). */
+// `TData` is retained for symmetry across the axis option family (ChartYAxisItemOptions, ChartAxisInput, etc.).
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface ChartAxisItemOptions<TData = unknown> {
     /** Whether the axis line, ticks, and labels are rendered. */
     visible: boolean;
@@ -474,11 +479,22 @@ export interface ChartAxisItemOptions<TData = unknown> {
     fontColor: string;
     /** Optional axis title drawn alongside the tick labels. */
     title?: string;
-    /** Accessor selecting the value this axis reads from each data item. */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    value?: keyof TData | ((item: TData) => any);
     /** How tick values are formatted — a built-in {@link AxisFormatType}, an Intl number-format options object, or a custom formatter. */
     format?: ValueFormatInput;
+    /** Scale family for this axis. Value axes default to `'linear'`. See {@link AxisScaleType}. */
+    scale?: AxisScaleType;
+    /** Expands the value domain to round, tick-aligned bounds. `true` (default) nices to the tick count, a number nices to that many segments, `false` disables it. */
+    nice?: boolean | number;
+    /** Target number of ticks and grid lines along the axis. Defaults to 10. */
+    ticks?: number;
+    /** Explicit lower bound of the value domain (overrides the data extent). */
+    min?: number;
+    /** Explicit upper bound of the value domain (overrides the data extent). */
+    max?: number;
+    /** Logarithm base for a `'log'` scale. Defaults to 10. */
+    base?: number;
+    /** Exponent for a `'pow'` scale. Defaults to 1. */
+    exponent?: number;
 }
 
 /** Y-axis specific options extending the base axis item with a left/right position. */

--- a/packages/charts/src/core/options.ts
+++ b/packages/charts/src/core/options.ts
@@ -18,30 +18,15 @@ import {
     easeOutQuint,
 } from '@ripl/core';
 
-import {
-    roundTo,
-    typeIsBoolean,
-    typeIsNumber,
-    typeIsString,
+import type {
+    NumberFormatOptions,
 } from '@ripl/utilities';
 
-/** Default maximum number of decimal places applied when rendering numeric values as text. */
-export const DEFAULT_NUMBER_PRECISION = 2;
-
-/**
- * Formats a numeric value as a localized string, capping the precision at `precision` decimal
- * places (default {@link DEFAULT_NUMBER_PRECISION}). Integers render without decimals; fractional
- * values are rounded to at most `precision` places with trailing zeros stripped. Non-numeric values
- * fall back to `String(value)`. This is the shared entry point every chart uses so labels, axes,
- * tooltips, and tick marks share one consistent precision cap.
- */
-export function formatNumber(value: unknown, precision: number = DEFAULT_NUMBER_PRECISION): string {
-    if (!typeIsNumber(value)) {
-        return String(value);
-    }
-
-    return roundTo(value, precision).toLocaleString();
-}
+import {
+    formatNumber,
+    typeIsBoolean,
+    typeIsString,
+} from '@ripl/utilities';
 
 // ---------------------------------------------------------------------------
 // Ease
@@ -492,9 +477,8 @@ export interface ChartAxisItemOptions<TData = unknown> {
     /** Accessor selecting the value this axis reads from each data item. */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value?: keyof TData | ((item: TData) => any);
-    /** How tick values are formatted — a built-in {@link AxisFormatType} or a custom formatter. */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    format?: AxisFormatType | ((value: any) => string);
+    /** How tick values are formatted — a built-in {@link AxisFormatType}, an Intl number-format options object, or a custom formatter. */
+    format?: ValueFormatInput;
 }
 
 /** Y-axis specific options extending the base axis item with a left/right position. */
@@ -610,10 +594,11 @@ export function normalizeAxis<TData = unknown>(input?: ChartAxisInput<TData>): C
 
 /**
  * A value formatter accepted anywhere a chart renders a raw value as text (tooltips, data
- * labels, pie segment labels). Either a built-in format type or a custom callback.
+ * labels, pie segment labels, axis ticks). Either a built-in {@link AxisFormatType}, an Intl
+ * number-format options object (e.g. `{ style: 'currency', currency: 'USD' }`), or a custom callback.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ValueFormatInput = AxisFormatType | ((value: any) => string);
+export type ValueFormatInput = AxisFormatType | NumberFormatOptions | ((value: any) => string);
 
 /**
  * Resolves a value formatter into a function, always returning a usable formatter (falling back
@@ -624,7 +609,7 @@ export function resolveValueFormat(format?: ValueFormatInput): (value: unknown) 
     const resolved = resolveFormatLabel(format);
     // Fall back to the shared precision-capped number formatter (rather than raw `String`) so
     // untyped numeric values still respect the default 2-decimal cap.
-    return resolved ?? (value => formatNumber(value));
+    return resolved ?? (value => formatNumber(value, { precision: 2 }));
 }
 
 // ---------------------------------------------------------------------------
@@ -790,15 +775,22 @@ export function normalizeSegmentLabels(input?: ChartSegmentLabelsInput, defaults
 /** Built-in value formatters keyed by {@link AxisFormatType}. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const VALUE_FORMATTERS: Record<AxisFormatType, (value: any) => string> = {
-    number: (value: number) => formatNumber(value),
-    percentage: (value: number) => `${formatNumber(value * 100)}%`,
+    number: (value: number) => formatNumber(value, { precision: 2 }),
+    percentage: (value: number) => formatNumber(value, {
+        style: 'percent',
+        maximumFractionDigits: 2,
+    }),
     date: (value: Date | number) => new Date(value).toLocaleDateString(),
     string: (value: unknown) => String(value),
 };
 
-/** Resolves an axis format type or custom formatter into a label formatting function. */
+/**
+ * Resolves a {@link ValueFormatInput} into a label formatting function. A built-in
+ * {@link AxisFormatType} maps to a preset formatter, an Intl number-format options object binds
+ * {@link formatNumber} to those options, and a function is returned as-is.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function resolveFormatLabel(format?: AxisFormatType | ((value: any) => string)): ((value: any) => string) | undefined {
+export function resolveFormatLabel(format?: ValueFormatInput): ((value: any) => string) | undefined {
     if (!format) {
         return undefined;
     }
@@ -807,5 +799,9 @@ export function resolveFormatLabel(format?: AxisFormatType | ((value: any) => st
         return format;
     }
 
-    return VALUE_FORMATTERS[format];
+    if (typeof format === 'string') {
+        return VALUE_FORMATTERS[format];
+    }
+
+    return value => formatNumber(value, format);
 }

--- a/packages/charts/src/core/scales.ts
+++ b/packages/charts/src/core/scales.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared value-axis scale construction for cartesian charts.
+ *
+ * Turns the resolved {@link ChartAxisItemOptions} for a value axis into a concrete
+ * {@link Scale}, selecting the scale family (`linear`/`log`/`pow`/`sqrt`), applying an explicit
+ * `min`/`max` domain override, and nice-ing the domain to tick-aligned bounds. Charts route their
+ * value scale through this so a `scale`, `nice`, `ticks`, `min`, or `max` option works uniformly.
+ */
+
+import type {
+    ChartAxisItemOptions,
+} from './options';
+
+import type {
+    Scale,
+} from '@ripl/core';
+
+import {
+    scaleContinuous,
+    scaleLogarithmic,
+    scalePower,
+} from '@ripl/core';
+
+/**
+ * The target number of ticks (and grid lines) an axis draws, from its `ticks` option (default 10).
+ *
+ * @param options - The resolved axis options.
+ * @returns The tick count.
+ */
+export function axisTickCount(options: ChartAxisItemOptions): number {
+    return options.ticks ?? 10;
+}
+
+/**
+ * Builds a value-axis {@link Scale} from resolved axis options over a data extent and pixel range.
+ *
+ * The scale family is chosen from `options.scale` (`'log'`, `'pow'`, `'sqrt'`, or the default
+ * `'linear'`). An explicit `min`/`max` overrides the corresponding end of the data extent and is
+ * respected exactly; otherwise the domain is niced to tick-aligned bounds unless `nice` is `false`.
+ *
+ * @param options - The resolved axis options (scale type, nice, ticks, min/max, base/exponent).
+ * @param domain - The data extent `[min, max]` the values span.
+ * @param range - The pixel range `[start, end]` the scale maps onto.
+ * @returns A numeric scale mapping `domain` to `range`.
+ */
+export function createValueScale(
+    options: ChartAxisItemOptions,
+    domain: number[],
+    range: number[]
+): Scale<number> {
+    const min = typeof options.min === 'number' ? options.min : domain[0];
+    const max = typeof options.max === 'number' ? options.max : domain[1];
+    const resolvedDomain: [number, number] = [min, max];
+
+    // Explicit bounds are honoured exactly; otherwise nice the domain to tick-aligned boundaries
+    // (the historical default via `padToTicks`), unless the caller opted out with `nice: false`.
+    const hasExplicitBounds = typeof options.min === 'number' || typeof options.max === 'number';
+    const nice = options.nice ?? true;
+
+    let padToTicks: boolean | number | undefined;
+
+    if (nice !== false && !hasExplicitBounds) {
+        padToTicks = typeof nice === 'number' ? nice : axisTickCount(options);
+    }
+
+    if (options.scale === 'log') {
+        return scaleLogarithmic(resolvedDomain, range, {
+            base: options.base ?? 10,
+            padToTicks,
+        });
+    }
+
+    if (options.scale === 'pow') {
+        return scalePower(resolvedDomain, range, {
+            exponent: options.exponent ?? 1,
+            padToTicks,
+        });
+    }
+
+    if (options.scale === 'sqrt') {
+        return scalePower(resolvedDomain, range, {
+            exponent: 0.5,
+            padToTicks,
+        });
+    }
+
+    return scaleContinuous(resolvedDomain, range, {
+        padToTicks,
+    });
+}

--- a/packages/charts/src/core/series/area-series.ts
+++ b/packages/charts/src/core/series/area-series.ts
@@ -287,7 +287,7 @@ export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TDa
 
     protected buildSeriesGroup(series: AreaSeriesLike<TData>, ctx: AreaSeriesContext<TData>, prepared: AreaPrepared<TData>): Group {
         const color = ctx.getColor(series.id);
-        const opacity = series.opacity ?? 0.3;
+        const opacity = series.fillOpacity ?? 0.3;
         const showMarkers = series.markers !== false;
         const { linePoints, bottomPoints, areaPoints } = this._buildPoints(series, ctx, prepared);
 

--- a/packages/charts/src/core/series/context.ts
+++ b/packages/charts/src/core/series/context.ts
@@ -153,7 +153,7 @@ export interface LineSeriesLike<TData> {
 /** The area series fields the area renderer reads (line fields plus a fill opacity). */
 export interface AreaSeriesLike<TData> extends LineSeriesLike<TData> {
     /** Fill opacity of the area band. Defaults to 0.3. */
-    opacity?: number;
+    fillOpacity?: number;
 }
 
 /** The bar series fields the bar renderer reads. */

--- a/packages/charts/test/box-plot.test.ts
+++ b/packages/charts/test/box-plot.test.ts
@@ -72,7 +72,7 @@ describe('BoxPlotChart animations', () => {
             autoRender: false,
             animation: false,
             data: SCORES,
-            group: 'group',
+            key: 'group',
             value: 'score',
         });
 
@@ -96,7 +96,7 @@ describe('BoxPlotChart animations', () => {
             autoRender: false,
             animation: false,
             data: SCORES,
-            group: 'group',
+            key: 'group',
             value: 'score',
         });
 

--- a/packages/charts/test/options.test.ts
+++ b/packages/charts/test/options.test.ts
@@ -10,7 +10,6 @@ import {
 } from '@ripl/core';
 
 import {
-    formatNumber,
     normalizeAnimation,
     normalizeDataLabels,
     normalizeLegend,
@@ -150,19 +149,51 @@ describe('resolveFormatLabel', () => {
     });
 });
 
-describe('formatNumber', () => {
-    it('caps at 2 decimals by default and strips trailing zeros', () => {
-        expect(formatNumber(3.14159)).toBe('3.14');
-        expect(formatNumber(5)).toBe('5');
-        expect(formatNumber(5.5)).toBe('5.5');
+describe('resolveFormatLabel', () => {
+    it('returns undefined when no format is supplied', () => {
+        expect(resolveFormatLabel()).toBeUndefined();
     });
 
-    it('respects a custom precision', () => {
-        expect(formatNumber(3.14159, 3)).toBe('3.142');
+    it('resolves the built-in number format at 2 decimals', () => {
+        const format = resolveFormatLabel('number')!;
+
+        expect(format(3.14159)).toBe('3.14');
     });
 
-    it('stringifies non-numeric values', () => {
-        expect(formatNumber('abc')).toBe('abc');
+    it('resolves the built-in percentage format', () => {
+        const format = resolveFormatLabel('percentage')!;
+
+        expect(format(0.5)).toBe('50%');
+    });
+
+    it('binds an Intl number-format options object', () => {
+        const format = resolveFormatLabel({
+            locale: 'en-US',
+            style: 'currency',
+            currency: 'USD',
+        })!;
+
+        expect(format(1234)).toBe('$1,234.00');
+    });
+
+    it('returns a custom formatter as-is', () => {
+        const custom = (value: number) => `#${value}`;
+
+        expect(resolveFormatLabel(custom)).toBe(custom);
+    });
+});
+
+describe('resolveValueFormat', () => {
+    it('falls back to a 2-decimal number formatter', () => {
+        const format = resolveValueFormat();
+
+        expect(format(3.14159)).toBe('3.14');
+    });
+
+    it('applies a supplied Intl options object', () => {
+        const format = resolveValueFormat({ style: 'percent' });
+
+        expect(format(0.25)).toBe('25%');
     });
 });
 

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -506,7 +506,7 @@ describe('Overview navigator strip', () => {
             data: DATA,
             key: 'month',
             overview: true,
-            mode: 'stacked',
+            stacked: true,
             series: [
                 {
                     id: 'a',

--- a/packages/charts/test/scales.test.ts
+++ b/packages/charts/test/scales.test.ts
@@ -1,0 +1,134 @@
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import type {
+    ChartAxisItemOptions,
+} from '../src/core/options';
+
+import {
+    axisTickCount,
+    createValueScale,
+} from '../src/core/scales';
+
+import {
+    createBarChart,
+} from '../src';
+
+function axis(overrides: Partial<ChartAxisItemOptions> = {}): ChartAxisItemOptions {
+    return {
+        visible: true,
+        font: '12px sans-serif',
+        fontColor: '#000000',
+        ...overrides,
+    };
+}
+
+describe('axisTickCount', () => {
+
+    it('defaults to 10', () => {
+        expect(axisTickCount(axis())).toBe(10);
+    });
+
+    it('uses the ticks option when provided', () => {
+        expect(axisTickCount(axis({ ticks: 5 }))).toBe(5);
+    });
+
+});
+
+describe('createValueScale', () => {
+
+    it('builds a linear scale by default', () => {
+        const scale = createValueScale(axis(), [0, 100], [0, 200]);
+
+        expect(scale(0)).toBeCloseTo(0);
+        expect(scale(100)).toBeCloseTo(200);
+    });
+
+    it('respects an explicit min/max domain override', () => {
+        const scale = createValueScale(axis({
+            min: 0,
+            max: 50,
+        }), [10, 40], [0, 100]);
+
+        expect(scale(0)).toBeCloseTo(0);
+        expect(scale(50)).toBeCloseTo(100);
+    });
+
+    it('builds a logarithmic scale', () => {
+        const scale = createValueScale(axis({
+            scale: 'log',
+            min: 1,
+            max: 1000,
+        }), [1, 1000], [0, 300]);
+
+        // 10 is one decade above 1 → one third of the way across three decades.
+        expect(scale(1)).toBeCloseTo(0);
+        expect(scale(1000)).toBeCloseTo(300);
+        expect(scale(10)).toBeCloseTo(100);
+    });
+
+    it('builds a power scale with a configurable exponent', () => {
+        const scale = createValueScale(axis({
+            scale: 'pow',
+            exponent: 2,
+            min: 0,
+            max: 10,
+        }), [0, 10], [0, 100]);
+
+        // exponent 2: 5 maps to (5/10)^2 = 0.25 of the range.
+        expect(scale(0)).toBeCloseTo(0);
+        expect(scale(10)).toBeCloseTo(100);
+        expect(scale(5)).toBeCloseTo(25);
+    });
+
+});
+
+describe('configurable axes (integration)', () => {
+
+    it('captures the axis scale type and tick count on a cartesian chart', () => {
+        polyfillPath2D();
+        mockCanvasContext();
+
+        const chart = createBarChart(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: [
+                {
+                    m: 'a',
+                    v: 10,
+                },
+                {
+                    m: 'b',
+                    v: 1000,
+                },
+            ],
+            key: 'm',
+            series: [{
+                id: 'v',
+                label: 'V',
+                value: 'v',
+            }],
+            axis: {
+                y: {
+                    scale: 'log',
+                    ticks: 4,
+                    min: 1,
+                    max: 1000,
+                },
+            },
+        });
+
+        // The resolved options are captured in setupCartesian and drive the value scale.
+        expect((chart as unknown as { yAxisOptions: ChartAxisItemOptions }).yAxisOptions.scale).toBe('log');
+        expect((chart as unknown as { yAxis: { tickCount: number } }).yAxis.tickCount).toBe(4);
+    });
+
+});

--- a/packages/charts/test/visual/gallery.ts
+++ b/packages/charts/test/visual/gallery.ts
@@ -228,7 +228,7 @@ createBoxPlotChart(mount('box-plot'), {
             latency: 160,
         },
     ],
-    group: 'region',
+    key: 'region',
     value: 'latency',
     axis: {
         x: {
@@ -354,11 +354,11 @@ createGaugeChart(mount('gauge'), {
     animation: false,
     title: 'Gauge — Performance',
     value: 72,
-    min: 0,
-    max: 100,
+    minValue: 0,
+    maxValue: 100,
     label: 'Performance',
-    formatValue: v => `${v}%`,
-    formatTickLabel: v => `${v}%`,
+    format: v => `${v}%`,
+    formatTick: v => `${v}%`,
 });
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
@@ -373,8 +373,8 @@ createHeatmapChart(mount('heatmap'), {
         // Deterministic, varied surface so colour intensity is visible.
         value: ((di * 7 + hi * 13) % 100),
     }))),
-    xBy: 'hour',
-    yBy: 'day',
+    keyX: 'hour',
+    keyY: 'day',
     value: 'value',
     xCategories: HOURS,
     yCategories: DAYS,
@@ -426,7 +426,7 @@ createRadarChart(mount('radar'), {
     animation: false,
     title: 'Radar — Player profiles',
     legend: true,
-    axes: RADAR_AXES,
+    categories: RADAR_AXES,
     data: [
         {
             axis: 'Speed',
@@ -484,13 +484,13 @@ const realtime = createRealtimeChart(mount('realtime'), {
             id: 'cpu',
             label: 'CPU %',
             showArea: true,
-            areaOpacity: 0.15,
+            fillOpacity: 0.15,
         },
         {
             id: 'memory',
             label: 'Memory %',
             showArea: true,
-            areaOpacity: 0.15,
+            fillOpacity: 0.15,
         },
         {
             id: 'network',
@@ -838,7 +838,7 @@ createPolarScatterChart(mount('polar-scatter'), {
             sizeBy: 'gust',
         },
     ],
-    maxRadiusValue: 100,
+    maxValue: 100,
 });
 
 createRadialBarChart(mount('radial-bar'), {


### PR DESCRIPTION
A1: demo export button right-most + mobile-first responsive aspect ratio (example.vue)
A2: drop charts-local formatNumber; use @ripl/utilities Intl version; widen ValueFormatInput to accept NumberFormatOptions
A3: clean-break option renames across 16 charts for consistency:
 - key accessor: box-plot group→key; heatmap xBy/yBy→keyX/keyY; radar axes→categories
 - colour: pie/polar-area/radial-bar/treemap/funnel/packed-circle/gantt color(accessor)→colorBy; heatmap colorRange→colors
 - scalars: polar-scatter maxRadiusValue→maxValue; gauge min/max→minValue/maxValue; polar-area innerRadiusRatio→innerRadius; bar mode→stacked (drop BarChartMode)
 - fill opacity: area/radar/trend/realtime series opacity/areaOpacity→fillOpacity (+ shared AreaSeriesLike)
 - format: gauge formatValue→format, formatTickLabel→formatTick (widened to ValueFormatInput)
 - add core/color.ts resolveColorBy helper
Updated demos, gallery fixture, showcase apps, and tests. 175 charts tests pass; lint clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kczgp9iZDqrEU1ki3vDg1y