### PR TITLE
feat(charts): segmented lineStyle for line/area/trend series

### DIFF
--- a/apps/website/src/charts/area.md
+++ b/apps/website/src/charts/area.md
@@ -46,6 +46,7 @@ The **Area Chart** renders filled areas beneath lines, making it easy to compare
                     <option value="solid">Solid</option>
                     <option value="dashed">Dashed</option>
                     <option value="dotted">Dotted</option>
+                    <option value="segmented">Segmented</option>
                 </RiplSelect>
             </RiplField>
             <RiplField label="Line width" option="lineWidth">
@@ -124,7 +125,7 @@ const { extras, reset } = useChartExtras({
     stackMode: 'overlaid' as keyof typeof STACK_MODE_VALUES,
     multiAxis: false,
     lineType: 'monotoneX' as PolylineRenderer,
-    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted',
+    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted' | 'segmented',
     lineWidth: 2,
     fillOpacity: 0.3,
     markers: false,
@@ -180,6 +181,25 @@ function activeData() {
     }));
 }
 
+// Bounds are read off the live dataset so the demo survives adding and removing points.
+function resolveLineStyle() {
+    if (extras.lineStyle !== 'segmented') {
+        return extras.lineStyle;
+    }
+
+    return [
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.25)]?.month,
+            to: (data: any[]) => data[Math.floor(data.length * 0.5)]?.month,
+            style: 'dashed',
+        },
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.75)]?.month,
+            style: 'dotted',
+        },
+    ];
+}
+
 function getSeries() {
     const multiAxis = multiAxisActive();
 
@@ -189,7 +209,7 @@ function getSeries() {
         label: s.label,
         fillOpacity: extras.fillOpacity,
         lineType: extras.lineType,
-        lineStyle: extras.lineStyle,
+        lineStyle: resolveLineStyle(),
         lineWidth: extras.lineWidth,
         markers: extras.markers,
         color: config.colors[s.id],
@@ -432,6 +452,67 @@ createAreaChart('#container', {
     ],
 });
 ```
+
+### Segmented line styles
+
+`lineStyle` also accepts spans anchored to data keys, so one line can change style along its
+length — actuals solid and a forecast dashed, say. The line is still a single polyline, so the
+draw-on animation and point morphing are unaffected.
+
+```ts
+createAreaChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: [
+                {
+                    from: 'Feb',
+                    to: 'Jun',
+                    style: 'dashed',
+                },
+                {
+                    // A function receives the dataset and returns the key to anchor to.
+                    from: data => data[data.length - 3].month,
+                    style: 'dotted',
+                },
+            ],
+        },
+    ],
+});
+```
+
+`from` defaults to the start of the line and `to` — which is inclusive — to its end. Use the object
+form to name the fallback style explicitly:
+
+```ts
+createAreaChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: {
+                default: 'solid',
+                segments: [
+                    {
+                        from: 'Feb',
+                        to: 'Jun',
+                        style: 'dashed',
+                    },
+                ],
+            },
+        },
+    ],
+});
+```
+
+See the [line chart](/charts/line#segmented-line-styles) for the full rules.
 
 ## Options
 

--- a/apps/website/src/charts/line.md
+++ b/apps/website/src/charts/line.md
@@ -39,6 +39,7 @@ The **Line Chart** renders one or more data series as smooth or straight lines w
                     <option value="solid">Solid</option>
                     <option value="dashed">Dashed</option>
                     <option value="dotted">Dotted</option>
+                    <option value="segmented">Segmented</option>
                 </RiplSelect>
             </RiplField>
             <RiplField label="Line width" option="lineWidth">
@@ -149,7 +150,7 @@ const { extras, reset } = useChartExtras({
     timeAxis: false,
     multiAxis: false,
     lineType: 'monotoneX' as PolylineRenderer,
-    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted',
+    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted' | 'segmented',
     lineWidth: 2,
     markers: true,
     markerSymbol: 'mixed' as 'mixed' | 'circle' | 'square' | 'diamond' | 'triangle',
@@ -230,13 +231,34 @@ function resolveMarker(index: number) {
     return extras.markerSymbol;
 }
 
+// Bounds are read off the live dataset so the demo survives adding, removing and the time axis.
+function resolveLineStyle() {
+    if (extras.lineStyle !== 'segmented') {
+        return extras.lineStyle;
+    }
+
+    const key = activeKey();
+
+    return [
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.25)]?.[key],
+            to: (data: any[]) => data[Math.floor(data.length * 0.5)]?.[key],
+            style: 'dashed',
+        },
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.75)]?.[key],
+            style: 'dotted',
+        },
+    ];
+}
+
 function getSeries() {
     return seriesMeta.map((s, index) => ({
         id: s.id,
         value: s.id,
         label: s.label,
         lineType: extras.lineType,
-        lineStyle: extras.lineStyle,
+        lineStyle: resolveLineStyle(),
         lineWidth: extras.lineWidth,
         markers: extras.markers,
         marker: resolveMarker(index),
@@ -451,6 +473,75 @@ createLineChart('#container', {
     ],
 });
 ```
+
+### Segmented line styles
+
+`lineStyle` also accepts spans anchored to data keys, so one line can change style along its
+length — actuals solid and a forecast dashed, say. The line is still a single polyline, so the
+draw-on animation and point morphing are unaffected.
+
+Pass an array of segments and everything they do not cover stays solid:
+
+```ts
+createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: [
+                {
+                    from: 'Feb',
+                    to: 'Jun',
+                    style: 'dashed',
+                },
+                {
+                    // A function receives the dataset and returns the key to anchor to.
+                    from: data => data[data.length - 3].month,
+                    style: 'dotted',
+                },
+            ],
+        },
+    ],
+});
+```
+
+Or name the fallback explicitly with the object form:
+
+```ts
+createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: {
+                default: 'solid',
+                segments: [
+                    {
+                        from: 'Feb',
+                        to: 'Jun',
+                        style: 'dashed',
+                    },
+                ],
+            },
+        },
+    ],
+});
+```
+
+`from` defaults to the start of the line and `to` — which is inclusive — to its end. Segments apply
+in order, so a later one wins where two overlap, and a segment whose key is not in the data is
+skipped rather than throwing, leaving that span at the default style.
+
+> [!NOTE]
+> A `basis` line is a B-spline that passes through none of its points, so there is no point at which
+> to split it: a segmented `basis` line falls back to a single style. On a `cardinal` line a boundary
+> on the second point resolves to the third, because its curve skips that point.
 
 ### Time x-axis
 

--- a/apps/website/src/charts/trend.md
+++ b/apps/website/src/charts/trend.md
@@ -41,6 +41,7 @@ The **Trend Chart** is a true mixed cartesian chart that combines line, bar, and
                     <option value="solid">Solid</option>
                     <option value="dashed">Dashed</option>
                     <option value="dotted">Dotted</option>
+                    <option value="segmented">Segmented</option>
                 </RiplSelect>
             </RiplField>
             <RiplField label="Line width" option="lineWidth">
@@ -144,7 +145,7 @@ const seriesMeta = [
 const { extras, reset } = useChartExtras({
     stacked: false,
     lineType: 'monotoneX' as PolylineRenderer,
-    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted',
+    lineStyle: 'solid' as 'solid' | 'dashed' | 'dotted' | 'segmented',
     lineWidth: 2,
     markers: false,
     markerRadius: 3,
@@ -174,6 +175,25 @@ const config = useChartConfig({
     colors: seedColors(seriesMeta.map(s => s.id)),
 });
 
+// Bounds are read off the live dataset so the demo survives adding and removing points.
+function resolveLineStyle() {
+    if (extras.lineStyle !== 'segmented') {
+        return extras.lineStyle;
+    }
+
+    return [
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.25)]?.month,
+            to: (data: any[]) => data[Math.floor(data.length * 0.5)]?.month,
+            style: 'dashed',
+        },
+        {
+            from: (data: any[]) => data[Math.floor(data.length * 0.75)]?.month,
+            style: 'dotted',
+        },
+    ];
+}
+
 function getSeries(): TrendChartSeriesOptions<SalesRow>[] {
     return seriesMeta.map(s => {
         const type = s.id === 'target' ? extras.targetType : s.type;
@@ -187,7 +207,7 @@ function getSeries(): TrendChartSeriesOptions<SalesRow>[] {
             ...(type === 'area' ? { fillOpacity: extras.fillOpacity } : {}),
             ...(type === 'bar' ? {} : {
                 lineType: extras.lineType,
-                lineStyle: extras.lineStyle,
+                lineStyle: resolveLineStyle(),
                 lineWidth: extras.lineWidth,
                 markers: extras.markers,
                 markerRadius: extras.markerRadius,
@@ -343,6 +363,69 @@ createTrendChart('#container', {
     ],
 });
 ```
+
+### Segmented line styles
+
+`lineStyle` also accepts spans anchored to data keys, so one line can change style along its
+length — actuals solid and a forecast dashed, say. The line is still a single polyline, so the
+draw-on animation and point morphing are unaffected.
+
+```ts
+createTrendChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            type: 'line',
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: [
+                {
+                    from: 'Feb',
+                    to: 'Jun',
+                    style: 'dashed',
+                },
+                {
+                    // A function receives the dataset and returns the key to anchor to.
+                    from: data => data[data.length - 3].month,
+                    style: 'dotted',
+                },
+            ],
+        },
+    ],
+});
+```
+
+`from` defaults to the start of the line and `to` — which is inclusive — to its end. Use the object
+form to name the fallback style explicitly:
+
+```ts
+createTrendChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        {
+            type: 'line',
+            id: 'revenue',
+            value: 'revenue',
+            label: 'Revenue',
+            lineStyle: {
+                default: 'solid',
+                segments: [
+                    {
+                        from: 'Feb',
+                        to: 'Jun',
+                        style: 'dashed',
+                    },
+                ],
+            },
+        },
+    ],
+});
+```
+
+See the [line chart](/charts/line#segmented-line-styles) for the full rules.
 
 ## Options
 

--- a/packages/charts/OPTIONS.md
+++ b/packages/charts/OPTIONS.md
@@ -86,7 +86,7 @@ One shape per property name, across every chart:
 | `legend` | `ChartLegendInput` — `boolean \| LegendPosition \| Partial<ChartLegendOptions>` |
 | `format` | `ValueFormatInput` — formats **values** |
 | `tickFormat` | `ValueFormatInput` — formats **tick labels** |
-| `lineStyle` | `LineStyle` — the single dash property; no raw `lineDash` |
+| `lineStyle` | `LineStyleInput` — a `LineStyle` for the whole line, or key-anchored style segments; no raw `lineDash` |
 | `stacked` | `boolean \| 'percent'` (`boolean` only where percent is meaningless — see below) |
 | `palette` | `string[]` — a positional series palette |
 | `gradient` | `string[]` — sequential color stops, low to high |

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -23,7 +23,7 @@ import {
 } from '../core/options';
 
 import type {
-    LineStyle,
+    LineStyleInput,
 } from '../core/options';
 
 import {
@@ -89,8 +89,8 @@ export interface AreaChartSeriesOptions<TData> {
     label: string;
     /** Renderer used to draw the line/area top edge (e.g. straight or curved); defaults to straight segments. */
     lineType?: PolylineRenderer;
-    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
-    lineStyle?: LineStyle;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, a custom dash array, or key-anchored spans each with their own style. */
+    lineStyle?: LineStyleInput<TData>;
     /** Width in pixels of the series line. */
     lineWidth?: number;
     /** Fill opacity of the area band. Defaults to 0.3. */

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -22,7 +22,7 @@ import {
 } from '../core/options';
 
 import type {
-    LineStyle,
+    LineStyleInput,
 } from '../core/options';
 
 import {
@@ -94,8 +94,8 @@ export interface LineChartSeriesOptions<TData> {
     lineType?: PolylineRenderer;
     /** Width in pixels of the series line. */
     lineWidth?: number;
-    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
-    lineStyle?: LineStyle;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, a custom dash array, or key-anchored spans each with their own style. */
+    lineStyle?: LineStyleInput<TData>;
     /** Show point markers along the line. Defaults to `true`; set `false` to hide them (toggling animates them in/out). */
     markers?: boolean;
     /** Radius in pixels of each point marker. Defaults to 3. */

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -12,7 +12,7 @@ import {
 
 import type {
     ChartDataLabelsInput,
-    LineStyle,
+    LineStyleInput,
     ValueFormatInput,
 } from '../core/options';
 
@@ -118,8 +118,8 @@ export interface TrendChartLineSeriesOptions<TData> extends TrendChartBaseSeries
     lineType?: PolylineRenderer;
     /** Width in pixels of the series line. */
     lineWidth?: number;
-    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
-    lineStyle?: LineStyle;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, a custom dash array, or key-anchored spans each with their own style. */
+    lineStyle?: LineStyleInput<TData>;
     /** Show point markers along the line. Defaults to `true`. */
     markers?: boolean;
     /** Radius in pixels of each point marker. Defaults to 3. */
@@ -134,8 +134,8 @@ export interface TrendChartAreaSeriesOptions<TData> extends TrendChartBaseSeries
     lineType?: PolylineRenderer;
     /** Width in pixels of the series line. */
     lineWidth?: number;
-    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
-    lineStyle?: LineStyle;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, a custom dash array, or key-anchored spans each with their own style. */
+    lineStyle?: LineStyleInput<TData>;
     /** Fill opacity of the area band. Defaults to 0.3. */
     fillOpacity?: number;
     /** Show point markers at each data value. Defaults to `true`. */

--- a/packages/charts/src/core/options.ts
+++ b/packages/charts/src/core/options.ts
@@ -9,6 +9,7 @@ import {
 
 import type {
     Ease,
+    PolylineSegment,
 } from '@ripl/core';
 
 import {
@@ -54,6 +55,7 @@ import {
     typeIsArray,
     typeIsBoolean,
     typeIsFunction,
+    typeIsNil,
     typeIsNumber,
     typeIsString,
 } from '@ripl/utilities';
@@ -766,6 +768,110 @@ export function resolveLineDash(style?: LineStyle): number[] {
     }
 
     return (style && LINE_DASH_PRESETS[style]) ?? [];
+}
+
+/** A segment boundary: the key of a data point, or a function picking one out of the chart data. */
+export type LineStyleBound<TData> = string | ((data: TData[]) => string);
+
+/** A span of a series line, anchored to data keys, stroked with its own style. */
+export interface LineStyleSegment<TData> {
+    /** Key of the point the span starts at; the start of the line when omitted. */
+    from?: LineStyleBound<TData>;
+    /** Key of the point the span ends at, inclusive; the end of the line when omitted. */
+    to?: LineStyleBound<TData>;
+    /** Dash style stroked over the span. */
+    style: LineStyle;
+}
+
+/** A segmented line style: the style of each span, plus the style used everywhere else. */
+export interface LineStyleSegments<TData> {
+    /** Style applied wherever no segment applies. Defaults to `'solid'`. */
+    default?: LineStyle;
+    /** Spans of the line overriding the default, applied in order so a later span wins where two overlap. */
+    segments: LineStyleSegment<TData>[];
+}
+
+/**
+ * How a series line is stroked: one style for the whole line, or key-anchored spans each with their
+ * own style. A bare array of segments defaults everything they do not cover to `'solid'`; the
+ * object form names that fallback explicitly.
+ *
+ * @typeParam TData - The type of each data item in the dataset.
+ */
+export type LineStyleInput<TData> = LineStyle | LineStyleSegment<TData>[] | LineStyleSegments<TData>;
+
+/** A {@link LineStyleInput} resolved into the polyline state that draws it. */
+export interface ResolvedLineStyle {
+    /** Dash pattern for every part of the line no segment covers. */
+    lineDash: number[];
+    /** Per-span dash overrides, or `undefined` when the line is uniformly styled. */
+    segments?: PolylineSegment[];
+}
+
+// A dash array and a segment list are both arrays; only a non-empty list of objects is the latter.
+function isSegmentList<TData>(style: LineStyleInput<TData>): style is LineStyleSegment<TData>[] {
+    return typeIsArray(style) && style.length > 0 && style.every(entry => !typeIsNumber(entry));
+}
+
+function isSegmented<TData>(style: LineStyleInput<TData>): style is LineStyleSegments<TData> {
+    return !typeIsArray(style) && !typeIsString(style) && typeIsArray(style.segments);
+}
+
+function resolveBound<TData>(bound: LineStyleBound<TData> | undefined, data: TData[], keys: string[], fallback: number): number {
+    if (typeIsNil(bound)) {
+        return fallback;
+    }
+
+    const key = typeIsFunction(bound) ? bound(data) : bound;
+
+    return keys.indexOf(key);
+}
+
+/**
+ * Resolves a {@link LineStyleInput} against the chart data into the dash state that draws it: the
+ * dash pattern for the line as a whole, plus the point-index spans that override it.
+ *
+ * Segments whose `from` or `to` matches no key in the data are dropped rather than throwing, so a
+ * data change that removes a boundary leaves the rest of the line intact.
+ *
+ * @param style - The series' `lineStyle` option.
+ * @param data - The dataset being plotted, in render order.
+ * @param getKey - Resolves a data item to its category key.
+ * @returns The polyline `lineDash` and, when the style is segmented, its `segments`.
+ */
+export function resolveLineStyle<TData>(style: LineStyleInput<TData> | undefined, data: TData[], getKey: (item: TData) => string): ResolvedLineStyle {
+    if (typeIsNil(style) || (!isSegmentList(style) && !isSegmented(style))) {
+        return {
+            lineDash: resolveLineDash(style as LineStyle | undefined),
+        };
+    }
+
+    const entries = isSegmentList(style) ? style : style.segments;
+    const lineDash = resolveLineDash(isSegmented(style) ? style.default : undefined);
+    const keys = data.map(getKey);
+    const lastIndex = keys.length - 1;
+
+    const segments = entries.reduce((output, entry) => {
+        const from = resolveBound(entry.from, data, keys, 0);
+        const to = resolveBound(entry.to, data, keys, lastIndex);
+
+        if (from < 0 || to < 0 || from >= to) {
+            return output;
+        }
+
+        output.push({
+            from,
+            to,
+            lineDash: resolveLineDash(entry.style),
+        });
+
+        return output;
+    }, [] as PolylineSegment[]);
+
+    return {
+        lineDash,
+        segments: segments.length ? segments : undefined,
+    };
 }
 
 // Data labels

--- a/packages/charts/src/core/series/area-series.ts
+++ b/packages/charts/src/core/series/area-series.ts
@@ -30,7 +30,7 @@ import type {
 } from '../animation';
 
 import {
-    resolveLineDash,
+    resolveLineStyle,
 } from '../options';
 
 import {
@@ -332,11 +332,14 @@ export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TDa
 
         areaFill.autoStroke = false;
 
+        const { lineDash, segments } = resolveLineStyle(series.lineStyle, ctx.data, ctx.getKey);
+
         const line = createPolyline({
             id: `${series.id}-line`,
             lineWidth: series.lineWidth ?? 2,
             stroke: color,
-            lineDash: resolveLineDash(series.lineStyle),
+            lineDash,
+            segments,
             points: linePoints,
             renderer: series.lineType,
             data: {
@@ -369,10 +372,13 @@ export class AreaSeriesRenderer<TData> extends SeriesRenderer<AreaSeriesLike<TDa
         const prevKeys = this._morphKeys.get(series.id);
         const keyed = !!prevKeys && keysDiffer(prevKeys, newKeys);
 
+        const { lineDash, segments } = resolveLineStyle(series.lineStyle, ctx.data, ctx.getKey);
+
         // The fill is a closed [top, reversed-bottom] polygon, so keys are `t:`/`b:` tagged per run.
         line.renderer = series.lineType;
         areaFill.renderer = areaBandRenderer(series.lineType);
-        line.lineDash = resolveLineDash(series.lineStyle);
+        line.lineDash = lineDash;
+        line.segments = segments;
 
         const fillKeys = (keys: string[]): string[] => [
             ...keys.map(key => `t:${key}`),

--- a/packages/charts/src/core/series/context.ts
+++ b/packages/charts/src/core/series/context.ts
@@ -23,7 +23,7 @@ import type {
 
 import type {
     ChartDataLabelsOptions,
-    LineStyle,
+    LineStyleInput,
 } from '../options';
 
 import type {
@@ -152,8 +152,8 @@ export interface LineSeriesLike<TData> {
     lineType?: PolylineRenderer;
     /** Width in pixels of the series line. */
     lineWidth?: number;
-    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, or a custom dash array. */
-    lineStyle?: LineStyle;
+    /** Line dash style: `'solid'` (default), `'dashed'`, `'dotted'`, a custom dash array, or key-anchored spans each with their own style. */
+    lineStyle?: LineStyleInput<TData>;
     /** Show point markers along the line. Defaults to `true`. */
     markers?: boolean;
     /** Radius in pixels of each point marker. Defaults to 3. */

--- a/packages/charts/src/core/series/line-series.ts
+++ b/packages/charts/src/core/series/line-series.ts
@@ -26,7 +26,7 @@ import {
 } from '../animation';
 
 import {
-    resolveLineDash,
+    resolveLineStyle,
 } from '../options';
 
 import {
@@ -201,12 +201,14 @@ export class LineSeriesRenderer<TData> extends SeriesRenderer<LineSeriesLike<TDa
     protected buildSeriesGroup(series: LineSeriesLike<TData>, ctx: LineSeriesContext<TData>): Group {
         const color = ctx.getColor(series.id);
         const items = ctx.data.map(item => this._buildMarker(series, item, ctx));
+        const { lineDash, segments } = resolveLineStyle(series.lineStyle, ctx.data, ctx.getKey);
 
         const line = createPolyline({
             id: `${series.id}-line`,
             lineWidth: series.lineWidth ?? 2,
             stroke: color,
-            lineDash: resolveLineDash(series.lineStyle),
+            lineDash,
+            segments,
             points: items.map(item => item.point),
             renderer: series.lineType,
         });
@@ -227,9 +229,12 @@ export class LineSeriesRenderer<TData> extends SeriesRenderer<LineSeriesLike<TDa
         const line = group.getElementsByType('polyline')[0] as Polyline;
         const markers = seriesMarkers(group);
 
+        const { lineDash, segments } = resolveLineStyle(series.lineStyle, ctx.data, ctx.getKey);
+
         // Apply the curve renderer + dash directly (not via the transition, which would snap them).
         line.renderer = series.lineType;
-        line.lineDash = resolveLineDash(series.lineStyle);
+        line.lineDash = lineDash;
+        line.segments = segments;
 
         const newKeys = ctx.data.map(ctx.getKey);
         const targetPoints = ctx.data.map(item => this._markerState(series, item, ctx).point);

--- a/packages/charts/test/line-style.test.ts
+++ b/packages/charts/test/line-style.test.ts
@@ -1,0 +1,344 @@
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import type {
+    Polyline,
+} from '@ripl/core';
+
+import {
+    createAreaChart,
+    createLineChart,
+    resolveLineStyle,
+} from '../src';
+
+interface SeriesInternals {
+    _series: {
+        groups: {
+            id: string;
+            getElementsByType(type: string): Polyline[];
+        }[];
+    };
+}
+
+function lineOf(chart: unknown, seriesId: string): Polyline {
+    const group = (chart as SeriesInternals)._series.groups.find(g => g.id === seriesId);
+
+    expect(group).toBeTruthy();
+
+    const polylines = group!.getElementsByType('polyline');
+
+    return polylines[polylines.length - 1];
+}
+
+interface Datum {
+    month: string;
+    revenue: number;
+}
+
+const DATA: Datum[] = [
+    {
+        month: 'january',
+        revenue: 10,
+    },
+    {
+        month: 'february',
+        revenue: 30,
+    },
+    {
+        month: 'march',
+        revenue: 20,
+    },
+    {
+        month: 'april',
+        revenue: 40,
+    },
+    {
+        month: 'may',
+        revenue: 25,
+    },
+];
+
+const DASHED = [6, 4];
+const DOTTED = [2, 3];
+
+const getKey = (item: Datum) => item.month;
+
+describe('resolveLineStyle', () => {
+
+    it('resolves the scalar forms exactly as before', () => {
+        expect(resolveLineStyle(undefined, DATA, getKey)).toEqual({ lineDash: [] });
+        expect(resolveLineStyle('solid', DATA, getKey)).toEqual({ lineDash: [] });
+        expect(resolveLineStyle('dashed', DATA, getKey)).toEqual({ lineDash: DASHED });
+        expect(resolveLineStyle([8, 2], DATA, getKey)).toEqual({ lineDash: [8, 2] });
+    });
+
+    // An empty array is a dash array, not an empty segment list, so it keeps meaning "solid".
+    it('reads an empty array as a solid dash array', () => {
+        expect(resolveLineStyle([], DATA, getKey)).toEqual({ lineDash: [] });
+    });
+
+    it('resolves a segment array against the data keys', () => {
+        expect(resolveLineStyle([{
+            from: 'february',
+            to: 'april',
+            style: 'dashed',
+        }], DATA, getKey)).toEqual({
+            lineDash: [],
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+    });
+
+    it('runs a segment without a `to` to the end of the line', () => {
+        const { segments } = resolveLineStyle([{
+            from: 'march',
+            style: 'dotted',
+        }], DATA, getKey);
+
+        expect(segments).toEqual([{
+            from: 2,
+            to: 4,
+            lineDash: DOTTED,
+        }]);
+    });
+
+    it('starts a segment without a `from` at the start of the line', () => {
+        const { segments } = resolveLineStyle([{
+            to: 'march',
+            style: 'dotted',
+        }], DATA, getKey);
+
+        expect(segments).toEqual([{
+            from: 0,
+            to: 2,
+            lineDash: DOTTED,
+        }]);
+    });
+
+    it('resolves a function bound against the whole dataset', () => {
+        const { segments } = resolveLineStyle([{
+            from: data => data.find(item => item.revenue === 40)!.month,
+            style: 'dashed',
+        }], DATA, getKey);
+
+        expect(segments).toEqual([{
+            from: 3,
+            to: 4,
+            lineDash: DASHED,
+        }]);
+    });
+
+    it('honours the default of the object form', () => {
+        expect(resolveLineStyle({
+            default: 'dotted',
+            segments: [{
+                from: 'february',
+                to: 'april',
+                style: 'dashed',
+            }],
+        }, DATA, getKey)).toEqual({
+            lineDash: DOTTED,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+    });
+
+    it('drops a segment whose key is not in the data', () => {
+        expect(resolveLineStyle([{
+            from: 'smarch',
+            to: 'april',
+            style: 'dashed',
+        }], DATA, getKey)).toEqual({
+            lineDash: [],
+            segments: undefined,
+        });
+    });
+
+    it('drops a degenerate segment', () => {
+        expect(resolveLineStyle([{
+            from: 'april',
+            to: 'february',
+            style: 'dashed',
+        }], DATA, getKey).segments).toBeUndefined();
+    });
+
+    it('keeps overlapping segments in declaration order', () => {
+        const { segments } = resolveLineStyle([
+            {
+                from: 'january',
+                to: 'april',
+                style: 'dashed',
+            },
+            {
+                from: 'march',
+                to: 'may',
+                style: 'dotted',
+            },
+        ], DATA, getKey);
+
+        expect(segments).toEqual([
+            {
+                from: 0,
+                to: 3,
+                lineDash: DASHED,
+            },
+            {
+                from: 2,
+                to: 4,
+                lineDash: DOTTED,
+            },
+        ]);
+    });
+
+});
+
+describe('segmented lineStyle on a chart', () => {
+
+    function chart(lineStyle: Parameters<typeof createLineChart<Datum>>[1]['series'][number]['lineStyle']) {
+        polyfillPath2D();
+        mockCanvasContext();
+
+        return createLineChart(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            series: [{
+                id: 's',
+                label: 'S',
+                value: 'revenue',
+                lineStyle,
+            }],
+        });
+    }
+
+    it('puts the resolved segments on the single series polyline', async () => {
+        const instance = chart([{
+            from: 'february',
+            to: 'april',
+            style: 'dashed',
+        }]);
+
+        await instance.render();
+
+        const group = (instance as unknown as SeriesInternals)._series.groups[0];
+
+        expect(group.getElementsByType('polyline')).toHaveLength(1);
+        expect(lineOf(instance, 's').segments).toEqual([{
+            from: 1,
+            to: 3,
+            lineDash: DASHED,
+        }]);
+
+        instance.destroy();
+    });
+
+    it('leaves a scalar style unsegmented', async () => {
+        const instance = chart('dashed');
+
+        await instance.render();
+
+        expect(lineOf(instance, 's').lineDash).toEqual(DASHED);
+        expect(lineOf(instance, 's').segments).toBeUndefined();
+
+        instance.destroy();
+    });
+
+    it('re-resolves segments against new data on update', async () => {
+        const instance = chart([{
+            from: 'february',
+            to: 'april',
+            style: 'dashed',
+        }]);
+
+        await instance.render();
+        expect(lineOf(instance, 's').segments).toEqual([{
+            from: 1,
+            to: 3,
+            lineDash: DASHED,
+        }]);
+
+        // Dropping a point shifts every later index, so a stale resolution would dash the wrong span.
+        instance.update({ data: DATA.slice(1) });
+        await instance.render();
+
+        expect(lineOf(instance, 's').segments).toEqual([{
+            from: 0,
+            to: 2,
+            lineDash: DASHED,
+        }]);
+
+        instance.destroy();
+    });
+
+    it('drops the segments when a boundary key leaves the data', async () => {
+        const instance = chart([{
+            from: 'april',
+            style: 'dashed',
+        }]);
+
+        await instance.render();
+        expect(lineOf(instance, 's').segments).toBeTruthy();
+
+        instance.update({ data: DATA.slice(0, 2) });
+        await instance.render();
+
+        expect(lineOf(instance, 's').segments).toBeUndefined();
+
+        instance.destroy();
+    });
+
+    it('segments an area series line without touching its fill', async () => {
+        polyfillPath2D();
+        mockCanvasContext();
+
+        const instance = createAreaChart(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            series: [{
+                id: 's',
+                label: 'S',
+                value: 'revenue',
+                lineStyle: {
+                    default: 'solid',
+                    segments: [{
+                        from: 'february',
+                        to: 'april',
+                        style: 'dotted',
+                    }],
+                },
+            }],
+        });
+
+        await instance.render();
+
+        const polylines = (instance as unknown as SeriesInternals)._series.groups[0].getElementsByType('polyline');
+
+        expect(polylines).toHaveLength(2);
+        expect(polylines[0].segments).toBeUndefined();
+        expect(polylines[1].segments).toEqual([{
+            from: 1,
+            to: 3,
+            lineDash: DOTTED,
+        }]);
+
+        instance.destroy();
+    });
+
+});

--- a/packages/charts/test/visual/chart-ids.ts
+++ b/packages/charts/test/visual/chart-ids.ts
@@ -6,6 +6,7 @@ export const CHART_IDS = [
     'bar',
     'box-plot',
     'line',
+    'line-segmented',
     'area',
     'scatter',
     'pie',

--- a/packages/charts/test/visual/gallery.ts
+++ b/packages/charts/test/visual/gallery.ts
@@ -136,6 +136,37 @@ createLineChart(mount('line'), {
     },
 });
 
+createLineChart(mount('line-segmented'), {
+    animation: false,
+    title: 'Line — Segmented Style',
+    legend: true,
+    data: DATA,
+    key: 'month',
+    series: baseSeries.map(s => ({
+        ...s,
+        markers: true,
+        lineType: 'monotoneX' as const,
+        lineStyle: {
+            default: 'solid' as const,
+            segments: [
+                {
+                    from: 'Feb',
+                    to: 'Apr',
+                    style: 'dashed' as const,
+                },
+                {
+                    from: 'May',
+                    style: 'dotted' as const,
+                },
+            ],
+        },
+    })),
+    axis: {
+        x: true,
+        y: { title: 'Amount ($)' },
+    },
+});
+
 createAreaChart(mount('area'), {
     animation: false,
     title: 'Area — Stacked',

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -82,20 +82,33 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
         this.cachePath = cachePath;
     }
 
+    protected get hitPaths(): ContextPath[] {
+        return this.path
+            ? [this.path]
+            : [];
+    }
+
+    protected strokePath(context: Context, path: ContextPath): void {
+        context.applyStroke(path);
+    }
+
     /** Tests whether a point intersects this shape using path-based fill and stroke hit testing. */
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
-        if (!this.context || !this.path) {
+        const context = this.context;
+        const paths = this.hitPaths;
+
+        if (!context || !paths.length) {
             return super.intersectsWith(x, y, options);
         }
 
         // The path is local-space, so backends that don't honor transforms need the point mapped back.
-        if (!this.context.hitTestHonorsTransform) {
+        if (!context.hitTestHonorsTransform) {
             const worldTransform = (this as unknown as Element).getWorldTransform();
             const inverse = worldTransform && matrixInvert(worldTransform);
 
             if (inverse) {
                 // The point is in device pixels but the world transform is logical, so scale by DPR.
-                const dpr = this.context.scaleDPR(1);
+                const dpr = context.scaleDPR(1);
                 const [localX, localY] = matrixApplyToPoint(inverse, [x / dpr, y / dpr]);
 
                 x = localX * dpr;
@@ -107,10 +120,10 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
             isPointer = false,
         } = options || {};
 
-        const isAnyIntersecting = () => !!(this.path && this.context) && (
-            this.context.isPointInStroke(this.path, x, y) ||
-            this.context.isPointInPath(this.path, x, y)
-        );
+        const isAnyIntersecting = () => paths.some(path => (
+            context.isPointInStroke(path, x, y) ||
+            context.isPointInPath(path, x, y)
+        ));
 
         if (!isPointer) {
             return isAnyIntersecting();
@@ -119,7 +132,7 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
         const hitTest = POINTER_EVENT_HIT_TESTS[this.pointerEvents];
 
         return hitTest
-            ? hitTest(this.context, this.path, x, y)
+            ? paths.some(path => hitTest(context, path, x, y))
             : isAnyIntersecting();
     }
 
@@ -152,7 +165,7 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
             }
 
             if (this.path && this.autoStroke && this.getComputedValue('stroke')) {
-                context.applyStroke(this.path);
+                this.strokePath(context, this.path);
             }
         }, this.clip);
     }

--- a/packages/core/src/elements/polyline.ts
+++ b/packages/core/src/elements/polyline.ts
@@ -11,7 +11,12 @@ import type {
     Context,
 } from '../context';
 
+import {
+    ContextPath,
+} from '../context/path';
+
 import type {
+    BorderRadius,
     Point,
 } from '../math';
 
@@ -32,15 +37,256 @@ import {
     resolvePolylineRenderer,
 } from '../math/polyline';
 
+/** A span of a polyline's points stroked with its own dash pattern. */
+export interface PolylineSegment {
+    /** Index of the point the span starts at. */
+    from: number;
+    /** Index of the point the span ends at; the span covers the line drawn between the two points. */
+    to: number;
+    /** Dash pattern stroked over the span; inherits the polyline's own dash pattern when omitted. */
+    lineDash?: number[];
+    /** Offset into the span's dash pattern; inherits the polyline's own offset when omitted. */
+    lineDashOffset?: number;
+}
+
 export interface PolylineState extends BaseElementState {
     /** The ordered points that make up the polyline. */
     points: Point[];
     /** The curve interpolation algorithm, or custom render function, used to draw the polyline. */
     renderer?: PolylineRenderer | PolylineRenderFunc;
+    /** Spans of the polyline stroked with their own dash pattern, applied in order so a later span wins where two overlap. */
+    segments?: PolylineSegment[];
+}
+
+function clampIndex(value: number, max: number): number {
+    return Math.max(0, Math.min(Math.round(value), max));
+}
+
+function runStyleKey(segment?: PolylineSegment): string {
+    return segment?.lineDash
+        ? `${segment.lineDash.join(',')}|${segment.lineDashOffset ?? 0}`
+        : '';
+}
+
+/**
+ * Normalizes a polyline's segments into the contiguous, non-overlapping runs it is stroked in.
+ *
+ * Segments are clamped to the point range and stamped in order (a later segment wins where two
+ * overlap), then adjacent runs resolving to the same dash are coalesced so the path is never split
+ * where its style does not actually change. Returns an empty array when the whole polyline resolves
+ * to its own dash pattern, so a uniformly styled line takes the single-stroke path.
+ *
+ * @param pointCount - The number of points the polyline is drawn through.
+ * @param segments - The spans to normalize.
+ * @returns Contiguous runs covering every point exactly once, or an empty array when uniform.
+ */
+export function normalizePolylineRuns(pointCount: number, segments?: PolylineSegment[]): PolylineSegment[] {
+    const intervals = pointCount - 1;
+
+    if (intervals < 1 || !segments?.length) {
+        return [];
+    }
+
+    const painted = new Array<PolylineSegment | undefined>(intervals).fill(undefined);
+
+    segments.forEach(segment => {
+        const from = clampIndex(segment.from, intervals);
+        const to = clampIndex(segment.to, intervals);
+
+        for (let index = from; index < to; index++) {
+            painted[index] = segment;
+        }
+    });
+
+    const runs: PolylineSegment[] = [];
+
+    let key: string | undefined;
+
+    painted.forEach((segment, index) => {
+        const paintedKey = runStyleKey(segment);
+
+        if (key === paintedKey) {
+            runs[runs.length - 1].to = index + 1;
+            return;
+        }
+
+        key = paintedKey;
+
+        runs.push({
+            from: index,
+            to: index + 1,
+            lineDash: segment?.lineDash,
+            lineDashOffset: segment?.lineDashOffset,
+        });
+    });
+
+    return runs.length > 1 || runs[0].lineDash
+        ? runs
+        : [];
+}
+
+/**
+ * Multiplexes a curve renderer's output onto the full path and onto one sub-path per run, so a
+ * polyline can be stroked once per run without re-running or re-implementing the renderer.
+ *
+ * Every command is forwarded to the full path unconditionally, and additionally to each run
+ * overlapping the point interval the command spans, prefixed with a `moveTo` the first time that
+ * run receives one. A command's interval is tracked by matching its endpoint against the upcoming
+ * points; the two-point lookahead covers the one index `cardinal` skips without letting degenerate
+ * data trigger a runaway jump.
+ */
+class SegmentedPathTracer extends ContextPath {
+
+    private _path: ContextPath;
+    private _points: Point[];
+    private _runs: PolylineSegment[];
+    private _createPath: (index: number) => ContextPath;
+    private _paths: (ContextPath | undefined)[];
+    private _index = 0;
+    private _x = 0;
+    private _y = 0;
+    private _traceable = true;
+
+    /** Whether the renderer's output could be attributed to points, and so split into runs at all. */
+    public get valid(): boolean {
+        return this._traceable && this._index === this._points.length - 1;
+    }
+
+    /** The sub-path traced for each run, in run order; a run the renderer emitted nothing for has none. */
+    public get paths(): (ContextPath | undefined)[] {
+        return this._paths;
+    }
+
+    constructor(path: ContextPath, points: Point[], runs: PolylineSegment[], createPath: (index: number) => ContextPath) {
+        super(path.id);
+
+        this._path = path;
+        this._points = points;
+        this._runs = runs;
+        this._createPath = createPath;
+        this._paths = new Array<ContextPath | undefined>(runs.length).fill(undefined);
+    }
+
+    private _advance(x: number, y: number): number {
+        const limit = Math.min(this._index + 2, this._points.length - 1);
+
+        for (let index = this._index + 1; index <= limit; index++) {
+            const point = this._points[index];
+
+            if (point[0] === x && point[1] === y) {
+                return index;
+            }
+        }
+
+        return this._index;
+    }
+
+    private _emit(draw: (path: ContextPath) => void, x: number, y: number): void {
+        draw(this._path);
+
+        const from = this._index;
+        const advanced = this._advance(x, y);
+        const to = Math.max(advanced, from + 1);
+
+        this._runs.forEach((run, index) => {
+            if (run.from >= to || run.to <= from) {
+                return;
+            }
+
+            let path = this._paths[index];
+
+            if (!path) {
+                path = this._createPath(index);
+                path.moveTo(this._x, this._y);
+                this._paths[index] = path;
+            }
+
+            draw(path);
+        });
+
+        this._index = advanced;
+        this._x = x;
+        this._y = y;
+    }
+
+    private _untraceable(draw: (path: ContextPath) => void): void {
+        this._traceable = false;
+        draw(this._path);
+    }
+
+    /** Adds an arc centered at `(x, y)`; a polyline traced with one cannot be split into runs. */
+    public arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, counterclockwise?: boolean): void {
+        this._untraceable(path => path.arc(x, y, radius, startAngle, endAngle, counterclockwise));
+    }
+
+    /** Adds a tangential arc; a polyline traced with one cannot be split into runs. */
+    public arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void {
+        this._untraceable(path => path.arcTo(x1, y1, x2, y2, radius));
+    }
+
+    /** Adds a full circle; a polyline traced with one cannot be split into runs. */
+    public circle(x: number, y: number, radius: number): void {
+        this._untraceable(path => path.circle(x, y, radius));
+    }
+
+    /** Adds a cubic Bézier curve to `(x, y)`, attributed to the point interval it spans. */
+    public bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void {
+        this._emit(path => path.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y), x, y);
+    }
+
+    /** Closes the current sub-path; a polyline traced with one cannot be split into runs. */
+    public closePath(): void {
+        this._untraceable(path => path.closePath());
+    }
+
+    /** Adds an ellipse; a polyline traced with one cannot be split into runs. */
+    public ellipse(x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, counterclockwise?: boolean): void {
+        this._untraceable(path => path.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise));
+    }
+
+    /** Adds a straight line to `(x, y)`, attributed to the point interval it spans. */
+    public lineTo(x: number, y: number): void {
+        this._emit(path => path.lineTo(x, y), x, y);
+    }
+
+    /** Moves the current point to `(x, y)`, starting a fresh sub-path in every run. */
+    public moveTo(x: number, y: number): void {
+        this._path.moveTo(x, y);
+
+        // A renderer that starts a new sub-path mid-trace must not continue any run's existing one.
+        this._paths.forEach(path => path?.moveTo(x, y));
+
+        this._x = x;
+        this._y = y;
+    }
+
+    /** Adds a quadratic Bézier curve to `(x, y)`, attributed to the point interval it spans. */
+    public quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void {
+        this._emit(path => path.quadraticCurveTo(cpx, cpy, x, y), x, y);
+    }
+
+    /** Adds a rectangle; a polyline traced with one cannot be split into runs. */
+    public rect(x: number, y: number, width: number, height: number): void {
+        this._untraceable(path => path.rect(x, y, width, height));
+    }
+
+    /** Adds a rounded rectangle; a polyline traced with one cannot be split into runs. */
+    public roundRect(x: number, y: number, width: number, height: number, radii?: BorderRadius): void {
+        this._untraceable(path => path.roundRect(x, y, width, height, radii));
+    }
+
+    /** Appends another path's commands; a polyline traced with one cannot be split into runs. */
+    public addPath(path: ContextPath): void {
+        this._untraceable(target => target.addPath(path));
+    }
+
 }
 
 /** A multi-point line shape supporting various curve interpolation algorithms. */
 export class Polyline extends Shape2D<PolylineState> {
+
+    private _runs: PolylineSegment[] = [];
+    private _runPaths: (ContextPath | undefined)[] = [];
 
     /** The ordered points that make up the polyline. */
     public get points() {
@@ -60,8 +306,75 @@ export class Polyline extends Shape2D<PolylineState> {
         this.setStateValue('renderer', value);
     }
 
+    /** Spans of the polyline stroked with their own dash pattern, applied in order so a later span wins where two overlap. */
+    public get segments() {
+        return this.getStateValue('segments');
+    }
+
+    public set segments(value) {
+        this.setStateValue('segments', value);
+    }
+
     constructor(options: Shape2DOptions<PolylineState>) {
         super('polyline', options);
+    }
+
+    private _trace(context: Context, path: ContextPath, renderer: PolylineRenderFunc): void {
+        const points = this.points;
+
+        this._runs = [];
+        this._runPaths = [];
+
+        // Clamped per trace, not once at author time: the draw-on transition shrinks `points` per frame.
+        const runs = normalizePolylineRuns(points.length, this.segments);
+
+        if (!runs.length) {
+            renderer(context, path, points);
+            return;
+        }
+
+        const tracer = new SegmentedPathTracer(path, points, runs, index => context.createPath(`${this.id}:${index}`));
+
+        renderer(context, tracer, points);
+
+        if (!tracer.valid) {
+            return;
+        }
+
+        this._runs = runs;
+        this._runPaths = tracer.paths;
+    }
+
+    protected get hitPaths(): ContextPath[] {
+        const paths = this._runPaths.filter(path => !!path) as ContextPath[];
+
+        return paths.length
+            ? paths
+            : super.hitPaths;
+    }
+
+    protected strokePath(context: Context, path: ContextPath): void {
+        if (!this._runs.length) {
+            return super.strokePath(context, path);
+        }
+
+        // The element's own dash is already on the context, so an inherited pattern is picked up too.
+        const lineDash = context.lineDash;
+        const lineDashOffset = context.lineDashOffset;
+
+        this._runs.forEach((run, index) => {
+            const runPath = this._runPaths[index];
+
+            if (!runPath) {
+                return;
+            }
+
+            context.layer(() => {
+                context.lineDash = run.lineDash ?? lineDash;
+                context.lineDashOffset = run.lineDashOffset ?? lineDashOffset;
+                context.applyStroke(runPath);
+            });
+        });
     }
 
     /** @internal Local-space bounding box of the polyline. */
@@ -81,7 +394,7 @@ export class Polyline extends Shape2D<PolylineState> {
     public render(context: Context) {
         const renderer = resolvePolylineRenderer(this.renderer);
 
-        return super.render(context, path => renderer(context, path, this.points));
+        return super.render(context, path => this._trace(context, path, renderer));
     }
 
 }

--- a/packages/core/test/elements/polyline-segments.test.ts
+++ b/packages/core/test/elements/polyline-segments.test.ts
@@ -1,0 +1,396 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    createPolyline,
+    normalizePolylineRuns,
+} from '../../src';
+
+import type {
+    Point,
+    PolylineRenderer,
+    PolylineRenderFunc,
+    PolylineState,
+    Shape2DOptions,
+} from '../../src';
+
+import {
+    createContext,
+} from '@ripl/canvas';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+polyfillPath2D();
+
+const POINTS: Point[] = [
+    [0, 0],
+    [10, 20],
+    [20, 10],
+    [30, 30],
+    [40, 5],
+    [50, 25],
+];
+
+const DASHED = [6, 4];
+const DOTTED = [2, 3];
+
+const RENDERERS: PolylineRenderer[] = [
+    'linear',
+    'spline',
+    'basis',
+    'bumpX',
+    'bumpY',
+    'cardinal',
+    'catmullRom',
+    'monotoneX',
+    'monotoneY',
+    'natural',
+    'step',
+    'stepBefore',
+    'stepAfter',
+];
+
+/** Every renderer whose commands land on its input points, and so can be split at one. */
+const SPLITTABLE = RENDERERS.filter(renderer => renderer !== 'basis');
+
+interface StrokeRecord {
+    lineDash: number[];
+    lineDashOffset: number;
+    pathId: string;
+}
+
+/** Gives the stubbed canvas real dash state, so `context.lineDash` reads back what was set. */
+function statefulDash() {
+    const stub = mockCanvasContext();
+
+    let lineDash: number[] = [];
+
+    stub.setLineDash = vi.fn((value: number[]) => {
+        lineDash = value;
+    }) as never;
+
+    stub.getLineDash = vi.fn(() => lineDash) as never;
+
+    return stub;
+}
+
+/** Renders a polyline and records the dash pattern in force at each stroke, in stroke order. */
+function renderStrokes(options: Shape2DOptions<PolylineState>): StrokeRecord[] {
+    const strokes: StrokeRecord[] = [];
+    const context = createContext(document.createElement('div'));
+    const applyStroke = context.applyStroke.bind(context);
+
+    context.applyStroke = path => {
+        strokes.push({
+            lineDash: [...context.lineDash],
+            lineDashOffset: context.lineDashOffset,
+            pathId: path.id,
+        });
+
+        return applyStroke(path as never);
+    };
+
+    createPolyline(options).render(context);
+
+    return strokes;
+}
+
+describe('normalizePolylineRuns', () => {
+
+    test('Should return no runs without segments', () => {
+        expect(normalizePolylineRuns(6)).toEqual([]);
+        expect(normalizePolylineRuns(6, [])).toEqual([]);
+    });
+
+    test('Should return no runs for fewer than two points', () => {
+        const segments = [{
+            from: 0,
+            to: 1,
+            lineDash: DASHED,
+        }];
+
+        expect(normalizePolylineRuns(1, segments)).toEqual([]);
+        expect(normalizePolylineRuns(0, segments)).toEqual([]);
+    });
+
+    test('Should cover every interval exactly once', () => {
+        const runs = normalizePolylineRuns(6, [{
+            from: 1,
+            to: 3,
+            lineDash: DASHED,
+        }]);
+
+        expect(runs.map(run => [run.from, run.to])).toEqual([[0, 1], [1, 3], [3, 5]]);
+        expect(runs.map(run => run.lineDash)).toEqual([undefined, DASHED, undefined]);
+    });
+
+    test('Should let a later segment win where two overlap', () => {
+        const runs = normalizePolylineRuns(6, [
+            {
+                from: 0,
+                to: 4,
+                lineDash: DASHED,
+            },
+            {
+                from: 2,
+                to: 5,
+                lineDash: DOTTED,
+            },
+        ]);
+
+        expect(runs.map(run => [run.from, run.to])).toEqual([[0, 2], [2, 5]]);
+        expect(runs.map(run => run.lineDash)).toEqual([DASHED, DOTTED]);
+    });
+
+    test('Should coalesce adjacent segments resolving to the same dash', () => {
+        const runs = normalizePolylineRuns(6, [
+            {
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            },
+            {
+                from: 3,
+                to: 5,
+                lineDash: DASHED,
+            },
+        ]);
+
+        expect(runs.map(run => [run.from, run.to])).toEqual([[0, 1], [1, 5]]);
+    });
+
+    test('Should clamp indices to the point range', () => {
+        const runs = normalizePolylineRuns(6, [{
+            from: -4,
+            to: 99,
+            lineDash: DASHED,
+        }]);
+
+        expect(runs.map(run => [run.from, run.to])).toEqual([[0, 5]]);
+        expect(runs[0].lineDash).toEqual(DASHED);
+    });
+
+    test('Should drop a degenerate segment', () => {
+        expect(normalizePolylineRuns(6, [{
+            from: 3,
+            to: 3,
+            lineDash: DASHED,
+        }])).toEqual([]);
+
+        expect(normalizePolylineRuns(6, [{
+            from: 4,
+            to: 2,
+            lineDash: DASHED,
+        }])).toEqual([]);
+    });
+
+    test('Should return no runs when every span resolves to the polyline\'s own dash', () => {
+        expect(normalizePolylineRuns(6, [{
+            from: 1,
+            to: 3,
+        }])).toEqual([]);
+    });
+
+});
+
+describe('Segmented polyline rendering', () => {
+
+    beforeEach(() => statefulDash());
+    afterEach(() => vi.restoreAllMocks());
+
+    test('Should stroke once when unsegmented', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            lineDash: DASHED,
+        });
+
+        expect(strokes).toHaveLength(1);
+        expect(strokes[0].lineDash).toEqual(DASHED);
+    });
+
+    test('Should stroke once per run with that run\'s dash', () => {
+        const strokes = renderStrokes({
+            id: 'line',
+            stroke: '#000000',
+            points: POINTS,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDash)).toEqual([[], DASHED, []]);
+        expect(strokes.map(stroke => stroke.pathId)).toEqual(['line:0', 'line:1', 'line:2']);
+    });
+
+    test('Should fall back to the polyline\'s own dash for uncovered runs', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            lineDash: DOTTED,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDash)).toEqual([DOTTED, DASHED, DOTTED]);
+    });
+
+    test('Should honour a segment\'s dash offset', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+                lineDashOffset: 4,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDashOffset)).toEqual([0, 4, 0]);
+    });
+
+    test.each(SPLITTABLE)('Should split a %s line into runs', renderer => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            renderer,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDash)).toEqual([[], DASHED, []]);
+    });
+
+    // A B-spline's commands land on none of its points, so no span of it can be identified.
+    test('Should fall back to a single stroke for a basis line', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            renderer: 'basis',
+            lineDash: DOTTED,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes).toHaveLength(1);
+        expect(strokes[0].lineDash).toEqual(DOTTED);
+    });
+
+    test('Should fall back to a single stroke for a renderer emitting unattributable commands', () => {
+        const renderer: PolylineRenderFunc = (context, path, points) => {
+            path.moveTo(points[0][0], points[0][1]);
+            path.arc(20, 20, 5, 0, Math.PI);
+        };
+
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            renderer,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes).toHaveLength(1);
+    });
+
+    test('Should skip segmentation while the draw-on transition holds a single point', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: [POINTS[0]],
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes).toHaveLength(1);
+    });
+
+    test('Should clamp runs to a point array truncated mid-animation', () => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS.slice(0, 3),
+            segments: [{
+                from: 1,
+                to: 5,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDash)).toEqual([[], DASHED]);
+    });
+
+    test('Should stroke once again after its segments are removed', () => {
+        const context = createContext(document.createElement('div'));
+        const strokeSpy = vi.spyOn(context, 'applyStroke');
+
+        const polyline = createPolyline({
+            stroke: '#000000',
+            points: POINTS,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        polyline.render(context);
+        expect(strokeSpy).toHaveBeenCalledTimes(3);
+
+        strokeSpy.mockClear();
+        polyline.segments = undefined;
+        polyline.render(context);
+
+        expect(strokeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should hit test against the run sub-paths', () => {
+        const context = createContext(document.createElement('div'));
+        const polyline = createPolyline({
+            id: 'line',
+            stroke: '#000000',
+            points: POINTS,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: DASHED,
+            }],
+        });
+
+        polyline.render(context);
+
+        // The full path is never stroked when segmented, so on SVG it carries no width or transform.
+        const inStroke = vi.spyOn(context, 'isPointInStroke').mockReturnValue(false);
+
+        vi.spyOn(context, 'isPointInPath').mockReturnValue(false);
+        polyline.intersectsWith(10, 10);
+
+        expect(inStroke.mock.calls.map(([path]) => path.id)).toEqual(['line:0', 'line:1', 'line:2']);
+    });
+
+});

--- a/packages/svg/test/polyline-segments.test.ts
+++ b/packages/svg/test/polyline-segments.test.ts
@@ -1,0 +1,161 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import type {
+    SVGContext,
+} from '../src';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    createPolyline,
+} from '@ripl/core';
+
+import type {
+    Point,
+    PolylineSegment,
+} from '@ripl/core';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+const POINTS: Point[] = [
+    [0, 0],
+    [10, 20],
+    [20, 10],
+    [30, 30],
+    [40, 5],
+    [50, 25],
+];
+
+describe('Segmented polylines on SVG', () => {
+
+    let el: HTMLDivElement;
+    let ctx: SVGContext;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+        ctx = createContext(el);
+    });
+
+    afterEach(() => {
+        ctx.destroy();
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function renderPass(segments?: PolylineSegment[]) {
+        ctx.save();
+        ctx.markRenderStart();
+
+        createPolyline({
+            id: 'line',
+            stroke: '#ff0000',
+            lineWidth: 3,
+            points: POINTS,
+            segments,
+        }).render(ctx);
+
+        ctx.markRenderEnd();
+        ctx.restore();
+
+        // Rendering is buffered to rAF; export forces a synchronous reconcile.
+        ctx.export();
+    }
+
+    function paths() {
+        return Array.from(ctx.element.querySelectorAll('path'));
+    }
+
+    test('Should emit one dasharray-carrying path per run', () => {
+        renderPass([{
+            from: 1,
+            to: 3,
+            lineDash: [6, 4],
+        }]);
+
+        const stroked = paths().filter(path => path.style.stroke && path.style.stroke !== 'none');
+
+        expect(stroked.map(path => path.id)).toEqual(['line:0', 'line:1', 'line:2']);
+        expect(stroked.map(path => path.style.strokeDasharray)).toEqual(['', '6 4', '']);
+        expect(stroked.every(path => path.style.strokeWidth === '3')).toBe(true);
+    });
+
+    test('Should leave the unstroked full path invisible', () => {
+        renderPass([{
+            from: 1,
+            to: 3,
+            lineDash: [6, 4],
+        }]);
+
+        const full = ctx.element.querySelector('#line') as SVGPathElement;
+
+        expect(full).not.toBeNull();
+        expect(full.style.stroke).toBe('none');
+        expect(full.style.fill).toBe('none');
+        expect(full.getAttribute('d')).not.toBe('');
+    });
+
+    test('Should draw every span of the line exactly once', () => {
+        renderPass([{
+            from: 1,
+            to: 3,
+            lineDash: [6, 4],
+        }]);
+
+        const stroked = paths().filter(path => path.style.stroke && path.style.stroke !== 'none');
+        const commands = stroked.map(path => (path.getAttribute('d') ?? '').split(/(?=[ML])/).length);
+
+        expect(commands).toEqual([2, 3, 3]);
+    });
+
+    test('Should remove stale run paths when the segment count shrinks', () => {
+        renderPass([
+            {
+                from: 1,
+                to: 2,
+                lineDash: [6, 4],
+            },
+            {
+                from: 3,
+                to: 4,
+                lineDash: [2, 3],
+            },
+        ]);
+
+        expect(paths().map(path => path.id)).toContain('line:4');
+
+        renderPass([{
+            from: 1,
+            to: 2,
+            lineDash: [6, 4],
+        }]);
+
+        const ids = paths().map(path => path.id);
+
+        expect(ids).toContain('line:2');
+        expect(ids).not.toContain('line:3');
+        expect(ids).not.toContain('line:4');
+    });
+
+    test('Should stroke the full path when unsegmented', () => {
+        renderPass();
+
+        const full = ctx.element.querySelector('#line') as SVGPathElement;
+
+        expect(paths()).toHaveLength(1);
+        expect(full.style.stroke).toBe('rgb(255, 0, 0)');
+    });
+
+});


### PR DESCRIPTION
`lineStyle` now also accepts key-anchored spans, each with their own dash style, so one line can change style along its length — actuals solid, forecast dashed, an outage window dotted.

```ts
series: [{
    id: 'revenue', value: 'revenue', label: 'Revenue', lineType: 'monotoneX',

    // array form — everything the segments don't cover stays solid
    lineStyle: [
        { from: 'february', to: 'june', style: 'dashed' },
        { from: data => data[data.length - 3].month, style: 'dotted' },
    ],

    // …or the object form, naming the fallback explicitly
    lineStyle: {
        default: 'solid',
        segments: [{ from: 'february', to: 'june', style: 'dashed' }],
    },
}]
```

`from` defaults to the start of the line and `to` (inclusive) to its end. Segments apply in declaration order, so a later one wins where two overlap. A segment whose key isn't in the data is skipped rather than throwing, so a data change that drops a boundary leaves the rest of the line intact.

Scalar `lineStyle` is untouched. `lineStyle: []` keeps meaning "solid" — only a non-empty array of *objects* reads as a segment list.

## How it renders

Still **one** `Polyline` element, so the progressive draw-on (`interpolatePath`) and the keyed point morph (`interpolatePoints` + `correspondence`) are completely unaffected.

Canvas `setLineDash` and SVG `stroke-dasharray` apply per stroke call, so the element traces one path and then strokes **once per run**. Runs are extracted by running the *unmodified* curve renderer against a multiplexing `ContextPath` proxy that forwards every command to the full path and to each run overlapping the point interval that command spans. Nothing about the 13 renderers changes, and the curve inside a run is identical to the unsegmented line, so adjacent runs meet exactly.

Slicing points per run and re-running the renderer would have been wrong rather than merely imprecise — `natural` solves a global tridiagonal system, and `spline`/`cardinal`/`catmullRom`/`monotone*` take tangents from neighbours, so every boundary would kink.

### Fallbacks, not silent gaps

A trace that can't be attributed to points **falls back to a single stroke** rather than dropping geometry:

- **`basis`** is a B-spline whose command endpoints land on none of its points, so no span of it can be identified. It renders in one style.
- **Custom `PolylineRenderFunc`s** emitting `arc`/`rect`/`closePath` etc. — same fallback.
- **`cardinal`** splits, but its first curve skips point 1, so a boundary there resolves to point 2.

All three are asserted in tests and the first is documented on the option.

## Changes

**Core**
- `Polyline` gains `segments?: PolylineSegment[]` (point-index spans with their own dash), plus `normalizePolylineRuns` — a pure function that clamps, stamps in order, and coalesces adjacent runs of equal dash so the path is never split where the style doesn't change.
- Segment indices are clamped **per trace**, not once at author time: `interpolatePath` shrinks the point array every frame during draw-on, and returns a *single* point on the first frames.
- `Shape2D` gains protected `strokePath` and `hitPaths` seams. `hitPaths` is load-bearing on SVG: `_setElementStyles` is the only writer of the `transform` attribute and runs only from `applyFill`/`applyStroke`, so the never-stroked full path has neither a transform nor a `stroke-width` and can't be hit tested. Hit testing now runs against the run sub-paths, which do get both.
- The run dash falls back to `context.lineDash` read at stroke time, not element state, so a pattern inherited from a group still applies.

**Charts**
- `LineStyleBound`, `LineStyleSegment`, `LineStyleSegments`, `LineStyleInput`, `ResolvedLineStyle` and `resolveLineStyle` in `core/options.ts`. `LineStyle` and `resolveLineDash` are unchanged and still public.
- `lineStyle` widened on all five declarations (`LineSeriesLike`, line, area, and both trend line/area series). Trend needed no renderer changes — it reuses the shared line and area renderers.
- Both resolved fields are assigned directly, never through a transition, alongside the existing non-tweenable `renderer`/`lineDash`.
- `OPTIONS.md` value-shape row updated.

**Docs & demos**
- A `Segmented` entry in the Line style control on line/area/trend, wired to bounds read off the live dataset so it survives add/remove and the time axis.
- A `### Segmented line styles` variant on each page, including the `basis`/`cardinal` note.

## Verification

- `yarn test` — 1920 passed / 174 files; coverage above every ratchet.
- `yarn lint`, `yarn typecheck`, `yarn typecheck:dist`, `yarn build` — all clean.
- `check-chart-options` and `check-config-coverage` — clean (the former type-checks every doc snippet against the source).
- TypeDoc `notDocumented` — nothing new for `@ripl/core` or `@ripl/charts`.
- 50 new tests: run normalization, per-renderer attribution across all 13 `lineType` values, the `basis`/custom-renderer fallbacks, the truncated-points animation frames, hit testing, the SVG backend end-to-end (dasharray per run, invisible full path, stale run-path removal), and the chart-level resolver including re-resolution on `update()`.

### Two things to note

**Visual snapshot.** A `line-segmented` gallery case is added, but its baseline is **not** committed — snapshots generated in this sandbox don't match the committed ones (`bar`, `line`, `pie` and others already fail here on an unmodified tree, so it's environmental font rendering). Please generate it with `yarn workspace @ripl/charts test:visual:update`. Seven chart ids already ship without a committed baseline, so this isn't a new state. I did render and inspect the case: solid Jan–Feb, dashed Feb–Apr, solid Apr–May, dotted May–Jun, one continuous `monotoneX` curve with no seams at the boundaries.

**Pre-existing issues found, deliberately not fixed here:**
- `polylineCardinalRenderer` emits `n-2` curves for `n-1` intervals — it draws one interval too few today, independent of this change.
- SVG stroke gradients use `gradientUnits="objectBoundingBox"`, so a gradient-stroked *segmented* line will restart the ramp per run. Canvas is unaffected. Fixing it means moving stroke gradients to `userSpaceOnUse`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu1Z4c37LSD5ZkbEF1bCyV)_