### PR TITLE
CI: Add devtools extension build workflow and update actions

### DIFF
--- a/.github/workflows/build-devtools-extension.yml
+++ b/.github/workflows/build-devtools-extension.yml
@@ -1,0 +1,52 @@
+name: Build Devtools Extension
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-devtools-extension-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build extension
+        run: yarn workspace @ripl/devtools-extension build
+
+      - name: Package extension
+        id: package
+        run: |
+          VERSION="$(node -p "require('./apps/devtools-extension/package.json').version")"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          ZIP_NAME="ripl-devtools-extension-${VERSION}-${SHORT_SHA}.zip"
+          ( cd apps/devtools-extension/dist && zip -r "${GITHUB_WORKSPACE}/${ZIP_NAME}" . )
+          echo "zip_name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripl-devtools-extension
+          path: ${{ steps.package.outputs.zip_name }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ permissions:
   checks: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -19,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn
@@ -39,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: yarn
@@ -58,7 +62,7 @@ jobs:
 
       - name: Test report
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: Test Results
           path: .reports/test-results.xml


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow to build and package the devtools extension, and updates existing CI workflows to use newer action versions with improved concurrency handling.

## Changes

### New Workflow
- **Build Devtools Extension** (`.github/workflows/build-devtools-extension.yml`)
  - Triggers on pushes to `main` and manual workflow dispatch
  - Builds the `@ripl/devtools-extension` workspace
  - Packages the built extension as a versioned ZIP artifact
  - Uploads artifact with 30-day retention for distribution

### Workflow Updates
- **test.yml**
  - Added concurrency configuration to cancel in-progress runs on the same ref
  - Updated action versions:
    - `actions/checkout@v4` → `v6`
    - `actions/setup-node@v4` → `v6`
    - `dorny/test-reporter@v1` → `v3`

## Implementation Details
- The devtools extension build extracts the version from `package.json` and includes a short commit SHA in the artifact filename for traceability
- Concurrency groups prevent duplicate workflow runs, improving CI efficiency
- Action version updates bring security patches and performance improvements

https://claude.ai/code/session_011HcWf5pNh1Jw3qnnJMXkuZ