### PR TITLE
Reuse resolved paint instead of rebuilding it every frame

### DIFF
--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -19,11 +19,17 @@ import type {
     FillRule,
     Gradient,
     GradientBounds,
+    Pattern,
     Scale,
 } from '@ripl/core';
 
 import {
+    createLRUCache,
     numberClamp,
+} from '@ripl/utilities';
+
+import type {
+    LRUCache,
 } from '@ripl/utilities';
 
 import type {
@@ -80,37 +86,36 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
     return canvasGradient;
 }
 
-// Pattern tiles are position-independent, so one `CanvasPattern` per string serves every element and frame.
-const PATTERN_CACHE_LIMIT = 256;
-const patternCache = new Map<string, CanvasPattern | null>();
+const PAINT_CACHE_LIMIT = 64;
+const TILE_CACHE_LIMIT = 64;
 
-/**
- * Materializes a `pattern(...)` paint string as a repeating `CanvasPattern`, drawing the shared
- * tile geometry into an offscreen canvas. Results (including parse failures) are cached per
- * string.
- *
- * @param ctx - The context the pattern will paint into.
- * @param value - The `pattern(...)` paint string.
- * @returns The repeating pattern, or `null` when the string or environment can't produce one.
- */
-export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): CanvasPattern | null {
-    const cached = patternCache.get(value);
+// A tile is plain pixels, independent of position and of the surface it ends up on, so one serves every context.
+const patternTileCache = createLRUCache<string, HTMLCanvasElement | null>(TILE_CACHE_LIMIT);
 
-    if (cached !== undefined) {
-        return cached;
+// `CanvasGradient`/`CanvasPattern` belong to the surface that minted them, so each context gets its own cache.
+const gradientCaches = new WeakMap<CanvasRenderingContext2D, LRUCache<string, CanvasGradient>>();
+const patternCaches = new WeakMap<CanvasRenderingContext2D, LRUCache<string, CanvasPattern | null>>();
+
+function getPaintCache<TValue>(caches: WeakMap<CanvasRenderingContext2D, LRUCache<string, TValue>>, ctx: CanvasRenderingContext2D): LRUCache<string, TValue> {
+    const existing = caches.get(ctx);
+
+    if (existing) {
+        return existing;
     }
 
-    if (patternCache.size >= PATTERN_CACHE_LIMIT) {
-        patternCache.clear();
-    }
+    const cache = createLRUCache<string, TValue>(PAINT_CACHE_LIMIT);
 
-    const pattern = parsePatternCached(value);
+    caches.set(ctx, cache);
 
-    if (!pattern) {
-        patternCache.set(value, null);
-        return null;
-    }
+    return cache;
+}
 
+// Rounded, so sub-pixel drift on an animating element doesn't miss the cache on every frame.
+function getGradientCacheKey(value: string, { x, y, width, height }: GradientBounds): string {
+    return `${value}|${x.toFixed(2)}|${y.toFixed(2)}|${width.toFixed(2)}|${height.toFixed(2)}`;
+}
+
+function renderPatternTile(pattern: Pattern): HTMLCanvasElement | null {
     const geometry = getPatternTileGeometry(pattern);
     const tile = document.createElement('canvas');
 
@@ -120,7 +125,6 @@ export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): C
     const tileContext = tile.getContext('2d');
 
     if (!tileContext) {
-        patternCache.set(value, null);
         return null;
     }
 
@@ -146,11 +150,81 @@ export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): C
         tileContext.fill();
     });
 
-    const canvasPattern = ctx.createPattern(tile, 'repeat');
+    return tile;
+}
 
-    patternCache.set(value, canvasPattern);
+function getPatternTile(value: string): HTMLCanvasElement | null {
+    if (patternTileCache.has(value)) {
+        return patternTileCache.get(value)!;
+    }
+
+    const pattern = parsePatternCached(value);
+    const tile = pattern && renderPatternTile(pattern);
+
+    patternTileCache.set(value, tile);
+
+    return tile;
+}
+
+/**
+ * Materializes a `pattern(...)` paint string as a repeating `CanvasPattern`, drawing the shared
+ * tile geometry into an offscreen canvas. The tile is cached across every context; the resulting
+ * pattern (including parse failures) is cached per context, since a `CanvasPattern` belongs to the
+ * surface that created it.
+ *
+ * @param ctx - The context the pattern will paint into.
+ * @param value - The `pattern(...)` paint string.
+ * @returns The repeating pattern, or `null` when the string or environment can't produce one.
+ */
+export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): CanvasPattern | null {
+    const cache = getPaintCache(patternCaches, ctx);
+
+    if (cache.has(value)) {
+        return cache.get(value)!;
+    }
+
+    const tile = getPatternTile(value);
+    const canvasPattern = tile && ctx.createPattern(tile, 'repeat');
+
+    cache.set(value, canvasPattern);
 
     return canvasPattern;
+}
+
+/**
+ * Resolves a CSS gradient string to a `CanvasGradient` for the given bounds, caching the result per
+ * context.
+ *
+ * The fill and stroke setters run per element per frame, so a completely static gradient would
+ * otherwise be rebuilt (and every stop color re-parsed) on every one of them. Bounds are part of the
+ * key because, unlike a pattern tile, a gradient's coordinates are resolved against the element it
+ * paints.
+ *
+ * @param ctx - The context the gradient will paint into.
+ * @param value - The CSS gradient string.
+ * @param bounds - The rectangle the gradient's coordinates resolve against.
+ * @returns The gradient, or `undefined` when the string is not a recognized gradient.
+ */
+export function resolveCanvasGradient(ctx: CanvasRenderingContext2D, value: string, bounds: GradientBounds): CanvasGradient | undefined {
+    const cache = getPaintCache(gradientCaches, ctx);
+    const key = getGradientCacheKey(value, bounds);
+    const cached = cache.get(key);
+
+    if (cached) {
+        return cached;
+    }
+
+    const gradient = parseGradientCached(value);
+
+    if (!gradient) {
+        return undefined;
+    }
+
+    const canvasGradient = toCanvasGradient(ctx, gradient, bounds);
+
+    cache.set(key, canvasGradient);
+
+    return canvasGradient;
 }
 
 /** Sets the fill style on a native canvas context, resolving gradient and pattern strings when applicable. */
@@ -165,10 +239,10 @@ export function setCanvasFill(ctx: CanvasRenderingContext2D, value: string, boun
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientCached(value);
+        const gradient = resolveCanvasGradient(ctx, value, bounds);
 
         if (gradient) {
-            ctx.fillStyle = toCanvasGradient(ctx, gradient, bounds);
+            ctx.fillStyle = gradient;
             return;
         }
     }
@@ -188,10 +262,10 @@ export function setCanvasStroke(ctx: CanvasRenderingContext2D, value: string, bo
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientCached(value);
+        const gradient = resolveCanvasGradient(ctx, value, bounds);
 
         if (gradient) {
-            ctx.strokeStyle = toCanvasGradient(ctx, gradient, bounds);
+            ctx.strokeStyle = gradient;
             return;
         }
     }

--- a/packages/canvas/test/gradient-cache.test.ts
+++ b/packages/canvas/test/gradient-cache.test.ts
@@ -1,0 +1,184 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+import {
+    resolveCanvasGradient,
+    setCanvasFill,
+    setCanvasStroke,
+    toCanvasPattern,
+} from '../src';
+
+const BOUNDS = {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+};
+
+const LINEAR = 'linear-gradient(90deg, #ff0000, #0000ff)';
+const RADIAL = 'radial-gradient(circle at 50% 50%, #ff0000, #0000ff)';
+const PATTERN = 'pattern(diagonal, #1a6, transparent, 8)';
+
+function context() {
+    return document.createElement('canvas').getContext('2d')!;
+}
+
+// `mockCanvasContext` hands every `getContext` call the same stub, so a second surface needs its own.
+function separateContext() {
+    return mockCanvasContext() as unknown as CanvasRenderingContext2D;
+}
+
+describe('Canvas gradient cache', () => {
+
+    beforeEach(() => mockCanvasContext());
+    afterEach(() => vi.restoreAllMocks());
+
+    test('Should build one native gradient for many elements sharing a static paint', () => {
+        const ctx = context();
+        const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
+
+        for (let frame = 0; frame < 10; frame++) {
+            for (let element = 0; element < 50; element++) {
+                setCanvasFill(ctx, LINEAR, BOUNDS);
+            }
+        }
+
+        expect(createLinearGradient).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should return a reference-identical gradient for the same string and bounds', () => {
+        const ctx = context();
+
+        expect(resolveCanvasGradient(ctx, LINEAR, BOUNDS)).toBe(resolveCanvasGradient(ctx, LINEAR, BOUNDS));
+    });
+
+    test('Should share one cache between fill and stroke', () => {
+        const ctx = context();
+        const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
+
+        setCanvasFill(ctx, LINEAR, BOUNDS);
+        setCanvasStroke(ctx, LINEAR, BOUNDS);
+
+        expect(createLinearGradient).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should rebuild when the bounds change', () => {
+        const ctx = context();
+        const first = resolveCanvasGradient(ctx, LINEAR, BOUNDS);
+
+        const second = resolveCanvasGradient(ctx, LINEAR, {
+            ...BOUNDS,
+            height: 250,
+        });
+
+        expect(second).not.toBe(first);
+    });
+
+    // Sub-pixel drift on an animating element would otherwise miss on every frame.
+    test('Should tolerate sub-hundredth bounds drift', () => {
+        const ctx = context();
+        const first = resolveCanvasGradient(ctx, LINEAR, BOUNDS);
+
+        const second = resolveCanvasGradient(ctx, LINEAR, {
+            ...BOUNDS,
+            width: BOUNDS.width + 0.0001,
+        });
+
+        expect(second).toBe(first);
+    });
+
+    test('Should key each gradient string separately', () => {
+        const ctx = context();
+
+        expect(resolveCanvasGradient(ctx, RADIAL, BOUNDS)).not.toBe(resolveCanvasGradient(ctx, LINEAR, BOUNDS));
+    });
+
+    test('Should return undefined for a string that is not a gradient', () => {
+        expect(resolveCanvasGradient(context(), '#ff0000', BOUNDS)).toBeUndefined();
+    });
+
+    // A CanvasGradient belongs to the surface that created it, so two surfaces must not share one.
+    test('Should not share a gradient between two contexts', () => {
+        const first = resolveCanvasGradient(separateContext(), LINEAR, BOUNDS);
+        const second = resolveCanvasGradient(separateContext(), LINEAR, BOUNDS);
+
+        expect(first).toBeDefined();
+        expect(second).not.toBe(first);
+    });
+
+    test('Should retain a recently used gradient once the per-context limit is exceeded', () => {
+        const ctx = context();
+        const first = resolveCanvasGradient(ctx, LINEAR, BOUNDS);
+
+        for (let i = 0; i < 100; i++) {
+            resolveCanvasGradient(ctx, `linear-gradient(${i}deg, #ff0000, #0000ff)`, BOUNDS);
+            resolveCanvasGradient(ctx, LINEAR, BOUNDS);
+        }
+
+        expect(resolveCanvasGradient(ctx, LINEAR, BOUNDS)).toBe(first);
+    });
+
+});
+
+describe('Canvas pattern cache', () => {
+
+    beforeEach(() => mockCanvasContext());
+    afterEach(() => vi.restoreAllMocks());
+
+    test('Should reuse one pattern per context', () => {
+        const ctx = context();
+        const createPattern = vi.spyOn(ctx, 'createPattern');
+
+        toCanvasPattern(ctx, PATTERN);
+        toCanvasPattern(ctx, PATTERN);
+
+        expect(createPattern).toHaveBeenCalledTimes(1);
+    });
+
+    // A CanvasPattern is surface-bound; the tile it is drawn from is not, so only the pattern re-mints.
+    test('Should mint a separate pattern per context from the shared tile', () => {
+        const first = separateContext();
+        const second = separateContext();
+        const firstCreate = vi.spyOn(first, 'createPattern');
+        const secondCreate = vi.spyOn(second, 'createPattern');
+
+        toCanvasPattern(first, PATTERN);
+        toCanvasPattern(second, PATTERN);
+
+        expect(firstCreate).toHaveBeenCalledTimes(1);
+        expect(secondCreate).toHaveBeenCalledTimes(1);
+        expect(firstCreate.mock.calls[0][0]).toBe(secondCreate.mock.calls[0][0]);
+    });
+
+    test('Should cache a failed parse without re-parsing', () => {
+        const ctx = context();
+        const createPattern = vi.spyOn(ctx, 'createPattern');
+
+        expect(toCanvasPattern(ctx, 'pattern(not-a-motif)')).toBeNull();
+        expect(toCanvasPattern(ctx, 'pattern(not-a-motif)')).toBeNull();
+        expect(createPattern).not.toHaveBeenCalled();
+    });
+
+    test('Should retain a recently used pattern once the per-context limit is exceeded', () => {
+        const ctx = context();
+        const first = toCanvasPattern(ctx, PATTERN);
+
+        for (let i = 1; i <= 100; i++) {
+            toCanvasPattern(ctx, `pattern(dots, red, transparent, ${i})`);
+            toCanvasPattern(ctx, PATTERN);
+        }
+
+        expect(toCanvasPattern(ctx, PATTERN)).toBe(first);
+    });
+
+});

--- a/packages/canvas/test/helpers.test.ts
+++ b/packages/canvas/test/helpers.test.ts
@@ -55,16 +55,28 @@ describe('setCanvasFill / setCanvasStroke', () => {
         expect(typeof ctx.fillStyle).toBe('object');
     });
 
-    test('memoizes gradient parsing across repeated calls', () => {
+    test('reuses the native gradient across repeated calls with the same bounds', () => {
         const ctx = context();
         const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
 
         setCanvasFill(ctx, LINEAR, BOUNDS);
         setCanvasFill(ctx, LINEAR, BOUNDS);
 
-        // Both calls build a native gradient (bounds change per frame), but parsing is cached.
-        expect(createLinearGradient).toHaveBeenCalledTimes(2);
+        expect(createLinearGradient).toHaveBeenCalledTimes(1);
         expect(typeof ctx.fillStyle).toBe('object');
+    });
+
+    test('builds a new native gradient when the bounds move', () => {
+        const ctx = context();
+        const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
+
+        setCanvasFill(ctx, LINEAR, BOUNDS);
+        setCanvasFill(ctx, LINEAR, {
+            ...BOUNDS,
+            width: 200,
+        });
+
+        expect(createLinearGradient).toHaveBeenCalledTimes(2);
     });
 
 });

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -77,6 +77,7 @@ export function measureText(value: string, options?: MeasureTextOptions): TextMe
 export abstract class Context<TElement extends Element = Element, TMeta extends Record<string, unknown> = Record<string, unknown>> extends EventBus<ContextEventMap> implements BaseState {
 
     private _groupDepthStack: number[] = [];
+    private _renderElementStack: (RenderElement | undefined)[] = [];
 
     protected states: BaseState[];
     protected currentState: BaseState;
@@ -525,7 +526,12 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
      */
     public pushGroup(group: RiplElement): void {
         this._groupDepthStack.push(this.saveDepth);
+        this._renderElementStack.push(this.renderElement);
         this.save();
+
+        // A group's paint resolves against a box, so it has to be the current element before applying it.
+        this.currentRenderElement = group as unknown as RenderElement;
+
         applyElementTransform(this, group);
         this.applyGroupPaint(group);
 
@@ -568,6 +574,8 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         while (this.saveDepth > depth) {
             this.restore();
         }
+
+        this.renderElement = this._renderElementStack.pop();
     }
 
     /** Applies a rotation transformation. */

--- a/packages/core/test/context/group-paint.test.ts
+++ b/packages/core/test/context/group-paint.test.ts
@@ -1,0 +1,136 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    createGroup,
+    createRect,
+    createScene,
+} from '../../src';
+
+import {
+    createContext,
+} from '@ripl/canvas';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+polyfillPath2D();
+
+// 90deg ramps left-to-right, so the call reads as (left, midY, right, midY) of the resolved box.
+const GRADIENT = 'linear-gradient(90deg, #ff0000, #0000ff)';
+
+describe('Group paint', () => {
+
+    let el: HTMLDivElement;
+    let canvasStub: ReturnType<typeof mockCanvasContext>;
+
+    beforeEach(() => {
+        canvasStub = mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function createGradientScene() {
+        const context = createContext(el);
+
+        const group = createGroup({
+            fill: GRADIENT,
+            children: [
+                createRect({
+                    x: 0,
+                    y: 0,
+                    width: 40,
+                    height: 50,
+                }),
+                createRect({
+                    x: 60,
+                    y: 0,
+                    width: 40,
+                    height: 50,
+                }),
+            ],
+        });
+
+        // Seeded through the constructor: a later `add` defers the graph rebuild to an animation frame.
+        const scene = createScene(context, {
+            children: [
+                // Drawn first, so it is the current render element when the group opens its boundary.
+                createRect({
+                    fill: '#ff0000',
+                    x: 0,
+                    y: 0,
+                    width: 10,
+                    height: 10,
+                }),
+                group,
+            ],
+        });
+
+        return {
+            context,
+            scene,
+        };
+    }
+
+    // Regression: the group used to resolve against whichever leaf happened to be rendered last.
+    test('Should resolve a group gradient against the group box, not the previous leaf', () => {
+        const { scene } = createGradientScene();
+
+        scene.render();
+
+        expect(canvasStub.createLinearGradient).toHaveBeenCalledTimes(1);
+        expect(canvasStub.createLinearGradient).toHaveBeenCalledWith(0, 25, 100, 25);
+    });
+
+    test('Should make the group the current render element for the duration of its boundary', () => {
+        const context = createContext(el);
+        const group = createGroup();
+
+        context.pushGroup(group);
+
+        expect(context.currentRenderElement).toBe(group);
+    });
+
+    test('Should restore the previous render element when the group boundary closes', () => {
+        const context = createContext(el);
+        const leaf = createRect({
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        });
+
+        context.currentRenderElement = leaf;
+        context.pushGroup(createGroup());
+        context.popGroup();
+
+        expect(context.currentRenderElement).toBe(leaf);
+    });
+
+    // Groups are abstract, so recording one would put a non-drawable element into the hit-test set.
+    test('Should not record the group as a rendered element', () => {
+        const context = createContext(el);
+        const group = createGroup();
+
+        context.markRenderStart();
+        context.pushGroup(group);
+        context.popGroup();
+        context.markRenderEnd();
+
+        expect(context.renderedElements).not.toContain(group);
+    });
+
+});

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -1,9 +1,12 @@
 import {
+    applyGradientStops,
     createSVGClipPathElement,
     createSVGGradientElement,
     createSVGPatternElement,
     createSVGShadowFilterElement,
     createSVGTextPathDefElement,
+    getGradientStopSignature,
+    isSameGradientBounds,
     isSupportedSVGGradient,
     resolveConicGradientFallback,
     sweepDefsCache,
@@ -68,6 +71,8 @@ import type {
     ContextOptions,
     ContextText,
     FillRule,
+    Gradient,
+    GradientBounds,
     Element as RiplElement,
     TextOptions,
 } from '@ripl/core';
@@ -221,8 +226,9 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         const bounds = getGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
         const cached = this._gradientCache.get(cacheKey);
 
-        if (cached) {
-            updateSVGGradientElement(cached.element, gradient, bounds);
+        // A linear gradient can't be updated into a radial one; the primitive itself has to change.
+        if (cached && cached.type === gradient.type) {
+            this._updateGradientEntry(cached, value, gradient, bounds);
             return `url(#${cached.gradientId})`;
         }
 
@@ -233,13 +239,35 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             return value;
         }
 
+        cached?.element.remove();
+
         this._defs.appendChild(gradientEl);
         this._gradientCache.set(cacheKey, {
             gradientId,
             element: gradientEl,
+            type: gradient.type,
+            stopSignature: getGradientStopSignature(gradient.stops),
+            appliedValue: value,
+            appliedBounds: bounds,
         });
 
         return `url(#${gradientId})`;
+    }
+
+    // Every write to a live `<defs>` paint server re-rasterizes everything painted with it, so write nothing that hasn't changed.
+    private _updateGradientEntry(entry: GradientCacheEntry, value: string, gradient: Gradient, bounds: GradientBounds): void {
+        if (entry.appliedValue !== value || !isSameGradientBounds(entry.appliedBounds, bounds)) {
+            updateSVGGradientElement(entry.element, gradient, bounds);
+            entry.appliedValue = value;
+            entry.appliedBounds = bounds;
+        }
+
+        const stopSignature = getGradientStopSignature(gradient.stops);
+
+        if (entry.stopSignature !== stopSignature) {
+            applyGradientStops(entry.element, gradient.stops);
+            entry.stopSignature = stopSignature;
+        }
     }
 
     private _resolveShadowFilter(element: SVGContextElement): string | undefined {

--- a/packages/svg/src/definitions.ts
+++ b/packages/svg/src/definitions.ts
@@ -32,6 +32,14 @@ export interface GradientCacheEntry {
     gradientId: string;
     /** The live gradient element in `<defs>`. */
     element: SVGElement;
+    /** Gradient type the live element was created for; a change to it needs a different SVG primitive. */
+    type: string;
+    /** Signature of the color stops currently in the element, so unchanged stops are not rebuilt. */
+    stopSignature: string;
+    /** The paint string whose coordinates were last written to the element. */
+    appliedValue: string;
+    /** The bounds the element's coordinates were last resolved against. */
+    appliedBounds: GradientBounds;
 }
 
 /** Cache entry for a text-path geometry definition living in `<defs>`. */
@@ -62,7 +70,17 @@ export interface ShadowCacheEntry {
     shadowElement: SVGElement;
 }
 
-function applyGradientStops(gradientEl: SVGElement, stops: GradientColorStop[]) {
+/**
+ * Rebuilds a gradient element's `<stop>` children from a parsed gradient's color stops.
+ *
+ * Mutating a live `<defs>` paint server forces the browser to re-rasterize everything painted with
+ * it, so callers should first compare {@link getGradientStopSignature} against the signature of the
+ * stops already applied and skip this entirely when it is unchanged.
+ *
+ * @param gradientEl - The live gradient element in `<defs>`.
+ * @param stops - The color stops to render.
+ */
+export function applyGradientStops(gradientEl: SVGElement, stops: GradientColorStop[]): void {
     gradientEl.replaceChildren();
 
     stops.forEach((stop) => {
@@ -71,6 +89,34 @@ function applyGradientStops(gradientEl: SVGElement, stops: GradientColorStop[]) 
         stopEl.setAttribute('stop-color', normalizeGradientColor(stop.color));
         gradientEl.appendChild(stopEl);
     });
+}
+
+/**
+ * Builds a cheap discriminant for a set of gradient color stops, used to skip rebuilding
+ * `<stop>` elements that have not changed.
+ *
+ * Colors are compared as authored rather than normalized: normalization is deterministic, so the
+ * raw string discriminates just as well without running a color parse per stop per frame.
+ *
+ * @param stops - The color stops to summarize.
+ * @returns A signature that differs whenever any stop's offset or color differs.
+ */
+export function getGradientStopSignature(stops: GradientColorStop[]): string {
+    let signature = '';
+
+    for (let i = 0; i < stops.length; i++) {
+        signature += `${stops[i].offset ?? 0}:${stops[i].color};`;
+    }
+
+    return signature;
+}
+
+/** Tests whether two gradient bounds resolve to the same rectangle. */
+export function isSameGradientBounds(left: GradientBounds, right: GradientBounds): boolean {
+    return left.x === right.x
+        && left.y === right.y
+        && left.width === right.width
+        && left.height === right.height;
 }
 
 function applyLinearGradientAttributes(element: SVGElement, gradient: Gradient, bounds: GradientBounds): void {
@@ -136,33 +182,34 @@ export function createSVGGradientElement(gradient: Gradient, gradientId: string,
     const element = factory(gradient);
 
     element.setAttribute('id', gradientId);
-
-    if (gradient.repeating) {
-        element.setAttribute('spreadMethod', 'repeat');
-    }
+    element.setAttribute('gradientUnits', 'userSpaceOnUse');
 
     updateSVGGradientElement(element, gradient, bounds);
+    applyGradientStops(element, gradient.stops);
 
     return element;
 }
 
 /**
- * Updates an existing gradient `<defs>` element in place from a parsed gradient.
+ * Updates an existing gradient `<defs>` element's coordinates in place from a parsed gradient.
  *
  * Coordinates are written in user space against the element's own bounding box rather than SVG's
  * per-node `objectBoundingBox`, so an element that paints as several paths ramps once across all of
- * them and matches what the canvas backend draws. They are rewritten every render because they move
- * with the element.
+ * them and matches what the canvas backend draws. Color stops are left alone — apply those with
+ * {@link applyGradientStops}, which callers should skip while the stops are unchanged.
  *
  * @param element - The live gradient element in `<defs>`.
  * @param gradient - The parsed gradient to render.
  * @param bounds - The rectangle the gradient's coordinates resolve against.
  */
 export function updateSVGGradientElement(element: SVGElement, gradient: Gradient, bounds: GradientBounds): void {
-    element.setAttribute('gradientUnits', 'userSpaceOnUse');
+    if (gradient.repeating) {
+        element.setAttribute('spreadMethod', 'repeat');
+    } else {
+        element.removeAttribute('spreadMethod');
+    }
 
     GRADIENT_ELEMENT_UPDATERS[gradient.type]?.(element, gradient, bounds);
-    applyGradientStops(element, gradient.stops);
 }
 
 /** Resolves a solid paint fallback for a gradient with no SVG primitive, using the color stop nearest the middle of the gradient. */

--- a/packages/svg/test/gradient-stops.test.ts
+++ b/packages/svg/test/gradient-stops.test.ts
@@ -1,0 +1,160 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import type {
+    SVGContext,
+} from '../src';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+describe('SVG gradient stop reuse', () => {
+
+    let el: HTMLDivElement;
+    let ctx: SVGContext;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+        ctx = createContext(el);
+    });
+
+    afterEach(() => {
+        ctx.destroy();
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function renderPass(body: () => void) {
+        ctx.save();
+        ctx.markRenderStart();
+        body();
+        ctx.markRenderEnd();
+        ctx.restore();
+        ctx.export();
+    }
+
+    // The surface is 0x0 under jsdom, so gradient bounds only move if a render element supplies a box.
+    function drawRect(id: string, fill: string, width = 10) {
+        ctx.currentRenderElement = {
+            id,
+            abstract: true,
+            getBoundingBox: () => ({
+                top: 0,
+                left: 0,
+                width,
+                height: 10,
+            }),
+        } as never;
+
+        ctx.fill = fill;
+
+        const path = ctx.createPath(id);
+
+        path.rect(0, 0, width, 10);
+        ctx.applyFill(path);
+    }
+
+    function getGradientElement() {
+        return ctx.element.querySelector('defs > linearGradient, defs > radialGradient')!;
+    }
+
+    function getStops() {
+        return Array.from(getGradientElement().children);
+    }
+
+    test('Should keep the same stop nodes across passes when nothing changes', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red, blue)'));
+
+        const before = getStops();
+
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red, blue)'));
+
+        const after = getStops();
+
+        expect(before).toHaveLength(2);
+        expect(after[0]).toBe(before[0]);
+        expect(after[1]).toBe(before[1]);
+    });
+
+    test('Should rebuild the stop nodes when a stop color changes', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red, blue)'));
+
+        const before = getStops();
+
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red, green)'));
+
+        const after = getStops();
+
+        expect(after[0]).not.toBe(before[0]);
+        expect(after[1].getAttribute('stop-color')).toBe('green');
+    });
+
+    test('Should rebuild the stop nodes when a stop offset changes', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red 0%, blue 100%)'));
+
+        const before = getStops();
+
+        renderPass(() => drawRect('r1', 'linear-gradient(180deg, red 20%, blue 100%)'));
+
+        expect(getStops()[0]).not.toBe(before[0]);
+        expect(getStops()[0].getAttribute('offset')).toBe('20%');
+    });
+
+    // Coordinates move with the element; the stops they ramp between do not.
+    test('Should rewrite coordinates without touching the stop nodes when the bounds move', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)', 10));
+
+        const before = getStops();
+        const beforeX2 = getGradientElement().getAttribute('x2');
+
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)', 80));
+
+        expect(getStops()[0]).toBe(before[0]);
+        expect(getGradientElement().getAttribute('x2')).not.toBe(beforeX2);
+    });
+
+    test('Should not rewrite coordinates when neither the paint nor the bounds change', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)'));
+
+        const setAttribute = vi.spyOn(getGradientElement(), 'setAttribute');
+
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)'));
+
+        expect(setAttribute).not.toHaveBeenCalled();
+    });
+
+    test('Should swap the defs primitive when the gradient type changes', () => {
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)'));
+
+        expect(ctx.element.querySelectorAll('defs > linearGradient')).toHaveLength(1);
+
+        renderPass(() => drawRect('r1', 'radial-gradient(circle at 50% 50%, red, blue)'));
+
+        expect(ctx.element.querySelectorAll('defs > linearGradient')).toHaveLength(0);
+        expect(ctx.element.querySelectorAll('defs > radialGradient')).toHaveLength(1);
+    });
+
+    test('Should drop spreadMethod when a repeating gradient becomes non-repeating', () => {
+        renderPass(() => drawRect('r1', 'repeating-linear-gradient(90deg, red, blue)'));
+
+        expect(getGradientElement().getAttribute('spreadMethod')).toBe('repeat');
+
+        renderPass(() => drawRect('r1', 'linear-gradient(90deg, red, blue)'));
+
+        expect(getGradientElement().getAttribute('spreadMethod')).toBeNull();
+    });
+
+});


### PR DESCRIPTION
Stacked on #59 — review that first; this PR's diff is only the paint-materialization commit.

This is the higher-risk bundle: three changes that each alter what reaches the screen, deliberately grouped so one careful review and one visual-regression run cover all of them.

## 1. Canvas rebuilt every `CanvasGradient` from scratch

`toCanvasGradient` allocated a fresh gradient and re-ran `parseColor` per stop on every call, and the fill/stroke setters run per element per frame — so a completely static gradient was rebuilt once per element per frame.

Now cached per context, keyed on the paint string plus bounds rounded to 0.01px so sub-pixel drift on an animating element still hits. Bounds have to be in the key: unlike a pattern tile, a gradient's coordinates resolve against the element it paints, and `CanvasContext3D.gradientBounds()` resolves a *world* box where the 2D backend resolves a local one.

Pattern caching splits along the same seam — the tile is plain pixels and is shared across contexts; the `CanvasPattern` belongs to the surface that minted it and is not. Both caches are bounded LRUs (the previous one wiped at 256).

## 2. SVG rebuilt every `<stop>` on every update

`applyGradientStops` called `replaceChildren()` and recreated every stop unconditionally from `updateSVGGradientElement`, cache hit or miss. Mutating a live `<defs>` paint server forces the browser to re-rasterize everything painted with it.

Stops and coordinates are now written only when their signature changes. Stop colours are compared as authored rather than normalized — normalization is deterministic, so the raw string discriminates just as well without a colour parse per stop per frame.

## 3. A group's gradient resolved against the wrong box

`currentRenderElement` is only ever assigned in `Element.render`, and `Group.render` doesn't go through it — so `applyGroupPaint` fired the canvas fill setter while the current element was still the previously rendered leaf.

`pushGroup` now assigns the group and `popGroup` restores the previous element. Safe: the setter only records non-abstract elements and `Group.abstract` is `true`.

Executed on `main`, a group's `linear-gradient` produced `createLinearGradient(0, 5, 10, 5)` — the previous sibling's box — instead of `(0, 25, 100, 25)`. The new test fails on `main` and passes here.

## Two more found while in here

- A gradient changing type (linear → radial) kept applying the new type's coordinates to the old primitive, because the cache reused the element regardless of tag.
- `spreadMethod` was set at creation and never cleared, so a repeating gradient stayed repeating after the paint changed.

## Verification

- `yarn test` 181 files / 2038 tests, `yarn lint`, `yarn typecheck`, TypeDoc `notDocumented` all pass
- **Visual regression: byte-identical output across all 26 charts.** The committed baselines fail on `main` in this environment (they were rendered elsewhere — the README warns about font rendering), so a baseline comparison would have proved nothing. Instead I rendered the gallery on `main` and on this branch in the same environment and diffed those: `diff -rq` reports no difference on any of the 26 charts. Baselines are untouched.
- SVG stop reuse is asserted by node **identity** across passes — the strongest available proxy for "no re-rasterization"

## Breaking

`updateSVGGradientElement` no longer applies colour stops; call `applyGradientStops` alongside it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1KGv3Mu5uJguQqEQnCgTz)_