### PR TITLE
Share one bounded gradient and pattern parse memo across both backends

### DIFF
--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -8,8 +8,8 @@ import {
     isPatternString,
     measureText,
     parseColor,
-    parseGradient,
-    parsePattern,
+    parseGradientCached,
+    parsePatternCached,
     samplePathPoint,
     scaleContinuous,
     serializeRGBA,
@@ -80,26 +80,6 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
     return canvasGradient;
 }
 
-// Parsing is expensive and repeats per element per frame, so memoize by string; bounded for animated gradients.
-const GRADIENT_CACHE_LIMIT = 256;
-const gradientCache = new Map<string, Gradient | undefined>();
-
-/** Parses a CSS gradient string, memoizing the result within a bounded cache. */
-function parseGradientMemoized(value: string): Gradient | undefined {
-    if (gradientCache.has(value)) {
-        return gradientCache.get(value);
-    }
-
-    if (gradientCache.size >= GRADIENT_CACHE_LIMIT) {
-        gradientCache.clear();
-    }
-
-    const gradient = parseGradient(value);
-    gradientCache.set(value, gradient);
-
-    return gradient;
-}
-
 // Pattern tiles are position-independent, so one `CanvasPattern` per string serves every element and frame.
 const PATTERN_CACHE_LIMIT = 256;
 const patternCache = new Map<string, CanvasPattern | null>();
@@ -124,7 +104,7 @@ export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): C
         patternCache.clear();
     }
 
-    const pattern = parsePattern(value);
+    const pattern = parsePatternCached(value);
 
     if (!pattern) {
         patternCache.set(value, null);
@@ -185,7 +165,7 @@ export function setCanvasFill(ctx: CanvasRenderingContext2D, value: string, boun
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientMemoized(value);
+        const gradient = parseGradientCached(value);
 
         if (gradient) {
             ctx.fillStyle = toCanvasGradient(ctx, gradient, bounds);
@@ -208,7 +188,7 @@ export function setCanvasStroke(ctx: CanvasRenderingContext2D, value: string, bo
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientMemoized(value);
+        const gradient = parseGradientCached(value);
 
         if (gradient) {
             ctx.strokeStyle = toCanvasGradient(ctx, gradient, bounds);

--- a/packages/core/src/gradient/parser.ts
+++ b/packages/core/src/gradient/parser.ts
@@ -6,8 +6,15 @@ import type {
     RadialGradient,
 } from './types';
 
+import {
+    createLRUCache,
+} from '@ripl/utilities';
+
 
 const GRADIENT_PATTERN = /^(repeating-)?(linear|radial|conic)-gradient\((.+)\)$/is;
+const GRADIENT_CACHE_LIMIT = 256;
+
+const gradientCache = createLRUCache<string, Gradient | undefined>(GRADIENT_CACHE_LIMIT);
 
 const DIRECTION_MAP: Record<string, number> = {
     'to top': 0,
@@ -252,6 +259,31 @@ export function parseGradient(value: string): Gradient | undefined {
     return parse
         ? parse(args, repeating)
         : undefined;
+}
+
+/**
+ * Parses a CSS gradient string via {@link parseGradient}, memoizing the result in a bounded LRU
+ * cache shared by every rendering backend.
+ *
+ * Parsing is pure but not cheap, and the same handful of paint strings resolve for every element on
+ * every frame, so backends should prefer this over {@link parseGradient} on any render path.
+ *
+ * The returned object is **shared between callers and must not be mutated**; parse it yourself with
+ * {@link parseGradient} when a private, mutable copy is required.
+ *
+ * @param value - The CSS gradient string to parse.
+ * @returns The parsed gradient, or `undefined` if the string is not a recognized gradient.
+ */
+export function parseGradientCached(value: string): Gradient | undefined {
+    if (gradientCache.has(value)) {
+        return gradientCache.get(value);
+    }
+
+    const gradient = parseGradient(value);
+
+    gradientCache.set(value, gradient);
+
+    return gradient;
 }
 
 /** Tests whether a string looks like a CSS gradient (starts with a recognized gradient function name). */

--- a/packages/core/src/pattern/parser.ts
+++ b/packages/core/src/pattern/parser.ts
@@ -10,10 +10,17 @@ import type {
     PatternType,
 } from './types';
 
+import {
+    createLRUCache,
+} from '@ripl/utilities';
+
 
 const PATTERN_REGEX = /^pattern\((.+)\)$/is;
 const SIZE_REGEX = /^(\d*\.?\d+)(px)?$/i;
 const MAX_PATTERN_ARGS = 4;
+const PATTERN_CACHE_LIMIT = 256;
+
+const patternCache = createLRUCache<string, Pattern | null>(PATTERN_CACHE_LIMIT);
 
 function splitPatternArgs(input: string): string[] {
     const args: string[] = [];
@@ -109,6 +116,31 @@ export function parsePattern(value: string): Pattern | null {
         background: args[2] ?? DEFAULT_PATTERN_BACKGROUND,
         size,
     };
+}
+
+/**
+ * Parses a `pattern(...)` paint string via {@link parsePattern}, memoizing the result in a bounded
+ * LRU cache shared by every rendering backend.
+ *
+ * Backends should prefer this over {@link parsePattern} on any render path, where the same paint
+ * string resolves for every element on every frame.
+ *
+ * The returned object is **shared between callers and must not be mutated**; parse it yourself with
+ * {@link parsePattern} when a private, mutable copy is required.
+ *
+ * @param value - The paint string to parse, e.g. `pattern(diagonal, #1a6, #fff0, 8)`.
+ * @returns The parsed pattern, or `null` when the string is not a valid pattern.
+ */
+export function parsePatternCached(value: string): Pattern | null {
+    if (patternCache.has(value)) {
+        return patternCache.get(value)!;
+    }
+
+    const pattern = parsePattern(value);
+
+    patternCache.set(value, pattern);
+
+    return pattern;
 }
 
 /** Tests whether a string looks like a `pattern(...)` paint value (cheap shape check; use {@link parsePattern} to validate fully). */

--- a/packages/core/test/gradient/parser.test.ts
+++ b/packages/core/test/gradient/parser.test.ts
@@ -7,6 +7,7 @@ import {
 import {
     isGradientString,
     parseGradient,
+    parseGradientCached,
 } from '../../src';
 
 describe('Gradient', () => {
@@ -242,6 +243,40 @@ describe('Gradient', () => {
             expect(gradient!.stops).toHaveLength(2);
             expect(gradient!.stops[0].color).toBe('rgba(255, 0, 0, 0.5)');
             expect(gradient!.stops[1].color).toBe('rgba(0, 0, 255, 0.5)');
+        });
+
+    });
+
+    describe('parseGradientCached', () => {
+
+        test('Should parse identically to parseGradient', () => {
+            const value = 'linear-gradient(45deg, red 10%, blue 90%)';
+
+            expect(parseGradientCached(value)).toEqual(parseGradient(value));
+        });
+
+        test('Should return a reference-identical result for the same string', () => {
+            const value = 'radial-gradient(circle at 25% 75%, #fff, #000)';
+
+            expect(parseGradientCached(value)).toBe(parseGradientCached(value));
+        });
+
+        test('Should memoize a non-gradient string as undefined without re-parsing', () => {
+            expect(parseGradientCached('#FF0000')).toBeUndefined();
+            expect(parseGradientCached('#FF0000')).toBeUndefined();
+        });
+
+        // A wipe-at-threshold cache would drop the hot entry here; the bounded LRU keeps it.
+        test('Should retain a recently used entry after the limit is exceeded', () => {
+            const hot = 'linear-gradient(to right, #010203, #040506)';
+            const first = parseGradientCached(hot);
+
+            for (let i = 0; i < 300; i++) {
+                parseGradientCached(`linear-gradient(${i}deg, red, blue)`);
+                parseGradientCached(hot);
+            }
+
+            expect(parseGradientCached(hot)).toBe(first);
         });
 
     });

--- a/packages/core/test/pattern/pattern.test.ts
+++ b/packages/core/test/pattern/pattern.test.ts
@@ -8,6 +8,7 @@ import {
     getPatternTileGeometry,
     isPatternString,
     parsePattern,
+    parsePatternCached,
     serializePattern,
 } from '../../src';
 
@@ -86,6 +87,40 @@ describe('Pattern tile geometry', () => {
         const geometry = getPatternTileGeometry(parsePattern('pattern(cross-hatch)')!);
 
         expect(geometry.shapes).toHaveLength(2);
+    });
+
+});
+
+describe('parsePatternCached', () => {
+
+    it('Should parse identically to parsePattern', () => {
+        const value = 'pattern(diagonal, #1a6, #fff0, 8)';
+
+        expect(parsePatternCached(value)).toEqual(parsePattern(value));
+    });
+
+    it('Should return a reference-identical result for the same string', () => {
+        const value = 'pattern(dots, red, transparent, 12)';
+
+        expect(parsePatternCached(value)).toBe(parsePatternCached(value));
+    });
+
+    it('Should memoize an invalid pattern string as null', () => {
+        expect(parsePatternCached('not-a-pattern')).toBeNull();
+        expect(parsePatternCached('not-a-pattern')).toBeNull();
+    });
+
+    // A wipe-at-threshold cache would drop the hot entry here; the bounded LRU keeps it.
+    it('Should retain a recently used entry after the limit is exceeded', () => {
+        const hot = 'pattern(cross-hatch, #123456, transparent, 9)';
+        const first = parsePatternCached(hot);
+
+        for (let i = 1; i <= 300; i++) {
+            parsePatternCached(`pattern(dots, red, transparent, ${i})`);
+            parsePatternCached(hot);
+        }
+
+        expect(parsePatternCached(hot)).toBe(first);
     });
 
 });

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -57,8 +57,8 @@ import {
     isPatternString,
     isTransparentColor,
     measureText,
-    parseGradient,
-    parsePattern,
+    parseGradientCached,
+    parsePatternCached,
     radiansToDegrees,
 } from '@ripl/core';
 
@@ -168,7 +168,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     }
 
     private _resolvePatternStyle(value: string, cacheKey: string): string {
-        const pattern = parsePattern(value);
+        const pattern = parsePatternCached(value);
 
         if (!pattern) {
             return value;
@@ -204,7 +204,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             return value;
         }
 
-        const gradient = parseGradient(value);
+        const gradient = parseGradientCached(value);
 
         if (!gradient) {
             return value;

--- a/packages/utilities/src/cache.ts
+++ b/packages/utilities/src/cache.ts
@@ -1,0 +1,77 @@
+/** A fixed-capacity cache that evicts the least recently used entry once it is full. */
+export interface LRUCache<TKey, TValue> {
+    /** The number of entries currently held. */
+    readonly size: number;
+    /** Reads an entry, marking it as the most recently used, or `undefined` when absent. */
+    get(key: TKey): TValue | undefined;
+    /** Writes an entry as the most recently used, evicting the least recently used entry when at capacity. */
+    set(key: TKey, value: TValue): void;
+    /** Tests whether an entry is present without affecting its recency. */
+    has(key: TKey): boolean;
+    /** Removes an entry, returning whether it was present. */
+    delete(key: TKey): boolean;
+    /** Removes every entry. */
+    clear(): void;
+}
+
+/**
+ * Creates a bounded {@link LRUCache}, evicting the single least recently used entry when a write
+ * exceeds the limit.
+ *
+ * Recency is tracked by `Map` insertion order: a read re-inserts its key so the oldest key is
+ * always the map's first. Preferred over an unbounded memo wherever the key space is open-ended
+ * (paint strings, resolved geometry), since evicting one entry keeps every other caller's entry
+ * warm — wiping the whole cache at a threshold makes the steady state a permanent miss.
+ *
+ * @param limit - Maximum number of entries to retain. Values below `1` are clamped to `1`.
+ * @typeParam TKey - Type of the cache key.
+ * @typeParam TValue - Type of the cached value.
+ * @returns The cache instance.
+ * @example
+ * const cache = createLRUCache<string, number>(2);
+ *
+ * cache.set('a', 1);
+ * cache.set('b', 2);
+ * cache.get('a');
+ * cache.set('c', 3); // evicts 'b', the least recently used
+ */
+export function createLRUCache<TKey, TValue>(limit: number): LRUCache<TKey, TValue> {
+    const entries = new Map<TKey, TValue>();
+    const maxSize = Math.max(1, Math.floor(limit));
+
+    return {
+        get size() {
+            return entries.size;
+        },
+        get(key) {
+            if (!entries.has(key)) {
+                return undefined;
+            }
+
+            const value = entries.get(key)!;
+
+            entries.delete(key);
+            entries.set(key, value);
+
+            return value;
+        },
+        set(key, value) {
+            entries.delete(key);
+
+            if (entries.size >= maxSize) {
+                entries.delete(entries.keys().next().value!);
+            }
+
+            entries.set(key, value);
+        },
+        has(key) {
+            return entries.has(key);
+        },
+        delete(key) {
+            return entries.delete(key);
+        },
+        clear() {
+            entries.clear();
+        },
+    };
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,3 +1,4 @@
+export * from './cache';
 export * from './collection';
 export * from './comparitors';
 export * from './function';

--- a/packages/utilities/test/cache.test.ts
+++ b/packages/utilities/test/cache.test.ts
@@ -1,0 +1,139 @@
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    createLRUCache,
+} from '../src';
+
+describe('Cache Utilities', () => {
+
+    describe('createLRUCache', () => {
+
+        test('Should store and retrieve values', () => {
+            const cache = createLRUCache<string, number>(4);
+
+            cache.set('a', 1);
+
+            expect(cache.get('a')).toBe(1);
+            expect(cache.has('a')).toBe(true);
+            expect(cache.size).toBe(1);
+        });
+
+        test('Should return undefined for a missing key', () => {
+            const cache = createLRUCache<string, number>(4);
+
+            expect(cache.get('missing')).toBeUndefined();
+            expect(cache.has('missing')).toBe(false);
+        });
+
+        test('Should overwrite an existing key without growing', () => {
+            const cache = createLRUCache<string, number>(4);
+
+            cache.set('a', 1);
+            cache.set('a', 2);
+
+            expect(cache.get('a')).toBe(2);
+            expect(cache.size).toBe(1);
+        });
+
+        test('Should never exceed the limit', () => {
+            const cache = createLRUCache<number, number>(3);
+
+            for (let i = 0; i < 20; i++) {
+                cache.set(i, i);
+            }
+
+            expect(cache.size).toBe(3);
+        });
+
+        test('Should evict exactly one entry per write at the limit', () => {
+            const cache = createLRUCache<string, number>(3);
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.set('c', 3);
+            cache.set('d', 4);
+
+            expect(cache.size).toBe(3);
+            expect(cache.has('a')).toBe(false);
+            expect(cache.has('b')).toBe(true);
+            expect(cache.has('c')).toBe(true);
+            expect(cache.has('d')).toBe(true);
+        });
+
+        // The whole point of the LRU over the previous wipe-at-threshold cache: a hot entry survives.
+        test('Should evict the least recently used entry, not the oldest inserted', () => {
+            const cache = createLRUCache<string, number>(3);
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.set('c', 3);
+
+            expect(cache.get('a')).toBe(1);
+
+            cache.set('d', 4);
+
+            expect(cache.has('a')).toBe(true);
+            expect(cache.has('b')).toBe(false);
+        });
+
+        test('Should refresh recency on overwrite', () => {
+            const cache = createLRUCache<string, number>(3);
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.set('c', 3);
+            cache.set('a', 10);
+            cache.set('d', 4);
+
+            expect(cache.get('a')).toBe(10);
+            expect(cache.has('b')).toBe(false);
+        });
+
+        test('Should delete a key and report whether it was present', () => {
+            const cache = createLRUCache<string, number>(4);
+
+            cache.set('a', 1);
+
+            expect(cache.delete('a')).toBe(true);
+            expect(cache.delete('a')).toBe(false);
+            expect(cache.size).toBe(0);
+        });
+
+        test('Should clear every entry', () => {
+            const cache = createLRUCache<string, number>(4);
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+            cache.clear();
+
+            expect(cache.size).toBe(0);
+            expect(cache.has('a')).toBe(false);
+        });
+
+        test('Should retain undefined values as present entries', () => {
+            const cache = createLRUCache<string, number | undefined>(4);
+
+            cache.set('a', undefined);
+
+            expect(cache.has('a')).toBe(true);
+            expect(cache.get('a')).toBeUndefined();
+            expect(cache.size).toBe(1);
+        });
+
+        test('Should clamp a limit below one', () => {
+            const cache = createLRUCache<string, number>(0);
+
+            cache.set('a', 1);
+            cache.set('b', 2);
+
+            expect(cache.size).toBe(1);
+            expect(cache.has('b')).toBe(true);
+        });
+
+    });
+
+});


### PR DESCRIPTION
First of six branches from the gradient/paint, pointer and SVG commit investigation. Additive and pure — no behaviour change, no visual change. **Gates PR for `claude/paint-materialization`.**

## Problem

The gradient parse memo was private to `@ripl/canvas`, so SVG called raw `parseGradient` on every `applyFill` and every `applyStroke`, every pass, whether or not anything changed. Patterns had no memo at all and re-parsed on *both* backends (`svg/src/context.ts:171` — this one wasn't in the original report).

The memo that did exist evicted by wiping:

```ts
if (gradientCache.size >= GRADIENT_CACHE_LIMIT) {
    gradientCache.clear();
}
```

So an animating gradient periodically dropped every *other* element's stable entry, and any scene with more distinct paint strings than the limit never got a hit at all.

## Change

- `createLRUCache` in `@ripl/utilities` — `Map` insertion-order LRU, evicts one entry instead of all of them. `functionMemoize` is unbounded and `Context._getTrackedElements` depends on its exposed `.cache`, so it was left alone.
- `parseGradientCached` / `parsePatternCached` in `@ripl/core`, on 256-entry caches.
- Canvas drops its private memo; both backends now share one cache.

The memo returns a shared object. Every current consumer is read-only and the JSDoc says so; I grepped for mutation of a parsed result before merging.

## Verification

- `yarn test` 181 files / 2038 tests, `yarn lint`, `yarn typecheck` all pass
- TypeDoc `notDocumented` clean for `utilities` and `core`
- New tests assert eviction is least-recently-**used**, not oldest-inserted: a hot entry survives 300 intervening distinct strings, which is exactly what the old wipe broke

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1KGv3Mu5uJguQqEQnCgTz)_