### PR TITLE
feat(charts): default padding 16 + number|object; docs: list @ripl/devtools

### DIFF
--- a/apps/website/src/.vitepress/components/example-terminal-interactive.vue
+++ b/apps/website/src/.vitepress/components/example-terminal-interactive.vue
@@ -280,12 +280,8 @@ function runLineChart(ctx: TerminalContext) {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
+        // Tight padding: the terminal's braille grid is a small logical canvas, so the default 16 would crowd the plot.
+        padding: 10,
     });
 }
 
@@ -346,12 +342,8 @@ function runBarChart(ctx: TerminalContext) {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
+        // Tight padding: the terminal's braille grid is a small logical canvas, so the default 16 would crowd the plot.
+        padding: 10,
     });
 }
 
@@ -435,12 +427,8 @@ function runStockChart(ctx: TerminalContext) {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
+        // Tight padding: the terminal's braille grid is a small logical canvas, so the default 16 would crowd the plot.
+        padding: 10,
     });
 }
 
@@ -499,12 +487,8 @@ function runGanttChart(ctx: TerminalContext) {
         progress: 'progress',
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
+        // Tight padding: the terminal's braille grid is a small logical canvas, so the default 16 would crowd the plot.
+        padding: 10,
     });
 }
 

--- a/apps/website/src/charts/arc-diagram.md
+++ b/apps/website/src/charts/arc-diagram.md
@@ -147,7 +147,6 @@ const { contextChanged, chart } = useRiplChart(context => {
     return createArcDiagramChart(context, {
         nodes,
         links,
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -98,7 +98,6 @@ const { contextChanged, chart } = useRiplChart(context => {
     return createChordChart(context, {
         labels: LABELS,
         matrix,
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/force-directed.md
+++ b/apps/website/src/charts/force-directed.md
@@ -137,7 +137,6 @@ const { contextChanged, chart } = useRiplChart(context => {
         nodes,
         links,
         root: 'eng-hub',
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/funnel.md
+++ b/apps/website/src/charts/funnel.md
@@ -88,7 +88,10 @@ const { contextChanged, chart } = useRiplChart(context => {
         key: 'stage',
         value: 'value',
         label: 'stage',
-        padding: { top: 10, right: 40, bottom: 10, left: 40 },
+        padding: {
+            left: 40,
+            right: 40,
+        },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/gauge.md
+++ b/apps/website/src/charts/gauge.md
@@ -104,7 +104,6 @@ function buildOptions() {
 const { contextChanged, chart } = useRiplChart(context => {
     return createGaugeChart(context, {
         label: 'Performance',
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/getting-started.md
+++ b/apps/website/src/charts/getting-started.md
@@ -123,7 +123,7 @@ All charts extend `BaseChartOptions` and share these core options:
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `padding` | `Partial<ChartPadding>` | `{ top: 10, right: 10, bottom: 10, left: 10 }` | Inner padding around the chart area |
+| `padding` | `number \| Partial<ChartPadding>` | `16` | Space reserved around the chart area (a number applies to all edges; an object sets individual ones) |
 | `animation` | `boolean \| Partial<ChartAnimationOptions>` | `{ enabled: true, duration: 1000, ease: 'easeOutCubic' }` | Animation toggle or configuration |
 | `title` | `string \| Partial<ChartTitleOptions>` | — | Chart title text or configuration |
 | `autoRender` | `boolean` | `true` | Automatically render on creation and update |

--- a/apps/website/src/charts/packed-circle.md
+++ b/apps/website/src/charts/packed-circle.md
@@ -93,7 +93,6 @@ const { contextChanged, chart } = useRiplChart(context => {
         key: 'name',
         value: 'size',
         label: 'name',
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/polar-scatter.md
+++ b/apps/website/src/charts/polar-scatter.md
@@ -142,7 +142,6 @@ const example = ref();
 const { contextChanged, chart } = useRiplChart(context => {
     return createPolarScatterChart(context, {
         data: samples,
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/radar.md
+++ b/apps/website/src/charts/radar.md
@@ -123,7 +123,6 @@ const example = ref();
 const { contextChanged, chart } = useRiplChart(context => {
     return createRadarChart(context, {
         data,
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/radial-bar.md
+++ b/apps/website/src/charts/radial-bar.md
@@ -112,7 +112,6 @@ const { contextChanged, chart } = useRiplChart(context => {
         data,
         key: 'language',
         value: 'share',
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/sankey.md
+++ b/apps/website/src/charts/sankey.md
@@ -126,7 +126,7 @@ const { contextChanged, chart } = useRiplChart(context => {
             { id: 'content', label: 'Content' },
         ],
         links,
-        padding: { top: 10, right: 80, bottom: 10, left: 10 },
+        padding: { right: 80 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/charts/shared-options.md
+++ b/apps/website/src/charts/shared-options.md
@@ -11,29 +11,36 @@ All Ripl charts extend `BaseChartOptions` and support a common set of feature op
 
 ## Padding
 
-Controls the inner padding around the chart drawing area.
+Controls the space reserved around the chart drawing area. Pass a single number to apply the same padding to all four edges, or an object to set individual edges.
 
 ```ts
-const chart = createBarChart('#container', {
+// A single number applies to every edge
+createBarChart('#container', {
+    padding: 24,
+    // ...
+});
+
+// An object sets individual edges; unspecified edges keep the default
+createBarChart('#container', {
     padding: {
-        top: 10,
-        right: 10,
-        bottom: 10,
-        left: 10,
+        top: 16,
+        right: 32,
+        bottom: 16,
+        left: 32,
     },
     // ...
 });
 ```
 
-Every side defaults to `10`. Supply any subset of `top`/`right`/`bottom`/`left` to override
-individual sides; the rest keep the default.
+Every side defaults to `16`. Supply a number to set all four edges at once, or any subset of
+`top`/`right`/`bottom`/`left` to override individual sides; the rest keep the default.
 
 | Property | Type | Default |
 | --- | --- | --- |
-| `top` | `number` | `10` |
-| `right` | `number` | `10` |
-| `bottom` | `number` | `10` |
-| `left` | `number` | `10` |
+| `top` | `number` | `16` |
+| `right` | `number` | `16` |
+| `bottom` | `number` | `16` |
+| `left` | `number` | `16` |
 
 ## Animation
 

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -104,7 +104,6 @@ const example = ref();
 const { contextChanged, chart } = useRiplChart(context => {
     return createSunburstChart(context, {
         data,
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildCommonOptions(config),
     });
 });

--- a/apps/website/src/charts/treemap.md
+++ b/apps/website/src/charts/treemap.md
@@ -88,7 +88,6 @@ const { contextChanged, chart } = useRiplChart(context => {
         key: 'name',
         value: 'value',
         label: 'name',
-        padding: { top: 10, right: 10, bottom: 10, left: 10 },
         ...buildOptions(),
     });
 });

--- a/apps/website/src/demos/product-analytics/components/active-users-chart.vue
+++ b/apps/website/src/demos/product-analytics/components/active-users-chart.vue
@@ -77,12 +77,6 @@ function buildChart() {
         data,
         key: 'date',
         format: 'number',
-        padding: {
-            top: 16,
-            right: 16,
-            bottom: 16,
-            left: 12,
-        },
         grid: true,
         series: [
             {

--- a/apps/website/src/demos/product-analytics/components/browser-share-chart.vue
+++ b/apps/website/src/demos/product-analytics/components/browser-share-chart.vue
@@ -57,12 +57,6 @@ function buildChart() {
         format: (value: number) => `${value}%`,
         // Leader-line labels sit outside the donut and animate with their connectors.
         labels: 'outside' as const,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 20,
-            left: 20,
-        },
     };
 
     if (chart) {

--- a/apps/website/src/demos/product-analytics/components/conversion-funnel.vue
+++ b/apps/website/src/demos/product-analytics/components/conversion-funnel.vue
@@ -65,10 +65,8 @@ function buildChart() {
         borderRadius: 4,
         format: 'number' as const,
         padding: {
-            top: 20,
-            right: 40,
-            bottom: 20,
             left: 40,
+            right: 40,
         },
     };
 

--- a/apps/website/src/demos/product-analytics/components/error-rate-gauge.vue
+++ b/apps/website/src/demos/product-analytics/components/error-rate-gauge.vue
@@ -63,12 +63,6 @@ function buildChart() {
         tickCount: 5,
         showTickLabels: true,
         formatTick: (v: number) => `${v}%`,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 20,
-            left: 20,
-        },
     };
 
     if (chart) {

--- a/apps/website/src/demos/product-analytics/components/feature-adoption-chart.vue
+++ b/apps/website/src/demos/product-analytics/components/feature-adoption-chart.vue
@@ -59,12 +59,6 @@ function buildChart() {
     const options = {
         data,
         key: 'feature' as const,
-        padding: {
-            top: 16,
-            right: 16,
-            bottom: 16,
-            left: 12,
-        },
         grid: true,
         legend: true,
         stacked: false,

--- a/apps/website/src/demos/product-analytics/components/page-load-scatter.vue
+++ b/apps/website/src/demos/product-analytics/components/page-load-scatter.vue
@@ -68,12 +68,6 @@ function buildChart() {
                 format: (v: number) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v)),
             },
         },
-        padding: {
-            top: 16,
-            right: 16,
-            bottom: 16,
-            left: 12,
-        },
         series: [
             {
                 id: 'pages',

--- a/apps/website/src/demos/product-analytics/components/retention-heatmap.vue
+++ b/apps/website/src/demos/product-analytics/components/retention-heatmap.vue
@@ -65,12 +65,6 @@ function buildChart() {
             x: { title: 'Weeks Since Signup' },
             y: { title: 'Cohort' },
         },
-        padding: {
-            top: 16,
-            right: 16,
-            bottom: 16,
-            left: 12,
-        },
     };
 
     if (chart) {

--- a/apps/website/src/demos/product-analytics/components/user-journey-sankey.vue
+++ b/apps/website/src/demos/product-analytics/components/user-journey-sankey.vue
@@ -49,12 +49,6 @@ function buildChart() {
         links,
         nodeWidth: 18,
         nodePadding: 14,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 20,
-            left: 20,
-        },
     };
 
     if (chart) {

--- a/apps/website/src/demos/trading-dashboard/components/commodity-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/commodity-chart.vue
@@ -87,12 +87,7 @@ function buildChart() {
         data,
         key: 'date',
         format: (value: number) => `$${value.toFixed(2)}`,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 30,
-            left: 20,
-        },
+        padding: { bottom: 30 },
         series,
     });
 

--- a/apps/website/src/demos/trading-dashboard/components/market-overview-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/market-overview-chart.vue
@@ -88,12 +88,7 @@ function buildChart() {
         data,
         key: 'date',
         format: (value: number) => `$${value.toFixed(2)}`,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 30,
-            left: 20,
-        },
+        padding: { bottom: 30 },
         series: [
             {
                 id: 'close',

--- a/apps/website/src/demos/trading-dashboard/components/stock-candlestick.vue
+++ b/apps/website/src/demos/trading-dashboard/components/stock-candlestick.vue
@@ -57,12 +57,6 @@ function buildChart() {
         showVolume: true,
         upColor: '#16a34a',
         downColor: '#dc2626',
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 20,
-            left: 20,
-        },
         axis: {
             x: {
                 format: (val: string) => {

--- a/apps/website/src/demos/trading-dashboard/components/stock-history-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/stock-history-chart.vue
@@ -81,12 +81,7 @@ function buildChart() {
         data,
         key: 'date',
         format: (value: number) => `$${value.toFixed(2)}`,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 30,
-            left: 20,
-        },
+        padding: { bottom: 30 },
         series: [
             {
                 id: 'close',

--- a/apps/website/src/demos/trading-dashboard/components/stock-volume-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/stock-volume-chart.vue
@@ -63,12 +63,7 @@ function buildChart() {
         data,
         key: 'date',
         format: formatVolume,
-        padding: {
-            top: 20,
-            right: 20,
-            bottom: 30,
-            left: 20,
-        },
+        padding: { bottom: 30 },
         series: [
             {
                 id: 'volume',

--- a/apps/website/src/docs/core/getting-started/installation.md
+++ b/apps/website/src/docs/core/getting-started/installation.md
@@ -15,6 +15,7 @@ Ripl is a modular library split into focused packages so you only ship what you 
 | `@ripl/3d` | 3D rendering: shapes, camera, shading, and projection onto 2D contexts |
 | `@ripl/terminal` | Terminal rendering context with braille-character output and ANSI truecolor |
 | `@ripl/node` | Node.js runtime bindings that configure the platform factory for headless environments |
+| `@ripl/devtools` | Runtime bridge connecting Ripl contexts, scenes, and renderers to the Ripl devtools browser extension |
 | `@ripl/dom` | DOM utilities used internally by browser contexts |
 | `@ripl/utilities` | Shared typed utility functions used across all packages |
 
@@ -29,6 +30,7 @@ Most projects only need one or two packages. Here's a quick guide:
 - **3D (WebGPU)** → `@ripl/web` + `@ripl/3d` + `@ripl/webgpu`
 - **Terminal / CLI** → `@ripl/terminal` + `@ripl/node`
 - **Terminal charts** → `@ripl/terminal` + `@ripl/node` + `@ripl/charts`
+- **Debugging** → `@ripl/devtools` (pairs with the Ripl devtools browser extension)
 
 > [!TIP]
 > Internal packages (`@ripl/core`, `@ripl/canvas`, `@ripl/dom`, `@ripl/utilities`) are installed automatically as dependencies, so you never need to install them directly.

--- a/packages/charts/src/constants/layout.ts
+++ b/packages/charts/src/constants/layout.ts
@@ -1,0 +1,2 @@
+/** Default space, in pixels, reserved around every chart when its `padding` option is unset. */
+export const DEFAULT_CHART_PADDING = 16;

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -60,6 +60,7 @@ import type {
 
 import {
     ChartLayout,
+    resolveChartPadding,
 } from './layout';
 
 import type {
@@ -100,8 +101,8 @@ export { ChartLayout };
 export interface BaseChartOptions {
     /** Whether the chart renders automatically on construction and after every {@link Chart.update}. Defaults to `true`. */
     autoRender?: boolean;
-    /** Space reserved around the chart, per edge, in pixels. */
-    padding?: Partial<ChartPadding>;
+    /** Space reserved around the chart, in pixels. A single number applies to all four edges; an object sets per-edge values `{ top, right, bottom, left }`, leaving unspecified edges at the default. Defaults to `16`. */
+    padding?: number | Partial<ChartPadding>;
     /** Chart title as plain text, or a {@link ChartTitleOptions} object for full control. */
     title?: string | Partial<ChartTitleOptions>;
     /** Animation configuration, or a boolean toggling all transitions. See {@link ChartAnimationOptions}. */
@@ -466,15 +467,9 @@ export class Chart<
     }
 
     protected getPadding(): ChartPadding {
-        const p = this.options.padding || {};
-
-        // All four sides default to 10; user-supplied values win via the `??` fallbacks.
-        return {
-            top: p.top ?? 10,
-            right: p.right ?? 10,
-            bottom: p.bottom ?? 10,
-            left: p.left ?? 10,
-        };
+        // A number applies to all edges; a partial object fills unspecified edges with the shared
+        // default (see `DEFAULT_CHART_PADDING`), so every chart reserves 16px unless told otherwise.
+        return resolveChartPadding(this.options.padding);
     }
 
     protected getChartArea(): ChartArea {

--- a/packages/charts/src/core/layout.ts
+++ b/packages/charts/src/core/layout.ts
@@ -8,6 +8,12 @@
  * titles to overlap or clip the plotting area.
  */
 
+import {
+    DEFAULT_CHART_PADDING,
+} from '../constants/layout';
+
+export { DEFAULT_CHART_PADDING };
+
 /** The center point and inscribed size of a rectangular {@link ChartArea}. */
 export interface AreaCenter {
     /** The horizontal center of the area, in chart pixels. */
@@ -40,6 +46,36 @@ export interface ChartPadding {
     bottom: number;
     /** Left padding, in pixels. */
     left: number;
+}
+
+/**
+ * Resolves a chart padding input into a full {@link ChartPadding}. A single number applies to all
+ * four edges; a partial object sets individual edges and leaves the rest at `fallback`; `undefined`
+ * falls back on every edge. Explicit `0` values are preserved.
+ *
+ * @param input - A uniform number, a partial per-edge object, or `undefined`.
+ * @param fallback - Value used for any edge left unspecified. Defaults to {@link DEFAULT_CHART_PADDING}.
+ * @returns Fully resolved padding for all four edges.
+ */
+export function resolveChartPadding(
+    input?: number | Partial<ChartPadding>,
+    fallback: number = DEFAULT_CHART_PADDING
+): ChartPadding {
+    if (typeof input === 'number') {
+        return {
+            top: input,
+            right: input,
+            bottom: input,
+            left: input,
+        };
+    }
+
+    return {
+        top: input?.top ?? fallback,
+        right: input?.right ?? fallback,
+        bottom: input?.bottom ?? fallback,
+        left: input?.left ?? fallback,
+    };
 }
 
 /** An edge of the layout from which a band can be reserved. */

--- a/packages/charts/test/layout.test.ts
+++ b/packages/charts/test/layout.test.ts
@@ -6,6 +6,8 @@ import {
 
 import {
     ChartLayout,
+    DEFAULT_CHART_PADDING,
+    resolveChartPadding,
 } from '../src/core/layout';
 
 const PADDING = {
@@ -134,5 +136,59 @@ describe('ChartLayout', () => {
 
         expect(layout.area.width).toBe(0);
         expect(layout.area.height).toBeGreaterThanOrEqual(0);
+    });
+});
+
+describe('resolveChartPadding', () => {
+    it('defaults every edge to 16 when no input is given', () => {
+        expect(resolveChartPadding()).toEqual({
+            top: DEFAULT_CHART_PADDING,
+            right: DEFAULT_CHART_PADDING,
+            bottom: DEFAULT_CHART_PADDING,
+            left: DEFAULT_CHART_PADDING,
+        });
+        expect(DEFAULT_CHART_PADDING).toBe(16);
+    });
+
+    it('applies a single number to all four edges', () => {
+        expect(resolveChartPadding(24)).toEqual({
+            top: 24,
+            right: 24,
+            bottom: 24,
+            left: 24,
+        });
+    });
+
+    it('fills unspecified edges of a partial object with the default', () => {
+        expect(resolveChartPadding({ right: 80 })).toEqual({
+            top: 16,
+            right: 80,
+            bottom: 16,
+            left: 16,
+        });
+    });
+
+    it('preserves an explicit 0 rather than falling back to the default', () => {
+        expect(resolveChartPadding(0)).toEqual({
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+        });
+        expect(resolveChartPadding({ top: 0 })).toEqual({
+            top: 0,
+            right: 16,
+            bottom: 16,
+            left: 16,
+        });
+    });
+
+    it('honours a custom fallback for unspecified edges', () => {
+        expect(resolveChartPadding({ left: 40 }, 8)).toEqual({
+            top: 8,
+            right: 8,
+            bottom: 8,
+            left: 40,
+        });
     });
 });

--- a/packages/charts/test/visual/gallery.ts
+++ b/packages/charts/test/visual/gallery.ts
@@ -513,12 +513,7 @@ for (let i = 0; i < 40; i++) {
 createSankeyChart(mount('sankey'), {
     animation: false,
     title: 'Sankey — Budget',
-    padding: {
-        top: 20,
-        right: 80,
-        bottom: 20,
-        left: 20,
-    },
+    padding: { right: 80 },
     nodes: [
         {
             id: 'budget',

--- a/sandbox/node/charts.ts
+++ b/sandbox/node/charts.ts
@@ -72,12 +72,6 @@ function runBarChart() {
         tooltip: false,
         grid: true,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
     });
 }
 
@@ -113,12 +107,6 @@ function runPieChart() {
         label: 'name',
         innerRadius: 0.35,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
     });
 }
 
@@ -219,12 +207,6 @@ function runStockChart() {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
     });
 }
 
@@ -288,12 +270,6 @@ function runLineChart() {
         grid: true,
         tooltip: false,
         animation: { duration: 2000 },
-        padding: {
-            top: 10,
-            right: 10,
-            bottom: 10,
-            left: 10,
-        },
     });
 }
 


### PR DESCRIPTION
Two small, self-contained changes.

## 1. Chart padding

- The chart `padding` option now accepts **either a single number** (applied to all four edges) **or a partial `{ top, right, bottom, left }` object**.
- The default is **16** on every side (was 10), stored as the shared `DEFAULT_CHART_PADDING` constant.
- `resolveChartPadding` normalizes the input in one place (`Chart.getPadding`), so every chart type inherits the behavior; explicit `0` is preserved.
- Demos and docs are swept to match: redundant per-edge overrides removed so charts inherit the shared default, genuinely asymmetric ones slimmed to the edges that actually differ, and the padding docs corrected to `16` / `number | Partial<ChartPadding>`.

> ⚠️ The default changed from 10 to 16, so the chart **visual snapshots** (`packages/charts/test/visual/__snapshots__`) need regenerating with `yarn --cwd packages/charts test:visual:update`. Automated regen in the sandbox was blocked by a pre-existing Playwright harness error ("No tests found"), unrelated to this change; CI doesn't run the visual suite.

## 2. Devtools listing

Add the published `@ripl/devtools` package (the runtime bridge to the devtools browser extension) to the installation page's packages table and the "What to Install" guide, where it was missing.

## Verification

- `yarn test` (charts: 308, incl. new `resolveChartPadding` cases; repo: 1801) and `yarn lint` pass.
- New public API (`DEFAULT_CHART_PADDING`, `resolveChartPadding`, `BaseChartOptions.padding`) is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKwEmuy6xKusDzNNDVRKCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKwEmuy6xKusDzNNDVRKCA)_