### PR TITLE
Commit SVG synchronously and fix what the reconciler tears down

### DIFF
--- a/apps/website/src/docs/core/advanced/custom-contexts.md
+++ b/apps/website/src/docs/core/advanced/custom-contexts.md
@@ -40,9 +40,7 @@ import type {
 class MyContext extends Context {
 
     constructor(target: string | HTMLElement) {
-        super('my-context', target, {
-            buffer: false,
-        });
+        super('my-context', target);
     }
 
     // --- Abstract methods to implement ---

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -90,8 +90,6 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     /** Arbitrary metadata attached to the context. */
     public readonly meta: TMeta;
 
-    /** Whether drawing is buffered rather than committed to the surface immediately. */
-    public buffer = false;
     /**
      * Whether this context's hit testing natively accounts for element and ancestor group
      * transforms (as SVG does, via the DOM). When `false` (e.g. canvas), callers map the hit

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -135,8 +135,6 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
             throw new Error('Scene requires a Context instance or factory.createContext to be set. Use @ripl/web or call factory.set() with a createContext implementation.');
         }
 
-        context.buffer = false;
-
         const font = !typeIsNil(globalThis.HTMLElement) && context.element instanceof globalThis.HTMLElement
             ? factory.getComputedStyle(context.element).font
             : undefined;

--- a/packages/dom/src/vdom.ts
+++ b/packages/dom/src/vdom.ts
@@ -165,7 +165,8 @@ function reconcileChildren<TElement = unknown>(
             }
         }
 
-        if (childVNode.children.length > 0) {
+        // Also when the vnode has no children but the node does: that pass is what empties it.
+        if (childVNode.children.length > 0 || domChild.children.length > 0) {
             reconcileChildren(domChild, childVNode, domCache, options, state);
         }
     }

--- a/packages/dom/src/vdom.ts
+++ b/packages/dom/src/vdom.ts
@@ -71,6 +71,25 @@ export function ensureGroupPath<TElement = unknown>(root: VNode<TElement>, group
     return parent;
 }
 
+/**
+ * Drops cache entries whose node is no longer under the reconciled root.
+ *
+ * Removing a node only ever deletes its own entry, so a removed group used to leave every
+ * descendant's entry behind holding a detached node. Sweeping after the tree is reconciled catches
+ * those without ordering hazards: a node reparented out of a removed subtree has already been
+ * re-attached by the time this runs, so it survives.
+ *
+ * Containment is tested against the root rather than the document, so a surface that has not been
+ * mounted still reconciles normally.
+ */
+function evictDetachedNodes(root: Element, domCache: Map<string, Element>): void {
+    domCache.forEach((node, id) => {
+        if (!root.contains(node)) {
+            domCache.delete(id);
+        }
+    });
+}
+
 function isExcluded(element: Element, selectors: string[]): boolean {
     for (let i = 0; i < selectors.length; i++) {
         if (element.matches(selectors[i])) {
@@ -81,12 +100,12 @@ function isExcluded(element: Element, selectors: string[]): boolean {
     return false;
 }
 
-/** Reconciles a virtual node tree against the live DOM, creating, updating, reordering, and removing child elements as needed. */
-export function reconcileNode<TElement = unknown>(
+function reconcileChildren<TElement = unknown>(
     domParent: Element,
     vnode: VNode<TElement>,
     domCache: Map<string, Element>,
-    options: ReconcilerOptions<TElement>
+    options: ReconcilerOptions<TElement>,
+    state: { removed: boolean }
 ): void {
     const {
         createElement,
@@ -112,7 +131,9 @@ export function reconcileNode<TElement = unknown>(
             existingChildren.set(childId, child);
         } else {
             child.remove();
-            if (childId) {
+            state.removed = true;
+
+            if (childId && domCache.get(childId) === child) {
                 domCache.delete(childId);
             }
         }
@@ -145,8 +166,36 @@ export function reconcileNode<TElement = unknown>(
         }
 
         if (childVNode.children.length > 0) {
-            reconcileNode(domChild, childVNode, domCache, options);
+            reconcileChildren(domChild, childVNode, domCache, options, state);
         }
+    }
+}
+
+/**
+ * Reconciles a virtual node tree against the live DOM, creating, updating, reordering, and removing
+ * child elements as needed.
+ *
+ * @param domParent - The live element whose children are reconciled.
+ * @param vnode - The virtual node describing the desired children.
+ * @param domCache - Node cache keyed by reconciliation id, reused across passes so a node that moves
+ * between parents is re-attached rather than re-created. Entries left detached by this pass are
+ * swept before returning.
+ * @param options - Element lifecycle callbacks and filtering.
+ */
+export function reconcileNode<TElement = unknown>(
+    domParent: Element,
+    vnode: VNode<TElement>,
+    domCache: Map<string, Element>,
+    options: ReconcilerOptions<TElement>
+): void {
+    const state = {
+        removed: false,
+    };
+
+    reconcileChildren(domParent, vnode, domCache, options, state);
+
+    if (state.removed) {
+        evictDetachedNodes(domParent, domCache);
     }
 }
 

--- a/packages/dom/test/reconcile.test.ts
+++ b/packages/dom/test/reconcile.test.ts
@@ -638,3 +638,98 @@ describe('VDOM', () => {
     });
 
 });
+
+describe('reconcileNode - cache eviction', () => {
+
+    function group(id: string, children: VNode<TestElement>[]) {
+        return createVNode<TestElement>(id, 'div', children);
+    }
+
+    function leaf(id: string) {
+        return createVNode<TestElement>(id, 'span', [], {
+            tag: 'span',
+            attributes: {},
+        });
+    }
+
+    // A removed group used to leave its descendants' entries in the cache, pinning detached nodes.
+    test('Should evict every descendant of a removed subtree', () => {
+        const parent = createDOMElement('div');
+        const cache = new Map<string, Element>();
+        const options = createTestOptions();
+
+        reconcileNode(parent, group('root', [
+            group('outer', [
+                leaf('a'),
+                group('inner', [leaf('b')]),
+            ]),
+        ]), cache, options);
+
+        expect(cache.size).toBe(4);
+
+        reconcileNode(parent, group('root', []), cache, options);
+
+        expect(cache.size).toBe(0);
+    });
+
+    test('Should leave a surviving sibling subtree cached', () => {
+        const parent = createDOMElement('div');
+        const cache = new Map<string, Element>();
+        const options = createTestOptions();
+
+        reconcileNode(parent, group('root', [
+            group('doomed', [leaf('a')]),
+            group('kept', [leaf('b')]),
+        ]), cache, options);
+
+        reconcileNode(parent, group('root', [
+            group('kept', [leaf('b')]),
+        ]), cache, options);
+
+        expect(cache.has('doomed')).toBe(false);
+        expect(cache.has('a')).toBe(false);
+        expect(cache.has('kept')).toBe(true);
+        expect(cache.has('b')).toBe(true);
+    });
+
+    // The cache doubles as the reparenting mechanism, so an id that moved must keep its node.
+    test('Should keep a node that moved out of a removed subtree', () => {
+        const parent = createDOMElement('div');
+        const cache = new Map<string, Element>();
+        const options = createTestOptions();
+
+        reconcileNode(parent, group('root', [
+            group('doomed', [leaf('mover')]),
+        ]), cache, options);
+
+        const moved = cache.get('mover');
+
+        reconcileNode(parent, group('root', [
+            group('kept', [leaf('mover')]),
+        ]), cache, options);
+
+        expect(cache.get('mover')).toBe(moved);
+        expect(cache.has('doomed')).toBe(false);
+    });
+
+    test('Should return the cache to its baseline size across repeated add and remove cycles', () => {
+        const parent = createDOMElement('div');
+        const cache = new Map<string, Element>();
+        const options = createTestOptions();
+
+        const populated = group('root', [
+            group('outer', [
+                leaf('a'),
+                group('inner', [leaf('b')]),
+            ]),
+        ]);
+
+        for (let i = 0; i < 50; i++) {
+            reconcileNode(parent, populated, cache, options);
+            reconcileNode(parent, group('root', []), cache, options);
+        }
+
+        expect(cache.size).toBe(0);
+    });
+
+});

--- a/packages/dom/test/reconcile.test.ts
+++ b/packages/dom/test/reconcile.test.ts
@@ -732,4 +732,25 @@ describe('reconcileNode - cache eviction', () => {
         expect(cache.size).toBe(0);
     });
 
+    // Two independent audits found this: the pass that empties a group used to skip its own subtree.
+    test('Should remove every child of a group that empties', () => {
+        const parent = createDOMElement('div');
+        const cache = new Map<string, Element>();
+        const options = createTestOptions();
+
+        reconcileNode(parent, group('root', [
+            group('outer', [leaf('a'), leaf('b')]),
+        ]), cache, options);
+
+        const outer = parent.children[0];
+
+        expect(outer.children).toHaveLength(2);
+
+        reconcileNode(parent, group('root', [group('outer', [])]), cache, options);
+
+        expect(outer.children).toHaveLength(0);
+        expect(cache.has('a')).toBe(false);
+        expect(cache.has('b')).toBe(false);
+    });
+
 });

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -51,7 +51,6 @@ import type {
 } from './types';
 
 import {
-    createFrameBuffer,
     getGradientBounds,
     isGradientString,
     isPatternString,
@@ -86,10 +85,6 @@ import {
     stringUniqueId,
 } from '@ripl/utilities';
 
-import type {
-    AnyFunction,
-} from '@ripl/utilities';
-
 type SVGVNode = VNode<SVGContextElement>;
 
 /** SVG rendering context implementation, mapping the unified API to SVG DOM elements via virtual-DOM reconciliation. */
@@ -98,7 +93,6 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     private _vtree: SVGVNode;
     private _domCache: Map<string, Element>;
     private _reconcilerOptions: ReconcilerOptions<SVGContextElement>;
-    private _requestFrame: (callback: AnyFunction) => void;
     private _defs: SVGDefsElement;
     private _gradientCache: Map<string, GradientCacheEntry>;
     private _patternCache: Map<string, PatternCacheEntry>;
@@ -125,7 +119,6 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
 
         super('svg', target, svg, options);
 
-        this.buffer = true;
         // SVG hit testing runs against live DOM geometry, which already composes ancestor `<g>` transforms.
         this.hitTestHonorsTransform = true;
         this._vtree = {
@@ -162,7 +155,6 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         this._currentClipId = undefined;
         this._defs = createSVGElement('defs');
         this.element.appendChild(this._defs);
-        this._requestFrame = createFrameBuffer();
 
         this.init();
     }
@@ -340,8 +332,17 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         }
     }
 
+    // The reconciler already holds every node it created, so prefer it over a document-scoped id lookup.
+    private _resolveHitNode(id: string): Element | null {
+        const cached = this._domCache.get(id);
+
+        return cached && this.element.contains(cached)
+            ? cached
+            : this.element.getElementById(id);
+    }
+
     private _isPointIn(method: 'stroke' | 'fill', path: SVGPath, x: number, y: number) {
-        const element = this.element.getElementById(path.id);
+        const element = this._resolveHitNode(path.id);
         const point = this.element.createSVGPoint();
 
         point.x = x;
@@ -404,18 +405,11 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             return;
         }
 
-        if (this.buffer) {
-            this._requestFrame(() => this._commit());
-        } else {
-            this._commit();
-        }
+        this._commit();
     }
 
     /** Captures a snapshot of the SVG surface and returns format-specific exporters (see {@link ContextExport}). */
     public export(): ContextExport {
-        // Buffered rendering defers to rAF, so commit synchronously for markup to reflect the latest scene.
-        this._commit();
-
         const markup = new XMLSerializer().serializeToString(this.element);
         const width = this.width;
         const height = this.height;

--- a/packages/svg/test/attr-removal.test.ts
+++ b/packages/svg/test/attr-removal.test.ts
@@ -44,8 +44,6 @@ describe('SVG attribute/style removal', () => {
         ctx.markRenderEnd();
         ctx.restore();
 
-        // Rendering is buffered to rAF; export forces a synchronous reconcile.
-        ctx.export();
     }
 
     function drawRect(id: string) {

--- a/packages/svg/test/commit.test.ts
+++ b/packages/svg/test/commit.test.ts
@@ -1,0 +1,138 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import type {
+    SVGContext,
+} from '../src';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+describe('SVG commit', () => {
+
+    let el: HTMLDivElement;
+    let ctx: SVGContext;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+        ctx = createContext(el);
+    });
+
+    afterEach(() => {
+        ctx.destroy();
+        el.remove();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    function renderPass(body: () => void) {
+        ctx.save();
+        ctx.markRenderStart();
+        body();
+        ctx.markRenderEnd();
+        ctx.restore();
+    }
+
+    function drawRect(id: string) {
+        ctx.fill = '#ff0000';
+
+        const path = ctx.createPath(id);
+
+        path.rect(0, 0, 10, 10);
+        ctx.applyFill(path);
+    }
+
+    // Rendering used to defer to an animation frame, so nothing downstream could read the DOM it just drew.
+    test('Should commit to the DOM by the time the render pass ends', () => {
+        renderPass(() => drawRect('r1'));
+
+        expect(ctx.element.querySelector('#r1')).not.toBeNull();
+    });
+
+    test('Should reflect the latest pass in the exported markup', () => {
+        renderPass(() => drawRect('r1'));
+        renderPass(() => drawRect('r2'));
+
+        const markup = ctx.export().toString();
+
+        expect(markup).toContain('id="r2"');
+        expect(markup).not.toContain('id="r1"');
+    });
+
+    test('Should commit once per outermost pass, not per nested depth', () => {
+        renderPass(() => {
+            ctx.markRenderStart();
+            drawRect('inner');
+            ctx.markRenderEnd();
+
+            expect(ctx.element.querySelector('#inner')).toBeNull();
+        });
+
+        expect(ctx.element.querySelector('#inner')).not.toBeNull();
+    });
+
+    // jsdom implements neither `SVGGeometryElement` nor the geometry methods the real hit test calls.
+    function makeHitTestable(id: string) {
+        const node = ctx.element.querySelector(`#${id}`)!;
+        const isPointInFill = vi.fn(() => true);
+
+        vi.stubGlobal('SVGGeometryElement', node.constructor);
+        Object.assign(node, {
+            isPointInFill,
+        });
+
+        ctx.element.createSVGPoint = vi.fn(() => ({
+            x: 0,
+            y: 0,
+        })) as never;
+
+        return isPointInFill;
+    }
+
+    test('Should hit test against the node committed in the same pass', () => {
+        renderPass(() => drawRect('hit'));
+
+        const isPointInFill = makeHitTestable('hit');
+
+        expect(ctx.isPointInPath(ctx.createPath('hit'), 5, 5)).toBe(true);
+        expect(isPointInFill).toHaveBeenCalled();
+    });
+
+    // The reconciler already holds the node, so the hover path shouldn't re-search the document for it.
+    test('Should resolve the hit node from the reconciler cache', () => {
+        renderPass(() => drawRect('hit'));
+
+        makeHitTestable('hit');
+
+        const getElementById = vi.spyOn(ctx.element, 'getElementById');
+
+        ctx.isPointInPath(ctx.createPath('hit'), 5, 5);
+
+        expect(getElementById).not.toHaveBeenCalled();
+    });
+
+    test('Should fall back to a document lookup for a node the reconciler never created', () => {
+        renderPass(() => drawRect('hit'));
+
+        makeHitTestable('hit');
+
+        const getElementById = vi.spyOn(ctx.element, 'getElementById').mockReturnValue(null);
+
+        expect(ctx.isPointInPath(ctx.createPath('unknown'), 5, 5)).toBe(false);
+        expect(getElementById).toHaveBeenCalledWith('unknown');
+    });
+
+});

--- a/packages/svg/test/defs-lifecycle.test.ts
+++ b/packages/svg/test/defs-lifecycle.test.ts
@@ -58,7 +58,6 @@ describe('SVG defs lifecycle', () => {
         body();
         ctx.markRenderEnd();
         ctx.restore();
-        ctx.export();
     }
 
     function drawRect(id: string) {

--- a/packages/svg/test/gradient-units.test.ts
+++ b/packages/svg/test/gradient-units.test.ts
@@ -63,8 +63,6 @@ describe('SVG gradient units', () => {
         ctx.markRenderEnd();
         ctx.restore();
 
-        // Rendering is buffered to rAF; export forces a synchronous reconcile.
-        ctx.export();
     }
 
     function gradients() {
@@ -163,7 +161,6 @@ describe('SVG gradient units', () => {
         ctx.applyFill(path);
         ctx.markRenderEnd();
         ctx.restore();
-        ctx.export();
 
         const [gradient] = gradients();
 

--- a/packages/svg/test/index.test.ts
+++ b/packages/svg/test/index.test.ts
@@ -592,9 +592,6 @@ describe('SVG', () => {
             // The leaf must NOT carry the group transform (it is supplied once by the <g>).
             expect(leaf.definition.attributes.transform).toBeUndefined();
 
-            // Force a synchronous reconcile and inspect the DOM.
-            ctx.export();
-
             const groupEl = ctx.element.querySelector('g');
             expect(groupEl).not.toBeNull();
             expect(groupEl?.getAttribute('id')).toBe(group.id);

--- a/packages/svg/test/pattern-defs.test.ts
+++ b/packages/svg/test/pattern-defs.test.ts
@@ -55,7 +55,6 @@ describe('SVG pattern defs', () => {
         body();
         ctx.markRenderEnd();
         ctx.restore();
-        ctx.export();
     }
 
     function drawRect(id: string) {

--- a/packages/svg/test/polyline-segments.test.ts
+++ b/packages/svg/test/polyline-segments.test.ts
@@ -70,8 +70,6 @@ describe('Segmented polylines on SVG', () => {
         ctx.markRenderEnd();
         ctx.restore();
 
-        // Rendering is buffered to rAF; export forces a synchronous reconcile.
-        ctx.export();
     }
 
     function paths() {

--- a/packages/svg/test/reorder.test.ts
+++ b/packages/svg/test/reorder.test.ts
@@ -50,7 +50,6 @@ describe('SVG element reordering', () => {
 
         ctx.markRenderEnd();
         ctx.restore();
-        ctx.export();
     }
 
     function getPathNodes() {


### PR DESCRIPTION
The second higher-risk bundle: everything that touches *when* the SVG DOM commits and *what* the reconciler tears down. Grouped because the commit path is delicate (see `da90765 fix(svg): sweep defs after the reconcile, not before it`) and one careful review beats three casual ones.

## 1. `Context.buffer` is removed

Answering the question directly: **it wasn't necessary.** `Scene`'s constructor did `context.buffer = false` unconditionally, so SVG's buffered commit has been dead for every scene, renderer and chart pipeline since `Scene` was written. It stayed live only for a raw `SVGContext` — the docs demos, `export()`, and the SVG unit tests — where it cost a frame of latency, left synchronous hit tests reading a stale DOM, and forced `export()` to reconcile in order to see the scene it had just drawn.

Removed rather than defaulted off: nothing set it, and a `Scene` reaching into a context's public config to disable a feature isn't a contract worth keeping.

**The evidence that synchronous commit is correct:** the whole SVG suite passes with the `export()` flushes deleted from six test files.

## 2. Hit testing resolves through the reconciler cache

`_isPointIn` did `this.element.getElementById(path.id)`. It now prefers the node the reconciler already holds, falling back to the document lookup — so it survives a pending commit and can't collide with another context's ids on the same page. Containment is tested against the surface, not the document, so an unmounted context still works.

## 3. The reconciler leaked detached nodes

Removing a node only ever deleted *its own* cache entry, so a removed group left every descendant's entry behind holding a detached node.

I first tried evicting the subtree at removal time, but that breaks reparenting: a node moving out of a group removed in the same pass got evicted before it was re-registered. Entries are now swept *after* the tree is reconciled, which is ordering-independent and lets the moved node keep its identity.

I also dropped `isConnected` as the predicate in favour of containment within the reconciled root — `isConnected` is false for every node when the surface isn't mounted, which would have wiped the whole cache on every removal for an offscreen context.

## 4. A group that empties kept its children

`reconcileNode` skipped recursion when the vnode had no children — but that's precisely the pass that empties a group, so an emptied `<g>` kept last frame's children painted and hit-testable indefinitely. Reachable whenever a series is toggled off or a filter matches nothing.

Not in the original report: **found independently by two of the context audits**, both with a repro. It's a one-line fix in the file this PR already restructures, so it's here rather than in its own branch.

## Verification

- `yarn test` 178 files / 2005 tests, `yarn lint`, `yarn typecheck`, TypeDoc `notDocumented` all pass
- New `packages/svg/test/commit.test.ts` — commit-by-end-of-pass, one commit per outermost pass, export freshness, and all three hit-test resolution paths
- `packages/dom/test/reconcile.test.ts` extended: descendant eviction, surviving siblings, reparenting out of a removed subtree, cache returning to baseline over 50 add/remove cycles, and the emptied-group case. The last one fails on `main`.
- Visual regression: rendered the gallery on `main` and on this branch in the same environment — byte-identical across all 26 charts

## On the heap measurement

The plan asked me to reproduce the reported 27.7 → 30.3 MB growth over 600 scrub events and show it flat. **I did not reproduce that measurement** — it needs a real browser heap profile, not jsdom. What I can assert is the mechanism and its removal: `domCache.size` returns to baseline across repeated add/remove cycles, which it did not before.

## Breaking

`Context.buffer` is removed. SVG always commits at the end of the outermost render pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1KGv3Mu5uJguQqEQnCgTz)_