### PR TITLE
fix: cardinal spline, SVG gradient units, SVG defs timing, slider starving demos

### DIFF
--- a/apps/website/src/.vitepress/components/ripl-input-range.vue
+++ b/apps/website/src/.vitepress/components/ripl-input-range.vue
@@ -3,7 +3,7 @@
         <input
             type="range"
             class="ripl-input-range__slider"
-            :value="modelValue"
+            :value="display"
             :min="min"
             :max="max"
             :step="step"
@@ -14,6 +14,10 @@
 </template>
 
 <script lang="ts" setup>
+import {
+    createFrameBuffer,
+} from '@ripl/web';
+
 import {
     computed,
     onBeforeUnmount,
@@ -26,66 +30,51 @@ const props = withDefaults(defineProps<{
     min?: number;
     max?: number;
     step?: number;
-    /**
-     * Milliseconds to hold back `update:modelValue` while the slider is being dragged. The first
-     * change in a gesture is emitted immediately, so a click or a keyboard step still applies at
-     * once; subsequent changes coalesce onto the trailing edge. Set `0` to emit every step.
-     */
-    debounce?: number;
 }>(), {
     min: undefined,
     max: undefined,
     step: undefined,
-    debounce: 120,
 });
 
 const emit = defineEmits<{
     'update:modelValue': [value: number];
 }>();
 
-// Each `input` costs a `chart.update()` and a full render, so throttle the emit; the thumb and readout stay live.
+// The input is bound to this, not the model, so a slow consumer can't drag the thumb back mid-gesture.
 const dragged = ref<number>();
 const display = computed(() => dragged.value ?? props.modelValue);
 
-let timer: ReturnType<typeof setTimeout> | undefined;
+// An emit only ever drives a render, which can't outpace the display, so coalesce onto the frame.
+const scheduleFlush = createFrameBuffer();
 
-function flush(value: number): void {
-    timer = undefined;
-    emit('update:modelValue', value);
-}
+let pending = false;
+let unmounted = false;
 
 function onInput(event: Event): void {
     const value = Number((event.target as HTMLInputElement).value);
 
     dragged.value = value;
+    pending = true;
 
-    if (!props.debounce) {
-        flush(value);
-        return;
-    }
+    scheduleFlush(() => {
+        pending = false;
 
-    // Leading edge: apply immediately when idle; values inside the window replace the pending one.
-    if (!timer) {
-        flush(value);
-        timer = setTimeout(() => {
-            timer = undefined;
-        }, props.debounce);
-
-        return;
-    }
-
-    clearTimeout(timer);
-    timer = setTimeout(() => flush(value), props.debounce);
+        if (!unmounted) {
+            emit('update:modelValue', value);
+        }
+    });
 }
 
 // Once the model catches up (or is reset externally) the readout goes back to tracking it.
 watch(() => props.modelValue, value => {
-    if (!timer || value === dragged.value) {
+    if (!pending || value === dragged.value) {
         dragged.value = undefined;
     }
 });
 
-onBeforeUnmount(() => clearTimeout(timer));
+onBeforeUnmount(() => {
+    unmounted = true;
+});
 </script>
 
 <style scoped>

--- a/apps/website/src/charts/line.md
+++ b/apps/website/src/charts/line.md
@@ -540,8 +540,8 @@ skipped rather than throwing, leaving that span at the default style.
 
 > [!NOTE]
 > A `basis` line is a B-spline that passes through none of its points, so there is no point at which
-> to split it: a segmented `basis` line falls back to a single style. On a `cardinal` line a boundary
-> on the second point resolves to the third, because its curve skips that point.
+> to split it: a segmented `basis` line falls back to a single style. Every other `lineType` splits
+> exactly on the point you name.
 
 ### Time x-axis
 

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -5,7 +5,6 @@ import {
     canvasIsPointInPath,
     canvasIsPointInStroke,
     canvasMeasureText,
-    getCanvasGradientBounds,
     setCanvasFill,
     setCanvasStroke,
 } from './utilities';
@@ -15,6 +14,7 @@ import {
 } from './path';
 
 import {
+    getGradientBounds,
     isGradientString,
     isPatternString,
 } from '@ripl/core';
@@ -161,7 +161,7 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
 
             // Fast path: plain colors skip bounds resolution and parsing; a raw pattern is not a valid fill.
             if (isGradientString(value) || isPatternString(value)) {
-                const bounds = getCanvasGradientBounds(this.gradientBounds(), this.width, this.height);
+                const bounds = getGradientBounds(this.gradientBounds(), this.width, this.height);
                 setCanvasFill(this.context, value, bounds);
             } else {
                 this.context.fillStyle = value;
@@ -305,7 +305,7 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
 
             // Fast path: plain colors skip bounds resolution and parsing; a raw pattern is not a valid stroke.
             if (isGradientString(value) || isPatternString(value)) {
-                const bounds = getCanvasGradientBounds(this.gradientBounds(), this.width, this.height);
+                const bounds = getGradientBounds(this.gradientBounds(), this.width, this.height);
                 setCanvasStroke(this.context, value, bounds);
             } else {
                 this.context.strokeStyle = value;

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -10,6 +10,7 @@ import {
     parseColor,
     parseGradient,
     parsePattern,
+    resolveGradientBounds,
     samplePathPoint,
     scaleContinuous,
     serializeRGBA,
@@ -19,6 +20,7 @@ import type {
     Box,
     FillRule,
     Gradient,
+    GradientBounds,
     Scale,
 } from '@ripl/core';
 
@@ -30,17 +32,7 @@ import type {
     CanvasPath,
 } from './path';
 
-/** Bounding rectangle used to resolve gradient coordinates. */
-export type GradientBounds = {
-    /** X coordinate of the rectangle's top-left corner. */
-    x: number;
-    /** Y coordinate of the rectangle's top-left corner. */
-    y: number;
-    /** Width of the bounding rectangle, in pixels. */
-    width: number;
-    /** Height of the bounding rectangle, in pixels. */
-    height: number;
-};
+export type { GradientBounds };
 
 type CanvasGradientFactory = (context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds) => CanvasGradient;
 
@@ -92,23 +84,9 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
     return canvasGradient;
 }
 
-/** Resolves gradient bounds from a bounding box or falls back to context dimensions. */
+/** Resolves gradient bounds from a bounding box or falls back to context dimensions. Alias of {@link resolveGradientBounds}, which every backend shares. */
 export function getCanvasGradientBounds(box: Box | undefined, width: number, height: number): GradientBounds {
-    if (box && box.width > 0 && box.height > 0) {
-        return {
-            x: box.left,
-            y: box.top,
-            width: box.width,
-            height: box.height,
-        };
-    }
-
-    return {
-        x: 0,
-        y: 0,
-        width,
-        height,
-    };
+    return resolveGradientBounds(box, width, height);
 }
 
 // Parsing is expensive and repeats per element per frame, so memoize by string; bounded for animated gradients.

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -10,14 +10,12 @@ import {
     parseColor,
     parseGradient,
     parsePattern,
-    resolveGradientBounds,
     samplePathPoint,
     scaleContinuous,
     serializeRGBA,
 } from '@ripl/core';
 
 import type {
-    Box,
     FillRule,
     Gradient,
     GradientBounds,
@@ -31,8 +29,6 @@ import {
 import type {
     CanvasPath,
 } from './path';
-
-export type { GradientBounds };
 
 type CanvasGradientFactory = (context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds) => CanvasGradient;
 
@@ -82,11 +78,6 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
     });
 
     return canvasGradient;
-}
-
-/** Resolves gradient bounds from a bounding box or falls back to context dimensions. Alias of {@link resolveGradientBounds}, which every backend shares. */
-export function getCanvasGradientBounds(box: Box | undefined, width: number, height: number): GradientBounds {
-    return resolveGradientBounds(box, width, height);
 }
 
 // Parsing is expensive and repeats per element per frame, so memoize by string; bounded for animated gradients.

--- a/packages/canvas/test/helpers.test.ts
+++ b/packages/canvas/test/helpers.test.ts
@@ -11,12 +11,7 @@ import {
     mockCanvasContext,
 } from '@ripl/test-utils';
 
-import type {
-    Box,
-} from '@ripl/core';
-
 import {
-    getCanvasGradientBounds,
     rescaleCanvas,
     setCanvasFill,
     setCanvasStroke,
@@ -35,45 +30,6 @@ const LINEAR = 'linear-gradient(90deg, #ff0000, #0000ff)';
 function context() {
     return document.createElement('canvas').getContext('2d')!;
 }
-
-describe('getCanvasGradientBounds', () => {
-
-    test('uses the box when it has a positive size', () => {
-        const box = {
-            left: 10,
-            top: 20,
-            width: 30,
-            height: 40,
-        } as Box;
-
-        expect(getCanvasGradientBounds(box, 100, 200)).toEqual({
-            x: 10,
-            y: 20,
-            width: 30,
-            height: 40,
-        });
-    });
-
-    test('falls back to context dimensions for a missing or empty box', () => {
-        expect(getCanvasGradientBounds(undefined, 100, 200)).toEqual({
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 200,
-        });
-
-        expect(getCanvasGradientBounds({
-            width: 0,
-            height: 0,
-        } as Box, 100, 200)).toEqual({
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 200,
-        });
-    });
-
-});
 
 describe('setCanvasFill / setCanvasStroke', () => {
 

--- a/packages/core/src/elements/polyline.ts
+++ b/packages/core/src/elements/polyline.ts
@@ -132,8 +132,8 @@ export function normalizePolylineRuns(pointCount: number, segments?: PolylineSeg
  * Every command is forwarded to the full path unconditionally, and additionally to each run
  * overlapping the point interval the command spans, prefixed with a `moveTo` the first time that
  * run receives one. A command's interval is tracked by matching its endpoint against the upcoming
- * points; the two-point lookahead covers the one index `cardinal` skips without letting degenerate
- * data trigger a runaway jump.
+ * points; the lookahead spans two points so a custom renderer that covers an interval in one
+ * command still attributes, without letting degenerate data trigger a runaway jump.
  */
 class SegmentedPathTracer extends ContextPath {
 

--- a/packages/core/src/gradient/bounds.ts
+++ b/packages/core/src/gradient/bounds.ts
@@ -27,7 +27,7 @@ export type GradientBounds = {
  * @param height - Height of the rendering surface, used as the fallback.
  * @returns The rectangle to resolve gradient coordinates against.
  */
-export function resolveGradientBounds(box: Box | undefined, width: number, height: number): GradientBounds {
+export function getGradientBounds(box: Box | undefined, width: number, height: number): GradientBounds {
     if (box && box.width > 0 && box.height > 0) {
         return {
             x: box.left,

--- a/packages/core/src/gradient/bounds.ts
+++ b/packages/core/src/gradient/bounds.ts
@@ -1,0 +1,46 @@
+import type {
+    Box,
+} from '../math';
+
+/** Bounding rectangle a gradient's coordinates are resolved against. */
+export type GradientBounds = {
+    /** X coordinate of the rectangle's top-left corner. */
+    x: number;
+    /** Y coordinate of the rectangle's top-left corner. */
+    y: number;
+    /** Width of the bounding rectangle, in pixels. */
+    width: number;
+    /** Height of the bounding rectangle, in pixels. */
+    height: number;
+};
+
+/**
+ * Resolves the rectangle a gradient's coordinates map onto: the given bounding box, falling back to
+ * the full surface when no box is supplied or it has no area.
+ *
+ * Every backend resolves gradients through this, so a gradient painted onto the same element renders
+ * identically whichever context draws it — including elements that paint as several paths, where
+ * each path's own box would otherwise restart the ramp.
+ *
+ * @param box - The element's local bounding box, when it has one.
+ * @param width - Width of the rendering surface, used as the fallback.
+ * @param height - Height of the rendering surface, used as the fallback.
+ * @returns The rectangle to resolve gradient coordinates against.
+ */
+export function resolveGradientBounds(box: Box | undefined, width: number, height: number): GradientBounds {
+    if (box && box.width > 0 && box.height > 0) {
+        return {
+            x: box.left,
+            y: box.top,
+            width: box.width,
+            height: box.height,
+        };
+    }
+
+    return {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+}

--- a/packages/core/src/gradient/index.ts
+++ b/packages/core/src/gradient/index.ts
@@ -1,3 +1,4 @@
+export * from './bounds';
 export * from './parser';
 export * from './serializer';
 export * from './types';

--- a/packages/core/src/math/polyline.ts
+++ b/packages/core/src/math/polyline.ts
@@ -258,41 +258,24 @@ export function polylineCardinalRenderer(tension: number = 0): PolylineRenderFun
         }
 
         const pointCount = points.length;
-        const tensionFactor = (1 - tension) / 2;
+        // The Hermite tangent is (1 - tension) * (p2 - p0) / 2, and converting it to a Bézier control point divides by 3.
+        const tensionFactor = (1 - tension) / 6;
 
-        for (let index = 1; index < pointCount - 1; index++) {
-            const [x0, y0] = points[index - 1];
+        for (let index = 0; index < pointCount - 1; index++) {
+            // The end tangents mirror their own point, matching the endpoint clamping every cardinal spline uses.
+            const [x0, y0] = points[index - 1] ?? points[index];
             const [x1, y1] = points[index];
             const [x2, y2] = points[index + 1];
+            const [x3, y3] = points[index + 2] ?? points[index + 1];
 
-            const cpx1 = x1 + (x2 - x0) * tensionFactor;
-            const cpy1 = y1 + (y2 - y0) * tensionFactor;
-
-            let cpx2: number;
-            let cpy2: number;
-            let endX: number;
-            let endY: number;
-
-            if (index === pointCount - 2) {
-                endX = x2;
-                endY = y2;
-                cpx2 = x2 - (x2 - x1) * tensionFactor;
-                cpy2 = y2 - (y2 - y1) * tensionFactor;
-            } else {
-                const [x3, y3] = points[index + 2];
-                endX = x2;
-                endY = y2;
-                cpx2 = x2 - (x3 - x1) * tensionFactor;
-                cpy2 = y2 - (y3 - y1) * tensionFactor;
-            }
-
-            path.bezierCurveTo(cpx1, cpy1, cpx2, cpy2, endX, endY);
-        }
-
-        if (pointCount > 2) {
-            const [xn1, yn1] = points[pointCount - 1];
-
-            path.lineTo(xn1, yn1);
+            path.bezierCurveTo(
+                x1 + (x2 - x0) * tensionFactor,
+                y1 + (y2 - y0) * tensionFactor,
+                x2 - (x3 - x1) * tensionFactor,
+                y2 - (y3 - y1) * tensionFactor,
+                x2,
+                y2
+            );
         }
     };
 }

--- a/packages/core/test/elements/polyline-renderers.test.ts
+++ b/packages/core/test/elements/polyline-renderers.test.ts
@@ -25,6 +25,7 @@ import type {
     Context,
     ContextPath,
     Point,
+    PolylineRenderFunc,
 } from '../../src';
 
 function createMockPath(): ContextPath {
@@ -50,7 +51,116 @@ const mockContext = {} as Context;
 const SIMPLE_POINTS: Point[] = [[0, 0], [50, 100], [100, 50], [150, 75]];
 const TWO_POINTS: Point[] = [[0, 0], [100, 100]];
 
+/** Records the commands a renderer emits, so a test can reconstruct the curve it drew. */
+function recordCommands(renderer: PolylineRenderFunc, points: Point[]) {
+    const commands: { type: string;
+        args: number[]; }[] = [];
+
+    const path = {
+        id: 'record-path',
+        moveTo: (...args: number[]) => commands.push({
+            type: 'moveTo',
+            args,
+        }),
+        lineTo: (...args: number[]) => commands.push({
+            type: 'lineTo',
+            args,
+        }),
+        bezierCurveTo: (...args: number[]) => commands.push({
+            type: 'bezierCurveTo',
+            args,
+        }),
+        quadraticCurveTo: (...args: number[]) => commands.push({
+            type: 'quadraticCurveTo',
+            args,
+        }),
+        polyline: (pts: Point[]) => pts.forEach(([x, y], index) => commands.push({
+            type: index ? 'lineTo' : 'moveTo',
+            args: [x, y],
+        })),
+    } as unknown as ContextPath;
+
+    renderer(mockContext, path, points);
+
+    return commands;
+}
+
+function cubicAt(p0: Point, cp1: Point, cp2: Point, p1: Point, position: number): Point {
+    const inverse = 1 - position;
+
+    return [0, 1].map(axis => inverse ** 3 * p0[axis]
+        + 3 * inverse ** 2 * position * cp1[axis]
+        + 3 * inverse * position ** 2 * cp2[axis]
+        + position ** 3 * p1[axis]) as Point;
+}
+
+/** Densely samples the recorded curve, so a test can assert what the rendered line actually touches. */
+function sampleCurve(renderer: PolylineRenderFunc, points: Point[]): Point[] {
+    const samples: Point[] = [];
+
+    let cursor: Point = [0, 0];
+
+    recordCommands(renderer, points).forEach(({ type, args }) => {
+        if (type === 'moveTo') {
+            cursor = [args[0], args[1]];
+            samples.push(cursor);
+            return;
+        }
+
+        if (type === 'lineTo') {
+            const end: Point = [args[0], args[1]];
+
+            for (let step = 1; step <= 40; step++) {
+                samples.push(cubicAt(cursor, cursor, end, end, step / 40));
+            }
+
+            cursor = end;
+            return;
+        }
+
+        if (type === 'bezierCurveTo') {
+            const end: Point = [args[4], args[5]];
+
+            for (let step = 1; step <= 40; step++) {
+                samples.push(cubicAt(cursor, [args[0], args[1]], [args[2], args[3]], end, step / 40));
+            }
+
+            cursor = end;
+        }
+    });
+
+    return samples;
+}
+
+function distanceToCurve(renderer: PolylineRenderFunc, points: Point[], point: Point): number {
+    return Math.min(...sampleCurve(renderer, points).map(([x, y]) => Math.hypot(x - point[0], y - point[1])));
+}
+
+const INTERPOLATING_RENDERERS: [string, PolylineRenderFunc][] = [
+    ['linear', polylineLinearRenderer()],
+    ['spline', polylineSplineRenderer()],
+    ['bumpX', polylineBumpXRenderer()],
+    ['bumpY', polylineBumpYRenderer()],
+    ['cardinal', polylineCardinalRenderer()],
+    ['catmullRom', polylineCatmullRomRenderer()],
+    ['monotoneX', polylineMonotoneXRenderer()],
+    ['monotoneY', polylineMonotoneYRenderer()],
+    ['natural', polylineNaturalRenderer()],
+    ['step', polylineStepRenderer()],
+    ['stepBefore', polylineStepBeforeRenderer()],
+    ['stepAfter', polylineStepAfterRenderer()],
+];
+
 describe('Polyline Renderers', () => {
+
+    // A renderer that misses a point draws a line through data it was never given.
+    describe.each(INTERPOLATING_RENDERERS)('%s passes through its points', (_name, renderer) => {
+
+        test.each(SIMPLE_POINTS)('Should draw through [%i, %i]', (x, y) => {
+            expect(distanceToCurve(renderer, SIMPLE_POINTS, [x, y])).toBeLessThan(0.5);
+        });
+
+    });
 
     // ── linear ───────────────────────────────────────────────────
 
@@ -189,6 +299,49 @@ describe('Polyline Renderers', () => {
             const path = createMockPath();
             renderer(mockContext, path, SIMPLE_POINTS);
             expect(path.bezierCurveTo).toHaveBeenCalled();
+        });
+
+        // It drew one curve per *pair* of intervals, so the second point was never on the line.
+        test('Should draw one curve per interval', () => {
+            const commands = recordCommands(polylineCardinalRenderer(), SIMPLE_POINTS);
+
+            expect(commands.filter(command => command.type === 'bezierCurveTo')).toHaveLength(SIMPLE_POINTS.length - 1);
+            expect(commands.map(command => command.type)).toEqual(['moveTo', 'bezierCurveTo', 'bezierCurveTo', 'bezierCurveTo']);
+        });
+
+        test('Should end each curve exactly on the next point', () => {
+            const commands = recordCommands(polylineCardinalRenderer(), SIMPLE_POINTS)
+                .filter(command => command.type === 'bezierCurveTo');
+
+            expect(commands.map(command => command.args.slice(4))).toEqual(SIMPLE_POINTS.slice(1));
+        });
+
+        test('Should collapse to straight segments at full tension', () => {
+            const commands = recordCommands(polylineCardinalRenderer(1), SIMPLE_POINTS)
+                .filter(command => command.type === 'bezierCurveTo');
+
+            commands.forEach((command, index) => expect(command.args).toEqual([
+                ...SIMPLE_POINTS[index],
+                ...SIMPLE_POINTS[index + 1],
+                ...SIMPLE_POINTS[index + 1],
+            ]));
+        });
+
+        test('Should match d3 curveCardinal control points', () => {
+            const factor = (1 - 0.5) / 6;
+            const [first] = recordCommands(polylineCardinalRenderer(0.5), SIMPLE_POINTS)
+                .filter(command => command.type === 'bezierCurveTo');
+
+            const [p0, p1, p2] = SIMPLE_POINTS;
+
+            expect(first.args).toEqual([
+                p0[0] + (p1[0] - p0[0]) * factor,
+                p0[1] + (p1[1] - p0[1]) * factor,
+                p1[0] - (p2[0] - p0[0]) * factor,
+                p1[1] - (p2[1] - p0[1]) * factor,
+                p1[0],
+                p1[1],
+            ]);
         });
 
     });

--- a/packages/core/test/elements/polyline-segments.test.ts
+++ b/packages/core/test/elements/polyline-segments.test.ts
@@ -279,6 +279,22 @@ describe('Segmented polyline rendering', () => {
         expect(strokes.map(stroke => stroke.lineDash)).toEqual([[], DASHED, []]);
     });
 
+    // `cardinal` used to skip point 1 entirely, so a boundary there could not be honoured.
+    test.each(SPLITTABLE)('Should split a %s line on its second point', renderer => {
+        const strokes = renderStrokes({
+            stroke: '#000000',
+            points: POINTS,
+            renderer,
+            segments: [{
+                from: 1,
+                to: 2,
+                lineDash: DASHED,
+            }],
+        });
+
+        expect(strokes.map(stroke => stroke.lineDash)).toEqual([[], DASHED, []]);
+    });
+
     // A B-spline's commands land on none of its points, so no span of it can be identified.
     test('Should fall back to a single stroke for a basis line', () => {
         const strokes = renderStrokes({

--- a/packages/core/test/gradient/bounds.test.ts
+++ b/packages/core/test/gradient/bounds.test.ts
@@ -1,0 +1,52 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    getGradientBounds,
+} from '../../src';
+
+import type {
+    Box,
+} from '../../src';
+
+describe('getGradientBounds', () => {
+
+    test('uses the box when it has a positive size', () => {
+        const box = {
+            left: 10,
+            top: 20,
+            width: 30,
+            height: 40,
+        } as Box;
+
+        expect(getGradientBounds(box, 100, 200)).toEqual({
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        });
+    });
+
+    test('falls back to context dimensions for a missing or empty box', () => {
+        expect(getGradientBounds(undefined, 100, 200)).toEqual({
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 200,
+        });
+
+        expect(getGradientBounds({
+            width: 0,
+            height: 0,
+        } as Box, 100, 200)).toEqual({
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 200,
+        });
+    });
+
+});

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -52,6 +52,7 @@ import type {
 
 import {
     createFrameBuffer,
+    getGradientBounds,
     isGradientString,
     isPatternString,
     isTransparentColor,
@@ -59,7 +60,6 @@ import {
     parseGradient,
     parsePattern,
     radiansToDegrees,
-    resolveGradientBounds,
 } from '@ripl/core';
 
 import type {
@@ -218,7 +218,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         this._usedDefs.add(`gradient:${cacheKey}`);
 
         // The element's own box, not the path node's, so a multi-path element ramps once across all of them.
-        const bounds = resolveGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
+        const bounds = getGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
         const cached = this._gradientCache.get(cacheKey);
 
         if (cached) {

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -59,6 +59,7 @@ import {
     parseGradient,
     parsePattern,
     radiansToDegrees,
+    resolveGradientBounds,
 } from '@ripl/core';
 
 import type {
@@ -216,15 +217,17 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
 
         this._usedDefs.add(`gradient:${cacheKey}`);
 
+        // The element's own box, not the path node's, so a multi-path element ramps once across all of them.
+        const bounds = resolveGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
         const cached = this._gradientCache.get(cacheKey);
 
         if (cached) {
-            updateSVGGradientElement(cached.element, gradient);
+            updateSVGGradientElement(cached.element, gradient, bounds);
             return `url(#${cached.gradientId})`;
         }
 
         const gradientId = `gradient-${stringUniqueId()}`;
-        const gradientEl = createSVGGradientElement(gradient, gradientId);
+        const gradientEl = createSVGGradientElement(gradient, gradientId, bounds);
 
         if (!gradientEl) {
             return value;

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -374,6 +374,12 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         reconcileNode(this.element, this._vtree, this._domCache, this._reconcilerOptions);
     }
 
+    // Sweeping after the reconcile, never before: a def removed while a live node still references it paints as a dangling `url(#…)`.
+    private _commit() {
+        this._render();
+        this._sweepDefs();
+    }
+
     /** Signals the start of a render pass; resets the virtual DOM tree, group-nesting pointer, and `<defs>` usage tracking at the outermost depth. */
     public markRenderStart(): void {
         if (this.renderDepth === 0) {
@@ -390,7 +396,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         super.markRenderStart();
     }
 
-    /** Signals the end of a render pass, sweeping `<defs>` entries unused during the pass and reconciling the virtual DOM tree to the SVG surface at the outermost depth. */
+    /** Signals the end of a render pass, reconciling the virtual DOM tree to the SVG surface and then sweeping the `<defs>` entries the pass left unused, at the outermost depth. */
     public markRenderEnd(): void {
         super.markRenderEnd();
 
@@ -398,19 +404,17 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             return;
         }
 
-        this._sweepDefs();
-
         if (this.buffer) {
-            this._requestFrame(() => this._render());
+            this._requestFrame(() => this._commit());
         } else {
-            this._render();
+            this._commit();
         }
     }
 
     /** Captures a snapshot of the SVG surface and returns format-specific exporters (see {@link ContextExport}). */
     public export(): ContextExport {
-        // Buffered rendering defers to rAF, so reconcile synchronously for markup to reflect the latest scene.
-        this._render();
+        // Buffered rendering defers to rAF, so commit synchronously for markup to reflect the latest scene.
+        this._commit();
 
         const markup = new XMLSerializer().serializeToString(this.element);
         const width = this.width;

--- a/packages/svg/src/definitions.ts
+++ b/packages/svg/src/definitions.ts
@@ -10,12 +10,13 @@ import {
 
 import type {
     Gradient,
+    GradientBounds,
     GradientColorStop,
     Pattern,
 } from '@ripl/core';
 
 type GradientElementFactory = (gradient: Gradient) => SVGElement;
-type GradientElementUpdater = (element: SVGElement, gradient: Gradient) => void;
+type GradientElementUpdater = (element: SVGElement, gradient: Gradient, bounds: GradientBounds) => void;
 
 /** Cache entry for a gradient definition living in `<defs>`. */
 /** A cached `<pattern>` definition: its referenced id and the live defs element. */
@@ -72,28 +73,33 @@ function applyGradientStops(gradientEl: SVGElement, stops: GradientColorStop[]) 
     });
 }
 
-function applyLinearGradientAttributes(element: SVGElement, gradient: Gradient): void {
+function applyLinearGradientAttributes(element: SVGElement, gradient: Gradient, bounds: GradientBounds): void {
     const angleRad = degreesToRadians((gradient as { angle: number }).angle - 90);
-    const x1 = 0.5 - Math.cos(angleRad) * 0.5;
-    const y1 = 0.5 - Math.sin(angleRad) * 0.5;
-    const x2 = 0.5 + Math.cos(angleRad) * 0.5;
-    const y2 = 0.5 + Math.sin(angleRad) * 0.5;
+    const cos = Math.cos(angleRad) * 0.5;
+    const sin = Math.sin(angleRad) * 0.5;
 
-    element.setAttribute('x1', x1.toFixed(4));
-    element.setAttribute('y1', y1.toFixed(4));
-    element.setAttribute('x2', x2.toFixed(4));
-    element.setAttribute('y2', y2.toFixed(4));
+    element.setAttribute('x1', (bounds.x + (0.5 - cos) * bounds.width).toFixed(4));
+    element.setAttribute('y1', (bounds.y + (0.5 - sin) * bounds.height).toFixed(4));
+    element.setAttribute('x2', (bounds.x + (0.5 + cos) * bounds.width).toFixed(4));
+    element.setAttribute('y2', (bounds.y + (0.5 + sin) * bounds.height).toFixed(4));
 }
 
-function applyRadialGradientAttributes(element: SVGElement, gradient: Gradient): void {
-    const cx = (gradient as { position: [number, number] }).position[0] / 100;
-    const cy = (gradient as { position: [number, number] }).position[1] / 100;
+function applyRadialGradientAttributes(element: SVGElement, gradient: Gradient, bounds: GradientBounds): void {
+    const position = (gradient as { position: [number, number] }).position;
+    const cx = bounds.x + (position[0] / 100) * bounds.width;
+    const cy = bounds.y + (position[1] / 100) * bounds.height;
+    const radius = bounds.width / 2;
 
     element.setAttribute('cx', cx.toFixed(4));
     element.setAttribute('cy', cy.toFixed(4));
-    element.setAttribute('r', '0.5');
+    element.setAttribute('r', radius.toFixed(4));
     element.setAttribute('fx', cx.toFixed(4));
     element.setAttribute('fy', cy.toFixed(4));
+
+    // A user-space radial gradient is a circle; scaling about the centre restores the ellipse the bounding box gave it.
+    const scaleY = bounds.height / bounds.width;
+
+    element.setAttribute('gradientTransform', `translate(${cx.toFixed(4)},${cy.toFixed(4)}) scale(1,${scaleY.toFixed(4)}) translate(${(-cx).toFixed(4)},${(-cy).toFixed(4)})`);
 }
 
 const GRADIENT_ELEMENT_FACTORIES: Record<string, GradientElementFactory> = {
@@ -111,8 +117,16 @@ export function isSupportedSVGGradient(gradient: Gradient): boolean {
     return !!GRADIENT_ELEMENT_FACTORIES[gradient.type];
 }
 
-/** Creates a gradient element for `<defs>` from a parsed gradient, or `undefined` when the gradient type has no SVG primitive. */
-export function createSVGGradientElement(gradient: Gradient, gradientId: string): SVGElement | undefined {
+/**
+ * Creates a gradient element for `<defs>` from a parsed gradient, or `undefined` when the gradient
+ * type has no SVG primitive.
+ *
+ * @param gradient - The parsed gradient to render.
+ * @param gradientId - The id the gradient is referenced by.
+ * @param bounds - The rectangle the gradient's coordinates resolve against.
+ * @returns The `<linearGradient>` or `<radialGradient>` element, or `undefined` for an unsupported type.
+ */
+export function createSVGGradientElement(gradient: Gradient, gradientId: string, bounds: GradientBounds): SVGElement | undefined {
     const factory = GRADIENT_ELEMENT_FACTORIES[gradient.type];
 
     if (!factory) {
@@ -122,21 +136,32 @@ export function createSVGGradientElement(gradient: Gradient, gradientId: string)
     const element = factory(gradient);
 
     element.setAttribute('id', gradientId);
-    element.setAttribute('gradientUnits', 'objectBoundingBox');
 
     if (gradient.repeating) {
         element.setAttribute('spreadMethod', 'repeat');
     }
 
-    GRADIENT_ELEMENT_UPDATERS[gradient.type]?.(element, gradient);
-    applyGradientStops(element, gradient.stops);
+    updateSVGGradientElement(element, gradient, bounds);
 
     return element;
 }
 
-/** Updates an existing gradient `<defs>` element in place from a parsed gradient. */
-export function updateSVGGradientElement(element: SVGElement, gradient: Gradient): void {
-    GRADIENT_ELEMENT_UPDATERS[gradient.type]?.(element, gradient);
+/**
+ * Updates an existing gradient `<defs>` element in place from a parsed gradient.
+ *
+ * Coordinates are written in user space against the element's own bounding box rather than SVG's
+ * per-node `objectBoundingBox`, so an element that paints as several paths ramps once across all of
+ * them and matches what the canvas backend draws. They are rewritten every render because they move
+ * with the element.
+ *
+ * @param element - The live gradient element in `<defs>`.
+ * @param gradient - The parsed gradient to render.
+ * @param bounds - The rectangle the gradient's coordinates resolve against.
+ */
+export function updateSVGGradientElement(element: SVGElement, gradient: Gradient, bounds: GradientBounds): void {
+    element.setAttribute('gradientUnits', 'userSpaceOnUse');
+
+    GRADIENT_ELEMENT_UPDATERS[gradient.type]?.(element, gradient, bounds);
     applyGradientStops(element, gradient.stops);
 }
 

--- a/packages/svg/test/defs-timing.test.ts
+++ b/packages/svg/test/defs-timing.test.ts
@@ -1,0 +1,180 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import type {
+    SVGContext,
+} from '../src';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+const REFERENCING_PROPERTIES = ['clip-path', 'fill', 'stroke', 'filter'];
+
+/**
+ * Buffered rendering defers the DOM reconcile to a frame, so every test here drives the frame by
+ * hand — `export()` would collapse the deferred work back into one task and hide what is being
+ * measured.
+ */
+describe('SVG defs timing', () => {
+
+    let el: HTMLDivElement;
+    let ctx: SVGContext;
+    let frames: FrameRequestCallback[];
+
+    beforeEach(() => {
+        mockCanvasContext();
+
+        frames = [];
+
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+            frames.push(callback);
+            return frames.length;
+        });
+
+        vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(handle => {
+            frames[handle - 1] = () => undefined;
+        });
+
+        el = document.createElement('div');
+        document.body.appendChild(el);
+        ctx = createContext(el);
+    });
+
+    afterEach(() => {
+        ctx.destroy();
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function flushFrames() {
+        const pending = frames;
+
+        frames = [];
+        pending.forEach(callback => callback(0));
+    }
+
+    function renderPass(body: () => void) {
+        ctx.save();
+        ctx.markRenderStart();
+        body();
+        ctx.markRenderEnd();
+        ctx.restore();
+    }
+
+    /** Every `url(#…)` a live node points at, that resolves to nothing inside `<defs>`. */
+    function danglingReferences(): string[] {
+        const defIds = new Set(Array.from(ctx.element.querySelectorAll('defs > *')).map(node => node.id).filter(Boolean));
+        const dangling: string[] = [];
+
+        Array.from(ctx.element.querySelectorAll('*')).forEach(node => {
+            REFERENCING_PROPERTIES.forEach(property => {
+                const value = node.getAttribute(property) ?? (node as SVGElement).style?.getPropertyValue(property) ?? '';
+                // Styles serialize the reference quoted (`url("#id")`), attributes do not.
+                const match = /url\(\s*["']?#([^"')]+)["']?\s*\)/.exec(value);
+
+                if (match && !defIds.has(match[1])) {
+                    dangling.push(`${property}=${match[1]}`);
+                }
+            });
+        });
+
+        return dangling;
+    }
+
+    function drawClipped(pass: string) {
+        const clip = ctx.createPath(`clip-${pass}`);
+
+        clip.rect(0, 0, 5, 5);
+        ctx.applyClip(clip);
+
+        const shape = ctx.createPath(`shape-${pass}`);
+
+        shape.rect(0, 0, 10, 10);
+        ctx.applyFill(shape);
+    }
+
+    function drawGradient(pass: string) {
+        ctx.fill = 'linear-gradient(180deg, red, blue)';
+
+        const shape = ctx.createPath(`gradient-${pass}`);
+
+        shape.rect(0, 0, 10, 10);
+        ctx.applyFill(shape);
+    }
+
+    // The demos mint a fresh element id per redraw, so every def is created and swept every frame.
+    test('Should never leave a live node pointing at a swept clip def', () => {
+        renderPass(() => drawClipped('a'));
+        flushFrames();
+
+        expect(ctx.element.querySelector('[clip-path]')).not.toBeNull();
+        expect(danglingReferences()).toEqual([]);
+
+        renderPass(() => drawClipped('b'));
+
+        // The DOM still holds pass "a" until the deferred reconcile, so "a" must still resolve.
+        expect(danglingReferences()).toEqual([]);
+
+        flushFrames();
+        expect(danglingReferences()).toEqual([]);
+    });
+
+    test('Should never leave a live node pointing at a swept gradient def', () => {
+        renderPass(() => drawGradient('a'));
+        flushFrames();
+
+        expect(danglingReferences()).toEqual([]);
+
+        renderPass(() => drawGradient('b'));
+        expect(danglingReferences()).toEqual([]);
+
+        flushFrames();
+        expect(danglingReferences()).toEqual([]);
+    });
+
+    test('Should hold no dangling reference across a long run of fresh ids', () => {
+        const observed: number[] = [];
+
+        for (let pass = 0; pass < 20; pass++) {
+            renderPass(() => drawClipped(`p${pass}`));
+            observed.push(danglingReferences().length);
+            flushFrames();
+            observed.push(danglingReferences().length);
+        }
+
+        expect(observed.filter(count => count > 0)).toEqual([]);
+    });
+
+    test('Should still collect defs an element stopped using', () => {
+        renderPass(() => drawGradient('a'));
+        flushFrames();
+
+        expect(ctx.element.querySelectorAll('defs > *')).toHaveLength(1);
+
+        renderPass(() => undefined);
+        flushFrames();
+
+        expect(ctx.element.querySelectorAll('defs > *')).toHaveLength(0);
+    });
+
+    test('Should keep defs bounded while ids churn', () => {
+        for (let pass = 0; pass < 20; pass++) {
+            renderPass(() => drawClipped(`p${pass}`));
+            flushFrames();
+        }
+
+        expect(ctx.element.querySelectorAll('defs > *').length).toBeLessThanOrEqual(1);
+    });
+
+});

--- a/packages/svg/test/gradient-units.test.ts
+++ b/packages/svg/test/gradient-units.test.ts
@@ -1,0 +1,174 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import type {
+    SVGContext,
+} from '../src';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    createPolyline,
+    createRect,
+} from '@ripl/core';
+
+import type {
+    Element,
+    Point,
+} from '@ripl/core';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+const POINTS: Point[] = [
+    [0, 0],
+    [10, 20],
+    [20, 10],
+    [30, 30],
+    [40, 5],
+    [50, 25],
+];
+
+describe('SVG gradient units', () => {
+
+    let el: HTMLDivElement;
+    let ctx: SVGContext;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+        ctx = createContext(el);
+    });
+
+    afterEach(() => {
+        ctx.destroy();
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function renderPass(element: Element) {
+        ctx.save();
+        ctx.markRenderStart();
+        element.render(ctx);
+        ctx.markRenderEnd();
+        ctx.restore();
+
+        // Rendering is buffered to rAF; export forces a synchronous reconcile.
+        ctx.export();
+    }
+
+    function gradients() {
+        return Array.from(ctx.element.querySelectorAll('linearGradient, radialGradient'));
+    }
+
+    test('Should resolve a linear gradient in user space against the element box', () => {
+        renderPass(createRect({
+            id: 'box',
+            x: 100,
+            y: 50,
+            width: 200,
+            height: 80,
+            fill: 'linear-gradient(90deg, red, blue)',
+        }));
+
+        const [gradient] = gradients();
+
+        expect(gradient.getAttribute('gradientUnits')).toBe('userSpaceOnUse');
+        expect(Number(gradient.getAttribute('x1'))).toBeCloseTo(100, 3);
+        expect(Number(gradient.getAttribute('x2'))).toBeCloseTo(300, 3);
+        expect(Number(gradient.getAttribute('y1'))).toBeCloseTo(90, 3);
+        expect(Number(gradient.getAttribute('y2'))).toBeCloseTo(90, 3);
+    });
+
+    // A user-space radial gradient is a circle, so the ellipse has to be restored by transform.
+    test('Should keep a radial gradient elliptical', () => {
+        renderPass(createRect({
+            id: 'box',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 50,
+            fill: 'radial-gradient(circle at 50% 50%, red, blue)',
+        }));
+
+        const [gradient] = gradients();
+
+        expect(gradient.getAttribute('gradientUnits')).toBe('userSpaceOnUse');
+        expect(Number(gradient.getAttribute('r'))).toBeCloseTo(100, 3);
+        expect(gradient.getAttribute('gradientTransform')).toBe('translate(100.0000,25.0000) scale(1,0.2500) translate(-100.0000,-25.0000)');
+    });
+
+    // Each run is its own <path>, so a per-node bounding box restarted the ramp on every run.
+    test('Should ramp once across every run of a segmented polyline', () => {
+        renderPass(createPolyline({
+            id: 'line',
+            stroke: 'linear-gradient(90deg, red, blue)',
+            lineWidth: 3,
+            points: POINTS,
+            segments: [{
+                from: 1,
+                to: 3,
+                lineDash: [6, 4],
+            }],
+        }));
+
+        const spans = gradients().map(gradient => [
+            Number(gradient.getAttribute('x1')),
+            Number(gradient.getAttribute('x2')),
+        ]);
+
+        // Each run spans the whole line's x range, not the sub-range of its own <path>.
+        expect(spans).toEqual([[0, 50], [0, 50], [0, 50]]);
+    });
+
+    test('Should follow the element when it moves', () => {
+        const rect = createRect({
+            id: 'box',
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+            fill: 'linear-gradient(90deg, red, blue)',
+        });
+
+        renderPass(rect);
+        expect(Number(gradients()[0].getAttribute('x2'))).toBeCloseTo(100, 3);
+
+        rect.x = 400;
+        renderPass(rect);
+
+        expect(gradients()).toHaveLength(1);
+        expect(Number(gradients()[0].getAttribute('x1'))).toBeCloseTo(400, 3);
+        expect(Number(gradients()[0].getAttribute('x2'))).toBeCloseTo(500, 3);
+    });
+
+    test('Should fall back to the surface when there is no render element', () => {
+        ctx.save();
+        ctx.markRenderStart();
+        ctx.fill = 'linear-gradient(90deg, red, blue)';
+
+        const path = ctx.createPath('bare');
+
+        path.rect(0, 0, 10, 10);
+        ctx.applyFill(path);
+        ctx.markRenderEnd();
+        ctx.restore();
+        ctx.export();
+
+        const [gradient] = gradients();
+
+        expect(path.definition.styles.fill).toMatch(/^url\(#gradient-/);
+        expect(gradient.getAttribute('gradientUnits')).toBe('userSpaceOnUse');
+    });
+
+});


### PR DESCRIPTION
Four fixes. The first two are unrelated defects found while building segmented `lineStyle` (#56) and deliberately left out of it. The last two came out of the "gradient demo is slow and glitchy" report, which turned out to be two separate bugs, neither of them in the gradient paint path.

> [!WARNING]
> **Breaking:** `@ripl/canvas` no longer exports `getCanvasGradientBounds` or `GradientBounds`. Import `getGradientBounds` and `GradientBounds` from `@ripl/core` instead. See [Gradient bounds live in core](#3-gradient-bounds-live-in-core-only) below.

## 1. `cardinal` never passed through its points

`polylineCardinalRenderer` emitted `n-2` curves for `n-1` intervals: the first curve jumped straight from `points[0]` to `points[2]`, so the second point was simply not on the line.

```
points [[0,0],[50,100],[100,50],[150,75]]
  before:  2 curves for 3 intervals — [50,100] sits 28.46 units off the curve
  after:   3 curves — every point on the curve
```

The tangent factor was wrong too. A cardinal spline's Hermite tangent is `(1 - tension) · (p₂ - p₀) / 2`, and converting it to a Bézier control point divides by 3 — so the factor is `(1 - tension) / 6`, not `/2`. Both defects came from the same mis-derivation, and the trailing `lineTo` was always zero-length dead code (a visible dot under `lineCap: 'round'`).

Overshoot on a spike (`[[0,50],[10,50],[20,0],[30,50],[40,50]]`, 50-unit range) drops from **11.1 units (22%) to 3.7 (7%)**, which is what d3's `curveCardinal` produces for the same input.

The loop now covers every interval with the usual endpoint clamping (`p₋₁ = p₀`, `pₙ = pₙ₋₁`), matching `catmullRom` and `monotoneX` sitting next to it.

**This changes how existing `cardinal` lines look** — they now touch their data points and are tighter. No committed visual snapshot uses `cardinal`, so nothing regenerates.

## 2. SVG resolved gradients against the wrong box

The real bug is a backend divergence, not anything to do with segmentation:

- Canvas resolves a gradient against the **element's** bounding box (`gradientBounds()` → `currentRenderElement.getBoundingBox(true)`).
- SVG used `gradientUnits="objectBoundingBox"`, which resolves against **each `<path>` node's own box** — and the gradient cache is keyed on `${path.id}:stroke`, so an element painting several paths got one def each.

With one node per element that was invisible. An element that paints several — a segmented polyline — restarted the ramp on every run.

Both backends now resolve through one shared function and SVG writes user-space coordinates, so they paint the same ramp.

Two details worth flagging in review:

- **`gradientUnits` and the coordinates moved into the per-frame update path.** They used to be normalized and therefore constant, so `updateSVGGradientElement` never touched them. Under `userSpaceOnUse` they move with the element and go stale otherwise — there's a test for exactly that.
- **A user-space radial gradient is a circle.** `objectBoundingBox` maps the box to a unit square, so its radial gradients are ellipses. That's restored with a `gradientTransform` scaling about the centre; without it every radial gradient would silently become circular.

**Patterns need no change** — `createSVGPatternElement` already uses `patternUnits="userSpaceOnUse"`.

### Accepted behaviour change

For a *curved* polyline, SVG's `objectBoundingBox` used the geometry bbox (including curve overshoot past the control points) while ripl's `Polyline._getLocalBoundingBox()` is the extent of the points. A gradient on a curved gradient-painted polyline shifts slightly as a result. That's the intended convergence — canvas already behaved this way, and the disagreement was the bug.

## 3. Gradient bounds live in core only

The shared resolver is `getGradientBounds` in `@ripl/core`, and it is the only version. An earlier revision of this PR kept `getCanvasGradientBounds` in `@ripl/canvas` as a delegating alias to avoid a breaking change; two names for one function is worse than one break, so the wrapper is gone.

`GradientBounds` follows it. `@ripl/svg` already took the type from core without re-exporting, and the canvas re-export was the only one in that file.

```diff
- import { getCanvasGradientBounds } from '@ripl/canvas';
- import type { GradientBounds } from '@ripl/canvas';
+ import { getGradientBounds } from '@ripl/core';
+ import type { GradientBounds } from '@ripl/core';
```

`@ripl/canvas` still exports `toCanvasGradient`, `setCanvasFill` and `setCanvasStroke` unchanged; their signatures reference the type from core.

## 4. SVG swept `<defs>` a frame before the DOM caught up

`markRenderEnd` removed unused defs **synchronously** but deferred the DOM reconcile to a frame, so `<defs>` was write-through while everything referencing it was buffered. In between, the browser painted with the previous frame's nodes still pointing at `url(#…)` ids that had just been deleted — **a dangling `clip-path` means no clipping, and a dangling `fill` resolves to none**.

Measured while scrubbing a slider on the SVG backend, sampling the live DOM every frame:

| Demo | Frames with a dangling reference — before | after |
|---|---|---|
| clip-paths | **59 / 60** | **0 / 91** |
| gradients | **59 / 61** | **0 / 91** |
| pattern-fills | **59 / 61** | **0 / 91** |

Reconcile and sweep now commit together, so a def is only removed once nothing references it. `export()` commits too — it previously relied on `markRenderEnd` having already swept, and 12 assertions across 7 test files depend on that.

Defs stay bounded: during a scrub they briefly hold two generations (the new frame's plus the outgoing one), returning to the settled count as soon as motion stops. Over an 800-event scrub, `<defs>` held 1 → 2 → 2 → 2 → 1 and DOM node count 734 → 736 → 734.

**The buffered path had no test coverage at all.** Every SVG test ends with `export()`, which collapses the sweep and the reconcile into one task, and the existing defs tests reuse stable ids so no def is ever created-and-swept in the same pass. The new `defs-timing.test.ts` drives the frame by hand with a fresh id per pass and asserts the invariant directly; three of its assertions fail on `main`.

This predates the slider change — it was simply unreachable at two redraws per drag.

## 5. The range slider was starving every demo

Reported as "the gradient demo is extremely unperformant and glitchy when sliding the angle", on both backends, and later confirmed on every demo with a slider. `RiplInputRange`'s debounce (added in `e8ff7b2`) armed a trailing timer and then cleared and re-armed it on every subsequent input, so a continuous drag never reached the trailing edge.

| | before | after |
|---|---|---|
| Redraws from a 2 s drag firing **120** input events | **2** | **120** |
| 200 events fired synchronously in one tick | 1 | **1** (coalesced) |
| Native `input.value` during a left→right drag | pinned at the last committed value | tracks the pointer |
| Synchronous cost per input event | 0.19 ms | 0.14 ms |

The input was also bound to the model while the model was held back, so Vue re-rendered on every event and patched the thumb back to the last committed value — the "glitchy" half. Observed directly: setting the DOM value to 175, 195, 215… snapped back to 155 every time while the readout raced ahead.

Emits now coalesce onto the animation frame via `createFrameBuffer` — the primitive already used for this in `Scene`, `DOMContext`, `SVGContext` and `CartesianChart`. The `debounce` prop is gone; it was never passed explicitly in any of the 100 usages across 42 pages.

**The gradient paint path was measured and exonerated**: `parseGradient` is ~1.5 µs and a whole redraw is 1.08 ms on canvas / 1.27 ms on SVG. The long-standing inefficiencies it does have (SVG re-parsing per resolve, unconditional `<stop>` rebuilds, no `toCanvasGradient` cache) are real but not load-bearing, and are carried separately.

## Why the two renderer bugs were not caught

Both renderers' existing tests only assert that a command was emitted (`expect(bezierCurveTo).toHaveBeenCalled()`), which cannot see geometry. Every point-interpolating renderer is now sampled and asserted to actually pass through its points — the assertion fails at 28.46 units on the old cardinal. The five SVG gradient tests all fail on the pre-fix code (`[0, 1]` normalized vs `[0, 50]` user space).

## Follow-ups from #56, now that it has merged

- `packages/core/src/elements/polyline.ts` — the segment tracer's two-point lookahead was documented as covering "the one index `cardinal` skips". It no longer skips one, so the rationale is rewritten; the lookahead stays (free, and still guards custom renderers).
- `apps/website/src/charts/line.md` — dropped the note that a boundary on a `cardinal` line resolves to the third point. The `basis` note stays correct.
- `packages/core/test/elements/polyline-segments.test.ts` — new case pinning that every splittable renderer honours a boundary on the **second** point, which was impossible before.

## Verification

- `yarn test` — 1994 passed / 177 files; coverage above every ratchet.
- `yarn lint`, `yarn typecheck`, `yarn typecheck:dist`, `yarn build` — clean. `publint` and `attw` pass, and the built `.d.ts` files confirm the export surface: `@ripl/core` exports `getGradientBounds` and `GradientBounds`, `@ripl/canvas` exports neither old name.
- `check-chart-options` and `check-config-coverage` — clean.
- TypeDoc `notDocumented` — nothing new for `@ripl/core`, `@ripl/canvas`, `@ripl/svg`.
- **Visual regression: 26/26 pass**, re-checked after each change. The committed baselines don't match in this sandbox (font rendering — all 26 fail on unmodified `main`), so each time a local baseline was regenerated on the pre-change state and compared after. Nothing in the gallery moved. No baseline was regenerated or committed.
- Browser-verified: mid-scrub screenshots of the clip demo on SVG show the square fully clipped throughout; the slider still yields 120 redraws from 120 events and coalesces 200 synchronous events to 1.
- Renderer fixes inspected visually: the `cardinal` line touches every marker, and a gradient-stroked segmented line ramps once across the whole line on **both** canvas and SVG.