### PR TITLE
build(types): single bundled .d.ts per package via tsup + API Extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # build output
 dist/
 .output/
+.tsup/
 
 # dependencies
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,17 +511,24 @@ describe('Scale', () => {
 
 ## Build System
 
-**tsup** configuration (shared across packages):
+Each package builds with **tsup** (esbuild), driven by the shared root `tsup.config.ts`:
 
-- **Clean** output directory before builds
-- **Declaration files** (`.d.ts`) generated
-- **Source maps** enabled
-- **Target:** ES2018
-- **Formats:** ESM, CommonJS, IIFE
-- **Entry:** `./src/index.ts`
-- **Output:** `./dist`
+- **Formats:** ESM, CommonJS, IIFE (per-package IIFE global, e.g. `RiplCore`)
+- **Entry:** `./src/index.ts` — **Output:** `./dist` — **Target:** ES2023
+- **Clean** output before builds; **source maps** emitted
+- **Declarations:** a single self-contained `dist/index.d.ts` per package, produced by tsup's
+  API-Extractor-backed `experimentalDts` rollup and flattened by `scripts/finalize-dts.mjs` (which
+  promotes the rollup to `index.d.ts` and removes the split artifacts). Cross-package `@ripl/*`
+  types stay as external imports. The declaration build uses each package's `tsconfig.build.json`
+  (`paths: {}`) so dependencies resolve to their built `dist` rather than source, and API
+  Extractor's compiler is pinned to the project's TypeScript 6 through the root `resolutions`
+  (`@microsoft/api-extractor/typescript`).
+- **Type-checking** is a separate `tsc --noEmit -p tsconfig.json` step at the front of each
+  package's `build` script — the CI type-check gate, since tsup/esbuild do not type-check.
 
-**Package manager:** Yarn 4 (Berry) with PnP
+Per-package `build` script: `tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs`
+
+**Package manager:** Yarn 4 (Berry), `node-modules` linker
 
 ## Performance Guidelines
 

--- a/apps/website/scripts/prepare-playground.mjs
+++ b/apps/website/scripts/prepare-playground.mjs
@@ -52,14 +52,14 @@ for (const pkg of PACKAGES) {
     const esmSrc = path.resolve(pkgDistDir, 'index.js');
     const dtsSrc = path.resolve(pkgDistDir, 'index.d.ts');
 
-    // The ESM bundle comes from tsup and the declarations from a separate
-    // tsc step, so run the package's full build if either artifact is missing.
+    // tsup emits the ESM bundle and (via its API-Extractor dts rollup) the declarations, which
+    // `finalize-dts` flattens into a single `dist/index.d.ts`; run that if either is missing.
     if (!fs.existsSync(esmSrc) || !fs.existsSync(dtsSrc)) {
         const pkgDir = path.resolve(packagesDir, shortName);
         console.warn(`Building ${pkg}...`);
 
         try {
-            execSync('npx tsup && npx tsc -p tsconfig.build.json', {
+            execSync('npx tsup && node ../../scripts/finalize-dts.mjs', {
                 cwd: pkgDir,
                 stdio: 'inherit',
             });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
         "@eslint/markdown": "^8.0.2",
+        "@microsoft/api-extractor": "^7.36.0",
         "@playwright/test": "1.61.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@vitest/coverage-v8": "^4.1.9",
@@ -38,5 +39,8 @@
         "typescript-eslint": "^8.62.1",
         "vitest": "^4.1.9",
         "vue-eslint-parser": "^10.4.1"
+    },
+    "resolutions": {
+        "@microsoft/api-extractor/typescript": "^6.0.3"
     }
 }

--- a/packages/3d/package.json
+++ b/packages/3d/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/canvas": "workspace:^",

--- a/packages/3d/tsconfig.build.json
+++ b/packages/3d/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/canvas/tsconfig.build.json
+++ b/packages/canvas/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json",
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs",
         "test:visual": "playwright test -c test/visual/playwright.config.ts",
         "test:visual:update": "playwright test -c test/visual/playwright.config.ts --update-snapshots"
     },

--- a/packages/charts/tsconfig.build.json
+++ b/packages/charts/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/utilities": "workspace:^"

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/devtools/tsconfig.build.json
+++ b/packages/devtools/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/dom/tsconfig.build.json
+++ b/packages/dom/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/node/tsconfig.build.json
+++ b/packages/node/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/svg/package.json
+++ b/packages/svg/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/svg/tsconfig.build.json
+++ b/packages/svg/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/core": "workspace:^",

--- a/packages/terminal/tsconfig.build.json
+++ b/packages/terminal/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -25,6 +25,6 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     }
 }

--- a/packages/utilities/tsconfig.build.json
+++ b/packages/utilities/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/canvas": "workspace:^",

--- a/packages/web/tsconfig.build.json
+++ b/packages/web/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/packages/webgpu/package.json
+++ b/packages/webgpu/package.json
@@ -25,7 +25,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "tsup && tsc -p tsconfig.build.json"
+        "build": "tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs"
     },
     "dependencies": {
         "@ripl/3d": "workspace:^",

--- a/packages/webgpu/tsconfig.build.json
+++ b/packages/webgpu/tsconfig.build.json
@@ -1,11 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "noEmit": false,
-        "outDir": "./dist",
-        "rootDir": "./src",
         "paths": {}
     }
 }

--- a/scripts/finalize-dts.mjs
+++ b/scripts/finalize-dts.mjs
@@ -1,0 +1,58 @@
+/**
+ * Flattens tsup's experimental (API Extractor) declaration output into a single, self-contained
+ * `dist/index.d.ts` per package.
+ *
+ * tsup's `experimentalDts` emits two files: a thin `index.d.ts` that re-exports from a sibling
+ * `_tsup-dts-rollup.d.ts`, and that rollup file, which already declares every symbol and exports it
+ * under its public name (plus internal `_alias_N` re-exports that exist only so the thin entry can
+ * reference them). Consumers that fetch a single declaration file - notably the docs playground,
+ * which registers each package's `index.d.ts` with Monaco - can't follow the relative re-export, so
+ * we promote the rollup to `index.d.ts`, drop the `_alias_N` re-exports, and delete the split
+ * artifacts. Cross-package `@ripl/*` imports are left untouched (they stay external), and npm
+ * consumers get one tidy declaration file.
+ *
+ * Run from a package directory (tsup's cwd) after the build: `node ../../scripts/finalize-dts.mjs`.
+ */
+
+import {
+    existsSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
+
+import {
+    resolve,
+} from 'node:path';
+
+const dist = resolve(process.cwd(), 'dist');
+const rollup = resolve(dist, '_tsup-dts-rollup.d.ts');
+const indexDts = resolve(dist, 'index.d.ts');
+
+// Remove tsup's `.tsup` scratch directory (intermediate declarations for the rollup); `clean`
+// only clears `dist`, so it would otherwise linger and get picked up by lint/type tooling.
+rmSync(resolve(process.cwd(), '.tsup'), {
+    recursive: true,
+    force: true,
+});
+
+// No rollup means the package emitted no declarations (or was already finalized); nothing to do.
+if (!existsSync(rollup)) {
+    process.exit(0);
+}
+
+const content = readFileSync(rollup, 'utf8')
+    // Drop tsup's internal alias re-exports (`export { foo as foo_alias_1 }`). Every symbol is
+    // already exported under its public name, so these only leak noise into the public surface.
+    .replace(/^export \{ \w+ as \w+_alias_\d+ \};?[ \t]*\r?\n/gm, '');
+
+writeFileSync(indexDts, content);
+
+// Remove the split artifacts so `dist` ships a single declaration file.
+for (const stale of ['_tsup-dts-rollup.d.ts', '_tsup-dts-rollup.d.cts', 'index.d.cts']) {
+    const path = resolve(dist, stale);
+
+    if (existsSync(path)) {
+        rmSync(path);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,9 +38,6 @@
             "@ripl/test-utils": ["./packages/test-utils/src/index.ts"],
         }
     },
-    "files": [
-        "global.d.ts"
-    ],
     "exclude": [
         "node_modules"
     ]

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -34,11 +34,17 @@ function resolveGlobalName(): string {
 
 export default (): Options => ({
     clean: true,
-    // Declarations are emitted by `tsc` (see each package's `tsconfig.build.json`) rather than
-    // tsup's bundled dts: tsup injects a `baseUrl` compiler option that TypeScript 6 deprecates
-    // (TS5101) and its rollup-plugin-dts engine caps at `typescript <6.1.0`, so emitting through
-    // `tsc` keeps the build working today and ready for the future TS7 native compiler.
-    dts: false,
+    // Build against `tsconfig.build.json`, which drops the workspace source aliases (`paths: {}`)
+    // that the root tsconfig defines. API Extractor reads this tsconfig directly, so without it the
+    // rollup would resolve `@ripl/*` to each dependency's source and pull that source into the
+    // analysis; with it, cross-package types resolve to the dependency's built `dist` and stay
+    // external imports in the emitted declarations.
+    tsconfig: 'tsconfig.build.json',
+    // Emit one flat, self-contained `dist/index.d.ts` per package via tsup's API-Extractor-backed
+    // declaration rollup (API Extractor's compiler is pinned to the project's TypeScript 6 through
+    // the root `resolutions`). Type-checking stays a separate `tsc --noEmit` step in each package's
+    // build script (the CI gate); this flag only controls declaration output.
+    experimentalDts: true,
     sourcemap: true,
     target: 'es2023',
     globalName: resolveGlobalName(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,6 +1570,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@microsoft/api-extractor-model@npm:7.33.10":
+  version: 7.33.10
+  resolution: "@microsoft/api-extractor-model@npm:7.33.10"
+  dependencies:
+    "@microsoft/tsdoc": "npm:~0.16.0"
+    "@microsoft/tsdoc-config": "npm:~0.18.1"
+    "@rushstack/node-core-library": "npm:5.23.3"
+  checksum: 10/b137623105f4db40548fa03e9325a5f620b03ce6f8bc2c7943682df6be8dbed300a921d9984eef22037ee61f24e5d8c3cbb72a864c2a782fc36c5cb5be048f0d
+  languageName: node
+  linkType: hard
+
+"@microsoft/api-extractor@npm:^7.36.0":
+  version: 7.58.12
+  resolution: "@microsoft/api-extractor@npm:7.58.12"
+  dependencies:
+    "@microsoft/api-extractor-model": "npm:7.33.10"
+    "@microsoft/tsdoc": "npm:~0.16.0"
+    "@microsoft/tsdoc-config": "npm:~0.18.1"
+    "@rushstack/node-core-library": "npm:5.23.3"
+    "@rushstack/rig-package": "npm:0.7.3"
+    "@rushstack/terminal": "npm:0.24.2"
+    "@rushstack/ts-command-line": "npm:5.3.12"
+    diff: "npm:~8.0.2"
+    minimatch: "npm:10.2.3"
+    resolve: "npm:~1.22.1"
+    semver: "npm:~7.7.4"
+    source-map: "npm:~0.6.1"
+    typescript: "npm:5.9.3"
+  bin:
+    api-extractor: bin/api-extractor
+  checksum: 10/7b9f0482034981a4f1f7dbf65829e38ba187bfc927c32053a16ece29bd22155d97264120f06231f8f0cee66b5e6402f86fbcded62e6a50d3568f6407f699eef1
+  languageName: node
+  linkType: hard
+
+"@microsoft/tsdoc-config@npm:~0.18.1":
+  version: 0.18.1
+  resolution: "@microsoft/tsdoc-config@npm:0.18.1"
+  dependencies:
+    "@microsoft/tsdoc": "npm:0.16.0"
+    ajv: "npm:~8.18.0"
+    jju: "npm:~1.4.0"
+    resolve: "npm:~1.22.2"
+  checksum: 10/1912c4d80af10c548897dafd2b76127a53d5154001fb63029d4414d57022bf0f0aced325d8a3a0970454bf651d506236b4d26c1c473a933ea77382bce67b1236
+  languageName: node
+  linkType: hard
+
+"@microsoft/tsdoc@npm:0.16.0, @microsoft/tsdoc@npm:~0.16.0":
+  version: 0.16.0
+  resolution: "@microsoft/tsdoc@npm:0.16.0"
+  checksum: 10/1eaad3605234dc7e44898c15d1ba3c97fb968af1117025400cba572ce268da05afc36634d1fb9e779457af3ff7f13330aee07a962510a4d9c6612c13f71ee41e
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -2717,6 +2770,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rushstack/node-core-library@npm:5.23.3":
+  version: 5.23.3
+  resolution: "@rushstack/node-core-library@npm:5.23.3"
+  dependencies:
+    ajv: "npm:~8.20.0"
+    ajv-draft-04: "npm:~1.0.0"
+    ajv-formats: "npm:~3.0.1"
+    fs-extra: "npm:~11.3.0"
+    import-lazy: "npm:~4.0.0"
+    jju: "npm:~1.4.0"
+    resolve: "npm:~1.22.1"
+    semver: "npm:~7.7.4"
+  peerDependencies:
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b34386ebc080e81f5d4ba2f2d18d3c448f5896df60404660e8aa9e07cefe10960f43c02eb1a8794baff525f2b19b57c969598b9b23fb18df531f9d52cbc1af3d
+  languageName: node
+  linkType: hard
+
+"@rushstack/problem-matcher@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@rushstack/problem-matcher@npm:0.2.1"
+  peerDependencies:
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/62fda91629577a2f57de19be357cd0990da145ff4933f4d2cd48f423cc03b92fca06dd8916dcbaf1d307a201c104847c77066d45d79fd3c323c4949f0c99bf44
+  languageName: node
+  linkType: hard
+
+"@rushstack/rig-package@npm:0.7.3":
+  version: 0.7.3
+  resolution: "@rushstack/rig-package@npm:0.7.3"
+  dependencies:
+    jju: "npm:~1.4.0"
+    resolve: "npm:~1.22.1"
+  checksum: 10/46cbdf1b4538640a6c93825ddaa7693b45cd7f640b34106ab554319b5d3fae18f65a3c91576c6cce005a1250722159c329ce5f4b1729bead594d9f634cd18616
+  languageName: node
+  linkType: hard
+
+"@rushstack/terminal@npm:0.24.2":
+  version: 0.24.2
+  resolution: "@rushstack/terminal@npm:0.24.2"
+  dependencies:
+    "@rushstack/node-core-library": "npm:5.23.3"
+    "@rushstack/problem-matcher": "npm:0.2.1"
+    supports-color: "npm:~8.1.1"
+  peerDependencies:
+    "@types/node": "*"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/2961f467ddf39f78714e37fb325cc555ea2c3c00a13ed8ba611d29315037183abc31e9d57cdee49180b44da4529cb26a47ab9daafd70da238bdb1b61bbf287ae
+  languageName: node
+  linkType: hard
+
+"@rushstack/ts-command-line@npm:5.3.12":
+  version: 5.3.12
+  resolution: "@rushstack/ts-command-line@npm:5.3.12"
+  dependencies:
+    "@rushstack/terminal": "npm:0.24.2"
+    "@types/argparse": "npm:1.0.38"
+    argparse: "npm:~1.0.9"
+    string-argv: "npm:~0.3.1"
+  checksum: 10/56dfd2e3d338116d36c5587006193d4583ad6449fb66690a9f58c4f1afe3a263a0be1ca38c8e2d7f271f8870940b6c382531e8046ad681ef6b3eb70db73c0f8e
+  languageName: node
+  linkType: hard
+
 "@shikijs/core@npm:2.5.0, @shikijs/core@npm:^2.1.0":
   version: 2.5.0
   resolution: "@shikijs/core@npm:2.5.0"
@@ -2955,6 +3079,13 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10/6cf39f7a2926b1c8bc6fe3f9f03318a33dd6dae81bdbd059983f9c6ee22d10a827f12564d648c05a2d4926e03c86cbe2799fb20609ee65e9efc39603039b4765
+  languageName: node
+  linkType: hard
+
+"@types/argparse@npm:1.0.38":
+  version: 1.0.38
+  resolution: "@types/argparse@npm:1.0.38"
+  checksum: 10/26ed7e3f1e3595efdb883a852f5205f971b798e4c28b7e30a32c5298eee596e8b45834ce831f014d250b9730819ab05acff5b31229666d3af4ba465b4697d0eb
   languageName: node
   linkType: hard
 
@@ -3773,6 +3904,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-draft-04@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "ajv-draft-04@npm:1.0.0"
+  peerDependencies:
+    ajv: ^8.5.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10/3f11fa0e7f7359bef6608657f02ab78e9cc62b1fb7bdd860db0d00351b3863a1189c1a23b72466d2d82726cab4eb20725c76f5e7c134a89865e2bfd0e6828137
+  languageName: node
+  linkType: hard
+
+"ajv-formats@npm:~3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10/5679b9f9ced9d0213a202a37f3aa91efcffe59a6de1a6e3da5c873344d3c161820a1f11cc29899661fee36271fd2895dd3851b6461c902a752ad661d1c1e8722
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.14.0":
   version: 6.15.0
   resolution: "ajv@npm:6.15.0"
@@ -3782,6 +3939,30 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10/0916dda09c152fb5857bc1cc7ce61718e9cec5b7faeff44a74f5e324eed8a556e1a84856724ea322a067b436ecad9f74ac8295fd395449788cca52f0c25bd5fb
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:~8.20.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10/5ce59c0537f4c2aca9a758b412659ec70acb4d5dde971c10ecf21d2e3d799f99acdb4a08e1f5fb2e067c8542930398aae793bb996bb07d3feb81dae22fe2ada9
+  languageName: node
+  linkType: hard
+
+"ajv@npm:~8.18.0":
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10/bfed9de827a2b27c6d4084324eda76a4e32bdde27410b3e9b81d06e6f8f5c78370fc6b93fe1d869f1939ff1d7c4ae8896960995acb8425e3e9288c8884247c48
   languageName: node
   linkType: hard
 
@@ -3855,6 +4036,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 10/18640244e641a417ec75a9bd38b0b2b6b95af5199aa241b131d4b2fb206f334d7ecc600bd194861610a5579084978bfcbb02baa399dbe442d56d0ae5e60dbaef
+  languageName: node
+  linkType: hard
+
+"argparse@npm:~1.0.9":
+  version: 1.0.10
+  resolution: "argparse@npm:1.0.10"
+  dependencies:
+    sprintf-js: "npm:~1.0.2"
+  checksum: 10/c6a621343a553ff3779390bb5ee9c2263d6643ebcd7843227bdde6cc7adbed796eb5540ca98db19e3fd7b4714e1faa51551f8849b268bb62df27ddb15cbcd91e
   languageName: node
   linkType: hard
 
@@ -4023,7 +4213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
+"brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
   version: 5.0.7
   resolution: "brace-expansion@npm:5.0.7"
   dependencies:
@@ -4774,6 +4964,13 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
+  languageName: node
+  linkType: hard
+
+"diff@npm:~8.0.2":
+  version: 8.0.4
+  resolution: "diff@npm:8.0.4"
+  checksum: 10/b4036ceda0d1e10683a2313079ed52c5e6b09553ae29da87bce81d98714d9725dbf3c0f6f7c3b1f16eec049fe17087e38ee329e732580fa62f6ec1c2487b2435
   languageName: node
   linkType: hard
 
@@ -5548,6 +5745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-uri@npm:^3.0.1":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
+  languageName: node
+  linkType: hard
+
 "fault@npm:^2.0.0":
   version: 2.0.1
   resolution: "fault@npm:2.0.1"
@@ -5716,7 +5920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.2.0, fs-extra@npm:^11.3.5":
+"fs-extra@npm:^11.2.0, fs-extra@npm:^11.3.5, fs-extra@npm:~11.3.0":
   version: 11.3.6
   resolution: "fs-extra@npm:11.3.6"
   dependencies:
@@ -6285,6 +6489,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-lazy@npm:~4.0.0":
+  version: 4.0.0
+  resolution: "import-lazy@npm:4.0.0"
+  checksum: 10/943309cc8eb01ada12700448c288b0384f77a1bc33c7e00fa4cb223c665f467a13ce9aaceb8d2e4cf586b07c1d2828040263dcc069873ce63cfc2ac6fd087971
+  languageName: node
+  linkType: hard
+
 "import-local@npm:3.1.0":
   version: 3.1.0
   resolution: "import-local@npm:3.1.0"
@@ -6593,6 +6804,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jju@npm:~1.4.0":
+  version: 1.4.0
+  resolution: "jju@npm:1.4.0"
+  checksum: 10/1067ff8ce02221faac5a842116ed0ec79a53312a111d0bf8342a80bd02c0a3fdf0b8449694a65947db0a3e8420e8b326dffb489c7dd5866efc380c0d1708a707
+  languageName: node
+  linkType: hard
+
 "joycon@npm:^3.1.1":
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
@@ -6718,6 +6936,13 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 10/7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10/02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
   languageName: node
   linkType: hard
 
@@ -7945,6 +8170,15 @@ __metadata:
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: 10/bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:10.2.3":
+  version: 10.2.3
+  resolution: "minimatch@npm:10.2.3"
+  dependencies:
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10/186c6a6ce9f7a79ae7776efc799c32d1a6670ebbcc2a8756e6cb6ec4aab7439a6ca6e592e1a6aac5f21674eefae5b19821b8fa95072a4f4567da1ae40eb6075d
   languageName: node
   linkType: hard
 
@@ -9543,7 +9777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0":
+"resolve@npm:^1.10.0, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
   version: 1.22.12
   resolution: "resolve@npm:1.22.12"
   dependencies:
@@ -9557,7 +9791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.12
   resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
   dependencies:
@@ -9602,6 +9836,7 @@ __metadata:
     "@eslint/compat": "npm:^2.1.0"
     "@eslint/js": "npm:^10.0.1"
     "@eslint/markdown": "npm:^8.0.2"
+    "@microsoft/api-extractor": "npm:^7.36.0"
     "@playwright/test": "npm:1.61.1"
     "@stylistic/eslint-plugin": "npm:^5.10.0"
     "@vitest/coverage-v8": "npm:^4.1.9"
@@ -9872,7 +10107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.7.4":
+"semver@npm:7.7.4, semver@npm:~7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -10006,7 +10241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.6.1":
+"source-map@npm:^0.6.1, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
@@ -10096,6 +10331,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sprintf-js@npm:~1.0.2":
+  version: 1.0.3
+  resolution: "sprintf-js@npm:1.0.3"
+  checksum: 10/c34828732ab8509c2741e5fd1af6b767c3daf2c642f267788f933a65b1614943c282e74c4284f4fa749c264b18ee016a0d37a3e5b73aee446da46277d3a85daa
+  languageName: node
+  linkType: hard
+
 "ssri@npm:12.0.0, ssri@npm:^12.0.0":
   version: 12.0.0
   resolution: "ssri@npm:12.0.0"
@@ -10125,6 +10367,13 @@ __metadata:
   version: 4.2.0
   resolution: "std-env@npm:4.2.0"
   checksum: 10/d30c3ae49c5568b4e61dca628eaafe12944dbcfe76980e5b1b1499b48e23f85f1ee01fe2306eeef5964a80b763948bbf2ba40490bc53709f45cf989071c9e4e7
+  languageName: node
+  linkType: hard
+
+"string-argv@npm:~0.3.1":
+  version: 0.3.2
+  resolution: "string-argv@npm:0.3.2"
+  checksum: 10/f9d3addf887026b4b5f997a271149e93bf71efc8692e7dc0816e8807f960b18bcb9787b45beedf0f97ff459575ee389af3f189d8b649834cac602f2e857e75af
   languageName: node
   linkType: hard
 
@@ -10239,6 +10488,15 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10/c8bb7afd564e3b26b50ca6ee47572c217526a1389fe018d00345856d4a9b08ffbd61fadaf283a87368d94c3dcdb8f5ffe2650a5a65863e21ad2730ca0f05210a
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:~8.1.1":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10/157b534df88e39c5518c5e78c35580c1eca848d7dbaf31bbe06cdfc048e22c7ff1a9d046ae17b25691128f631a51d9ec373c1b740c12ae4f0de6e292037e4282
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Restores single-file TypeScript declarations. The build previously moved declaration emit from tsup's bundled dts to `tsc`, which emits a **multi-file `.d.ts` tree** whose top-level `index.d.ts` only re-exports siblings. The docs playground's Monaco loader fetches a single `index.d.ts` per package and wraps it in `declare module`, so those relative re-exports resolved to nothing and IntelliSense collapsed to a stub. It also fragmented the types shipped to npm.

tsup now owns the whole build again and emits **one self-contained `dist/index.d.ts` per package** via its API-Extractor-backed `experimentalDts` rollup, flattened by `scripts/finalize-dts.mjs`.

## Changes

- **`tsup.config.ts`**: enable `experimentalDts`; build declarations against `tsconfig.build.json` (`paths: {}`) so cross-package `@ripl/*` types resolve to each dependency's built `dist` and stay **external** imports in the rollup, rather than pulling dependency source into the analysis.
- **`scripts/finalize-dts.mjs`** (new): promotes tsup's rollup to `dist/index.d.ts`, strips its internal `_alias_N` re-exports, and removes the split artifacts, so each package ships a single flat declaration file. Also clears tsup's `.tsup` scratch dir.
- **Root `package.json`**: add `@microsoft/api-extractor` (dev) and a `resolutions` override pinning its compiler to the project's **TypeScript 6** — its bundled 5.9.3 can't parse TS6 declarations.
- **Per-package `build` script** → `tsc --noEmit -p tsconfig.json && tsup && node ../../scripts/finalize-dts.mjs`. The `tsc --noEmit` step preserves the CI type-check gate (tsup/esbuild don't type-check).
- **`tsconfig.build.json`** (all packages): reduced to just `paths: {}` (its declaration-emit role is now tsup's).
- **Root `tsconfig.json`**: drop the empty `global.d.ts` `files` entry that the rollup misresolved to each package dir.
- **`prepare-playground.mjs`**, **`AGENTS.md`**, **`.gitignore`** updated to match.

## Verification

- `yarn build` — all 12 packages emit a single self-contained `dist/index.d.ts` (no relative imports; `@ripl/*` kept external).
- A consumer typecheck against the built `dist` resolves `@ripl/charts` / `@ripl/web` symbols (the npm + playground resolution path).
- `cd apps/website && yarn prepare-playground` writes non-stub types for every `@ripl/*` package.
- `yarn test` (1801 tests) and `yarn lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwEmuy6xKusDzNNDVRKCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwEmuy6xKusDzNNDVRKCA)_