### PR TITLE
Build demo elements once instead of rebuilding them per redraw

### DIFF
--- a/apps/website/src/.vitepress/compositions/example.ts
+++ b/apps/website/src/.vitepress/compositions/example.ts
@@ -39,6 +39,20 @@ type AdvancedExampleState = {
     renderer: Renderer;
 };
 
+/**
+ * Builds a demo's elements once, on first render.
+ *
+ * A demo that rebuilds its elements every redraw gives each one a fresh id, so every id-keyed
+ * cache misses by construction and the SVG reconciler tears down and recreates the whole tree.
+ * Building at module scope instead would run during the static build, where the browser platform
+ * bindings are not installed yet, so construction is deferred to the first call.
+ */
+export function useDemoElements<TElements>(build: () => TElements): () => TElements {
+    let elements: TElements | undefined;
+
+    return () => elements ??= build();
+}
+
 export function useRiplExample(onContextChanged?: (context: Context) => void, bindDevtools: boolean = true) {
     const context = shallowRef<Context>();
 

--- a/apps/website/src/docs/api/typedoc-sidebar.json
+++ b/apps/website/src/docs/api/typedoc-sidebar.json
@@ -396,10 +396,6 @@
           {
             "text": "AbstractConstructor",
             "link": "/docs/api/@ripl/canvas/type-aliases/AbstractConstructor.md"
-          },
-          {
-            "text": "GradientBounds",
-            "link": "/docs/api/@ripl/canvas/type-aliases/GradientBounds.md"
           }
         ]
       },
@@ -438,10 +434,6 @@
           {
             "text": "createContext",
             "link": "/docs/api/@ripl/canvas/functions/createContext.md"
-          },
-          {
-            "text": "getCanvasGradientBounds",
-            "link": "/docs/api/@ripl/canvas/functions/getCanvasGradientBounds.md"
           },
           {
             "text": "renderTextAlongPath",
@@ -947,6 +939,14 @@
             "link": "/docs/api/@ripl/charts/interfaces/LineChartSeriesOptions.md"
           },
           {
+            "text": "LineStyleSegment",
+            "link": "/docs/api/@ripl/charts/interfaces/LineStyleSegment.md"
+          },
+          {
+            "text": "LineStyleSegments",
+            "link": "/docs/api/@ripl/charts/interfaces/LineStyleSegments.md"
+          },
+          {
             "text": "PackedCircleChartEventMap",
             "link": "/docs/api/@ripl/charts/interfaces/PackedCircleChartEventMap.md"
           },
@@ -1049,6 +1049,10 @@
           {
             "text": "ResolvedAnimation",
             "link": "/docs/api/@ripl/charts/interfaces/ResolvedAnimation.md"
+          },
+          {
+            "text": "ResolvedLineStyle",
+            "link": "/docs/api/@ripl/charts/interfaces/ResolvedLineStyle.md"
           },
           {
             "text": "RibbonState",
@@ -1299,6 +1303,14 @@
           {
             "text": "LineStyle",
             "link": "/docs/api/@ripl/charts/type-aliases/LineStyle.md"
+          },
+          {
+            "text": "LineStyleBound",
+            "link": "/docs/api/@ripl/charts/type-aliases/LineStyleBound.md"
+          },
+          {
+            "text": "LineStyleInput",
+            "link": "/docs/api/@ripl/charts/type-aliases/LineStyleInput.md"
           },
           {
             "text": "NumericAccessor",
@@ -1695,6 +1707,10 @@
           {
             "text": "resolveLineDash",
             "link": "/docs/api/@ripl/charts/functions/resolveLineDash.md"
+          },
+          {
+            "text": "resolveLineStyle",
+            "link": "/docs/api/@ripl/charts/functions/resolveLineStyle.md"
           },
           {
             "text": "resolveRadialLabel",
@@ -2200,6 +2216,10 @@
             "link": "/docs/api/@ripl/core/interfaces/PolygonState.md"
           },
           {
+            "text": "PolylineSegment",
+            "link": "/docs/api/@ripl/core/interfaces/PolylineSegment.md"
+          },
+          {
             "text": "PolylineState",
             "link": "/docs/api/@ripl/core/interfaces/PolylineState.md"
           },
@@ -2408,6 +2428,10 @@
           {
             "text": "Gradient",
             "link": "/docs/api/@ripl/core/type-aliases/Gradient.md"
+          },
+          {
+            "text": "GradientBounds",
+            "link": "/docs/api/@ripl/core/type-aliases/GradientBounds.md"
           },
           {
             "text": "GradientType",
@@ -2962,6 +2986,10 @@
             "link": "/docs/api/@ripl/core/functions/getEuclideanDistance.md"
           },
           {
+            "text": "getGradientBounds",
+            "link": "/docs/api/@ripl/core/functions/getGradientBounds.md"
+          },
+          {
             "text": "getLinearScaleMethod",
             "link": "/docs/api/@ripl/core/functions/getLinearScaleMethod.md"
           },
@@ -3096,6 +3124,10 @@
           {
             "text": "normalizeBorderRadius",
             "link": "/docs/api/@ripl/core/functions/normalizeBorderRadius.md"
+          },
+          {
+            "text": "normalizePolylineRuns",
+            "link": "/docs/api/@ripl/core/functions/normalizePolylineRuns.md"
           },
           {
             "text": "padDomain",

--- a/apps/website/src/docs/core/advanced/clip-paths.md
+++ b/apps/website/src/docs/core/advanced/clip-paths.md
@@ -133,6 +133,7 @@ Clip paths work identically with both the **Canvas** and **SVG** contexts:
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -155,7 +156,74 @@ import {
 const clipRadiusPct = ref(100);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const clipCircle = createCircle({
+        clip: true,
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    });
+
+    const backdrop = createRect({
+        fill: '#3a86ff',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const hatching = Array.from({ length: 20 }, () => createLine({
+        stroke: '#ffffff44',
+        lineWidth: 2,
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+    }));
+
+    const clippedGroup = createGroup({
+        children: [clipCircle, backdrop, ...hatching],
+    });
+
+    const outline = createCircle({
+        stroke: '#1a56db',
+        lineWidth: 3,
+        autoFill: false,
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    return {
+        clipCircle,
+        backdrop,
+        hatching,
+        clippedGroup,
+        outline,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        clipCircle,
+        backdrop,
+        hatching,
+        clippedGroup,
+        outline,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const cx = w / 2;
@@ -163,41 +231,36 @@ function renderDemo(context: Context) {
     const maxR = Math.min(w, h) / 3;
     const r = maxR * (clipRadiusPct.value / 100);
 
+    clipCircle.cx = cx;
+    clipCircle.cy = cy;
+    clipCircle.radius = r;
+
+    backdrop.x = cx - maxR;
+    backdrop.y = cy - maxR;
+    backdrop.width = maxR * 2;
+    backdrop.height = maxR * 2;
+
+    hatching.forEach((line, index) => {
+        const offset = (index - 10) * (maxR / 5);
+
+        line.x1 = cx - maxR + offset;
+        line.y1 = cy - maxR;
+        line.x2 = cx + maxR + offset;
+        line.y2 = cy + maxR;
+    });
+
+    outline.cx = cx;
+    outline.cy = cy;
+    outline.radius = r;
+
+    label.x = cx;
+    label.y = cy + maxR + 24;
+    label.content = `Clip radius: ${Math.round(r)}px`;
+
     context.batch(() => {
-        const clippedGroup = createGroup({
-            children: [
-                createCircle({ clip: true, cx, cy, radius: r }),
-                createRect({
-                    fill: '#3a86ff',
-                    x: cx - maxR, y: cy - maxR,
-                    width: maxR * 2, height: maxR * 2,
-                }),
-                ...Array.from({ length: 20 }, (_, i) => {
-                    const offset = (i - 10) * (maxR / 5);
-                    return createLine({
-                        stroke: '#ffffff44',
-                        lineWidth: 2,
-                        x1: cx - maxR + offset, y1: cy - maxR,
-                        x2: cx + maxR + offset, y2: cy + maxR,
-                    });
-                }),
-            ],
-        });
-
         clippedGroup.render(context);
-
-        createCircle({
-            stroke: '#1a56db',
-            lineWidth: 3,
-            cx, cy, radius: r,
-            autoFill: false,
-        }).render(context);
-
-        createText({
-            x: cx, y: cy + maxR + 24,
-            content: `Clip radius: ${Math.round(r)}px`,
-            fill: '#666', textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
+        outline.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/advanced/color.md
+++ b/apps/website/src/docs/core/advanced/color.md
@@ -49,6 +49,7 @@ setColorAlpha('#3a86ff', 0.5); // 'rgba(58, 134, 255, 0.5)'
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -76,47 +77,86 @@ const pickedColor = ref('#3a86ff');
 const alpha = ref(100);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const backdrop = createRect({
+        fill: '#e9ecef',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const swatch = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 12,
+    });
+
+    const readouts = Array.from({ length: 4 }, () => createText({
+        fill: '#333',
+        x: 0,
+        y: 0,
+        content: '',
+        font: '13px monospace',
+        textBaseline: 'middle',
+    }));
+
+    return {
+        backdrop,
+        swatch,
+        readouts,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        backdrop,
+        swatch,
+        readouts,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
 
     const color = setColorAlpha(pickedColor.value, alpha.value / 100);
     const rgba = parseColor(color);
 
+    const swatchSize = Math.min(w * 0.25, h * 0.6);
+
+    backdrop.width = w;
+    backdrop.height = h;
+
+    swatch.fill = color;
+    swatch.x = w * 0.08;
+    swatch.y = h / 2 - swatchSize / 2;
+    swatch.width = swatchSize;
+    swatch.height = swatchSize;
+
+    const lines = rgba
+        ? [
+            `RGBA: ${rgba.join(', ')}`,
+            `HEX: ${serializeHEX(...rgba)}`,
+            `RGB: ${serializeRGBA(...rgba)}`,
+            `HSL: ${serializeHSL(...rgba)}`,
+        ]
+        : [];
+
+    const startX = w * 0.08 + swatchSize + 24;
+    const startY = h / 2 - (readouts.length - 1) * 12;
+
+    readouts.forEach((readout, index) => {
+        readout.x = startX;
+        readout.y = startY + index * 24;
+        readout.content = lines[index] ?? '';
+    });
+
     context.batch(() => {
-        const swatchSize = Math.min(w * 0.25, h * 0.6);
-
-        createRect({
-            fill: '#e9ecef',
-            x: 0, y: 0, width: w, height: h,
-        }).render(context);
-
-        createRect({
-            fill: color,
-            x: w * 0.08, y: h / 2 - swatchSize / 2,
-            width: swatchSize, height: swatchSize,
-            borderRadius: 12,
-        }).render(context);
-
-        if (rgba) {
-            const lines = [
-                `RGBA: ${rgba.join(', ')}`,
-                `HEX: ${serializeHEX(...rgba)}`,
-                `RGB: ${serializeRGBA(...rgba)}`,
-                `HSL: ${serializeHSL(...rgba)}`,
-            ];
-
-            const startX = w * 0.08 + swatchSize + 24;
-            const startY = h / 2 - (lines.length - 1) * 12;
-
-            lines.forEach((line, i) => {
-                createText({
-                    fill: '#333', x: startX, y: startY + i * 24,
-                    content: line, font: '13px monospace',
-                    textBaseline: 'middle',
-                }).render(context);
-            });
-        }
+        backdrop.render(context);
+        swatch.render(context);
+        readouts.forEach(readout => readout.render(context));
     });
 }
 

--- a/apps/website/src/docs/core/advanced/custom-elements.md
+++ b/apps/website/src/docs/core/advanced/custom-elements.md
@@ -273,6 +273,7 @@ await renderer.transition(star, {
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -337,25 +338,55 @@ const starPoints = ref(5);
 const innerPct = ref(40);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const star = new Star({
+        fill: '#ff006e',
+        cx: 0,
+        cy: 0,
+        outerRadius: 0,
+        innerRadius: 0,
+        points: 5,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        star,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        star,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const r = Math.min(w, h) / 4;
 
-    context.batch(() => {
-        new Star({
-            fill: '#ff006e',
-            cx: w / 2, cy: h / 2,
-            outerRadius: r,
-            innerRadius: r * (innerPct.value / 100),
-            points: starPoints.value,
-        }).render(context);
+    star.cx = w / 2;
+    star.cy = h / 2;
+    star.outerRadius = r;
+    star.innerRadius = r * (innerPct.value / 100);
+    star.points = starPoints.value;
 
-        createText({
-            x: w / 2, y: h / 2 + r + 24,
-            content: `${starPoints.value} points  inner: ${innerPct.value}%`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + r + 24;
+    label.content = `${starPoints.value} points  inner: ${innerPct.value}%`;
+
+    context.batch(() => {
+        star.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/advanced/gradients.md
+++ b/apps/website/src/docs/core/advanced/gradients.md
@@ -173,6 +173,7 @@ await renderer.transition(rect, {
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -193,48 +194,115 @@ import {
 const angleDeg = ref(135);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const linear = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    });
+
+    const radial = createCircle({
+        fill: 'radial-gradient(circle, #ff006e, #fb5607)',
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    });
+
+    const hardStops = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    });
+
+    const linearLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    const radialLabel = createText({
+        x: 0,
+        y: 0,
+        content: 'Radial',
+        fill: '#666',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    const hardStopsLabel = createText({
+        x: 0,
+        y: 0,
+        content: 'Hard Stops',
+        fill: '#666',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    return {
+        linear,
+        radial,
+        hardStops,
+        linearLabel,
+        radialLabel,
+        hardStopsLabel,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        linear,
+        radial,
+        hardStops,
+        linearLabel,
+        radialLabel,
+        hardStopsLabel,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const size = Math.min(w, h) / 3;
 
+    linear.fill = `linear-gradient(${angleDeg.value}deg, #3a86ff, #8338ec)`;
+    linear.x = w * 0.08;
+    linear.y = h / 2 - size / 2;
+    linear.width = size * 1.2;
+    linear.height = size;
+
+    linearLabel.x = w * 0.08 + size * 0.6;
+    linearLabel.y = h / 2 + size / 2 + 20;
+    linearLabel.content = `Linear ${angleDeg.value}°`;
+
+    radial.cx = w * 0.55;
+    radial.cy = h / 2;
+    radial.radius = size / 2;
+
+    radialLabel.x = w * 0.55;
+    radialLabel.y = h / 2 + size / 2 + 20;
+
+    hardStops.fill = `linear-gradient(${angleDeg.value}deg, #3a86ff 0%, #3a86ff 33%, #ff006e 33%, #ff006e 66%, #8338ec 66%, #8338ec 100%)`;
+    hardStops.x = w * 0.72;
+    hardStops.y = h / 2 - size / 2;
+    hardStops.width = size * 1.2;
+    hardStops.height = size;
+
+    hardStopsLabel.x = w * 0.72 + size * 0.6;
+    hardStopsLabel.y = h / 2 + size / 2 + 20;
+
     context.batch(() => {
-        createRect({
-            fill: `linear-gradient(${angleDeg.value}deg, #3a86ff, #8338ec)`,
-            x: w * 0.08, y: h / 2 - size / 2,
-            width: size * 1.2, height: size,
-            borderRadius: 8,
-        }).render(context);
-
-        createText({
-            x: w * 0.08 + size * 0.6, y: h / 2 + size / 2 + 20,
-            content: `Linear ${angleDeg.value}°`, fill: '#666',
-            textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
-
-        createCircle({
-            fill: 'radial-gradient(circle, #ff006e, #fb5607)',
-            cx: w * 0.55, cy: h / 2, radius: size / 2,
-        }).render(context);
-
-        createText({
-            x: w * 0.55, y: h / 2 + size / 2 + 20,
-            content: 'Radial', fill: '#666',
-            textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
-
-        createRect({
-            fill: `linear-gradient(${angleDeg.value}deg, #3a86ff 0%, #3a86ff 33%, #ff006e 33%, #ff006e 66%, #8338ec 66%, #8338ec 100%)`,
-            x: w * 0.72, y: h / 2 - size / 2,
-            width: size * 1.2, height: size,
-            borderRadius: 8,
-        }).render(context);
-
-        createText({
-            x: w * 0.72 + size * 0.6, y: h / 2 + size / 2 + 20,
-            content: 'Hard Stops', fill: '#666',
-            textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
+        linear.render(context);
+        linearLabel.render(context);
+        radial.render(context);
+        radialLabel.render(context);
+        hardStops.render(context);
+        hardStopsLabel.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/advanced/interpolators.md
+++ b/apps/website/src/docs/core/advanced/interpolators.md
@@ -366,6 +366,7 @@ polygon.points = interp(t); // smoothly morphs between shapes
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -400,7 +401,36 @@ import {
 const numberT = ref(0);
 let numberCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements1 = useDemoElements(() => {
+    const numberCircle = createCircle({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    });
+
+    const numberLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        numberCircle,
+        numberLabel,
+    };
+});
+
 function renderNumber(ctx: Context) {
+    const {
+        numberCircle,
+        numberLabel,
+    } = getElements1();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = numberT.value / 100;
@@ -409,13 +439,17 @@ function renderNumber(ctx: Context) {
     const interp = interpolateNumber(minR, maxR);
     const r = interp(t);
 
+    numberCircle.cx = w / 2;
+    numberCircle.cy = h / 2;
+    numberCircle.radius = r;
+
+    numberLabel.x = w / 2;
+    numberLabel.y = h - 16;
+    numberLabel.content = `t = ${t.toFixed(2)}  radius = ${Math.round(r)}`;
+
     ctx.batch(() => {
-        createCircle({ fill: '#3a86ff', cx: w / 2, cy: h / 2, radius: r }).render(ctx);
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}  radius = ${Math.round(r)}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        numberCircle.render(ctx);
+        numberLabel.render(ctx);
     });
 }
 
@@ -433,7 +467,37 @@ function numberRedraw() { if (numberCtx) renderNumber(numberCtx); }
 const colorT = ref(0);
 let colorCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements2 = useDemoElements(() => {
+    const colorRect = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    });
+
+    const colorLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        colorRect,
+        colorLabel,
+    };
+});
+
 function renderColor(ctx: Context) {
+    const {
+        colorRect,
+        colorLabel,
+    } = getElements2();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = colorT.value / 100;
@@ -441,20 +505,19 @@ function renderColor(ctx: Context) {
     const color = interp(t);
     const pad = 20;
 
+    colorRect.fill = color;
+    colorRect.x = pad;
+    colorRect.y = pad;
+    colorRect.width = w - pad * 2;
+    colorRect.height = h - 50;
+
+    colorLabel.x = w / 2;
+    colorLabel.y = h - 16;
+    colorLabel.content = `t = ${t.toFixed(2)}  color = ${color}`;
+
     ctx.batch(() => {
-        createRect({
-            fill: color,
-            x: pad,
-            y: pad,
-            width: w - pad * 2,
-            height: h - 50,
-            borderRadius: 8,
-        }).render(ctx);
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}  color = ${color}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        colorRect.render(ctx);
+        colorLabel.render(ctx);
     });
 }
 
@@ -472,7 +535,37 @@ function colorRedraw() { if (colorCtx) renderColor(colorCtx); }
 const gradientT = ref(0);
 let gradientCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements3 = useDemoElements(() => {
+    const gradientRect = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    });
+
+    const gradientLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        gradientRect,
+        gradientLabel,
+    };
+});
+
 function renderGradient(ctx: Context) {
+    const {
+        gradientRect,
+        gradientLabel,
+    } = getElements3();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = gradientT.value / 100;
@@ -483,20 +576,19 @@ function renderGradient(ctx: Context) {
     const grad = interp(t);
     const pad = 20;
 
+    gradientRect.fill = grad;
+    gradientRect.x = pad;
+    gradientRect.y = pad;
+    gradientRect.width = w - pad * 2;
+    gradientRect.height = h - 50;
+
+    gradientLabel.x = w / 2;
+    gradientLabel.y = h - 16;
+    gradientLabel.content = `t = ${t.toFixed(2)}`;
+
     ctx.batch(() => {
-        createRect({
-            fill: grad,
-            x: pad,
-            y: pad,
-            width: w - pad * 2,
-            height: h - 50,
-            borderRadius: 8,
-        }).render(ctx);
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        gradientRect.render(ctx);
+        gradientLabel.render(ctx);
     });
 }
 
@@ -514,7 +606,37 @@ function gradientRedraw() { if (gradientCtx) renderGradient(gradientCtx); }
 const patternT = ref(0);
 let patternCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements4 = useDemoElements(() => {
+    const patternRect = createRect({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    });
+
+    const patternLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        patternRect,
+        patternLabel,
+    };
+});
+
 function renderPattern(ctx: Context) {
+    const {
+        patternRect,
+        patternLabel,
+    } = getElements4();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = patternT.value / 100;
@@ -525,20 +647,19 @@ function renderPattern(ctx: Context) {
     const fill = interp(t);
     const pad = 20;
 
+    patternRect.fill = fill;
+    patternRect.x = pad;
+    patternRect.y = pad;
+    patternRect.width = w - pad * 2;
+    patternRect.height = h - 50;
+
+    patternLabel.x = w / 2;
+    patternLabel.y = h - 16;
+    patternLabel.content = `t = ${t.toFixed(2)}`;
+
     ctx.batch(() => {
-        createRect({
-            fill,
-            x: pad,
-            y: pad,
-            width: w - pad * 2,
-            height: h - 50,
-            borderRadius: 8,
-        }).render(ctx);
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        patternRect.render(ctx);
+        patternLabel.render(ctx);
     });
 }
 
@@ -556,7 +677,40 @@ function patternRedraw() { if (patternCtx) renderPattern(patternCtx); }
 const rotationT = ref(0);
 let rotationCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements5 = useDemoElements(() => {
+    const rotationRect = createRect({
+        fill: '#3a86ff',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 4,
+        transformOriginX: '50%',
+        transformOriginY: '50%',
+    });
+
+    const rotationLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        rotationRect,
+        rotationLabel,
+    };
+});
+
 function renderRotation(ctx: Context) {
+    const {
+        rotationRect,
+        rotationLabel,
+    } = getElements5();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = rotationT.value / 100;
@@ -564,24 +718,19 @@ function renderRotation(ctx: Context) {
     const angle = interp(t) as number;
     const size = Math.min(w, h) * 0.3;
 
-    ctx.batch(() => {
-        createRect({
-            fill: '#3a86ff',
-            x: w / 2 - size / 2,
-            y: h / 2 - size / 2,
-            width: size,
-            height: size,
-            borderRadius: 4,
-            rotation: angle,
-            transformOriginX: '50%',
-            transformOriginY: '50%',
-        }).render(ctx);
+    rotationRect.x = w / 2 - size / 2;
+    rotationRect.y = h / 2 - size / 2;
+    rotationRect.width = size;
+    rotationRect.height = size;
+    rotationRect.rotation = angle;
 
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}  angle = ${Math.round(angle * 180 / Math.PI)}°`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+    rotationLabel.x = w / 2;
+    rotationLabel.y = h - 16;
+    rotationLabel.content = `t = ${t.toFixed(2)}  angle = ${Math.round(angle * 180 / Math.PI)}°`;
+
+    ctx.batch(() => {
+        rotationRect.render(ctx);
+        rotationLabel.render(ctx);
     });
 }
 
@@ -599,7 +748,53 @@ function rotationRedraw() { if (rotationCtx) renderRotation(rotationCtx); }
 const pathT = ref(0);
 let pathCtx: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements6 = useDemoElements(() => {
+    const pathGuide = createPolyline({
+        points: [],
+        stroke: '#e9ecef',
+        lineWidth: 2,
+        lineDash: [4, 4],
+    });
+
+    const pathRevealed = createPolyline({
+        points: [],
+        stroke: '#3a86ff',
+        lineWidth: 3,
+    });
+
+    const pathTip = createCircle({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radius: 4,
+    });
+
+    const pathLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        pathGuide,
+        pathRevealed,
+        pathTip,
+        pathLabel,
+    };
+});
+
 function renderPath(ctx: Context) {
+    const {
+        pathGuide,
+        pathRevealed,
+        pathTip,
+        pathLabel,
+    } = getElements6();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = pathT.value / 100;
@@ -608,28 +803,23 @@ function renderPath(ctx: Context) {
     const interp = interpolatePath(points);
     const revealed = interp(t);
 
+    const tip = revealed[revealed.length - 1];
+
+    pathGuide.points = points;
+    pathRevealed.points = revealed;
+
+    pathTip.cx = tip[0];
+    pathTip.cy = tip[1];
+
+    pathLabel.x = w / 2;
+    pathLabel.y = h - 16;
+    pathLabel.content = `t = ${t.toFixed(2)}  points revealed = ${revealed.length}/${points.length}`;
+
     ctx.batch(() => {
-        createPolyline({
-            points,
-            stroke: '#e9ecef',
-            lineWidth: 2,
-            lineDash: [4, 4],
-        }).render(ctx);
-
-        createPolyline({
-            points: revealed,
-            stroke: '#3a86ff',
-            lineWidth: 3,
-        }).render(ctx);
-
-        const tip = revealed[revealed.length - 1];
-        createCircle({ fill: '#3a86ff', cx: tip[0], cy: tip[1], radius: 4 }).render(ctx);
-
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}  points revealed = ${revealed.length}/${points.length}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        pathGuide.render(ctx);
+        pathRevealed.render(ctx);
+        pathTip.render(ctx);
+        pathLabel.render(ctx);
     });
 }
 
@@ -649,7 +839,66 @@ const morphFrom = ref('3');
 const morphTo = ref('8');
 let morphCtx: Context | undefined;
 
+// The morph resamples to the larger polygon, so the marker pool matches the largest selectable option.
+const MAX_MORPH_POINTS = 8;
+
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements7 = useDemoElements(() => {
+    const morphFromOutline = createPolyline({
+        points: [],
+        stroke: '#e9ecef',
+        lineWidth: 1,
+        lineDash: [4, 4],
+    });
+
+    const morphToOutline = createPolyline({
+        points: [],
+        stroke: '#e9ecef',
+        lineWidth: 1,
+        lineDash: [4, 4],
+    });
+
+    const morphShape = createPolyline({
+        points: [],
+        stroke: '#3a86ff',
+        lineWidth: 2,
+        fill: 'rgba(58, 134, 255, 0.15)',
+    });
+
+    const morphVertices = Array.from({ length: MAX_MORPH_POINTS }, () => createCircle({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radius: 3,
+    }));
+
+    const morphLabel = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        morphFromOutline,
+        morphToOutline,
+        morphShape,
+        morphVertices,
+        morphLabel,
+    };
+});
+
 function renderMorph(ctx: Context) {
+    const {
+        morphFromOutline,
+        morphToOutline,
+        morphShape,
+        morphVertices,
+        morphLabel,
+    } = getElements7();
+
     const w = ctx.width;
     const h = ctx.height;
     const t = morphT.value / 100;
@@ -662,38 +911,27 @@ function renderMorph(ctx: Context) {
     const interp = interpolatePoints(fromPts, toPts);
     const morphed = interp(t) as Point[];
 
+    const closePts = (pts: Point[]) => pts.length > 0 ? [...pts, pts[0]] : pts;
+
+    morphFromOutline.points = closePts(fromPts);
+    morphToOutline.points = closePts(toPts);
+    morphShape.points = closePts(morphed);
+
+    morphed.forEach((pt, index) => {
+        morphVertices[index].cx = pt[0];
+        morphVertices[index].cy = pt[1];
+    });
+
+    morphLabel.x = w / 2;
+    morphLabel.y = h - 16;
+    morphLabel.content = `t = ${t.toFixed(2)}  points = ${morphed.length} (${morphFrom.value}-gon → ${morphTo.value}-gon)`;
+
     ctx.batch(() => {
-        const closePts = (pts: Point[]) => pts.length > 0 ? [...pts, pts[0]] : pts;
-
-        createPolyline({
-            points: closePts(fromPts),
-            stroke: '#e9ecef',
-            lineWidth: 1,
-            lineDash: [4, 4],
-        }).render(ctx);
-        createPolyline({
-            points: closePts(toPts),
-            stroke: '#e9ecef',
-            lineWidth: 1,
-            lineDash: [4, 4],
-        }).render(ctx);
-
-        createPolyline({
-            points: closePts(morphed),
-            stroke: '#3a86ff',
-            lineWidth: 2,
-            fill: 'rgba(58, 134, 255, 0.15)',
-        }).render(ctx);
-
-        morphed.forEach(pt => {
-            createCircle({ fill: '#3a86ff', cx: pt[0], cy: pt[1], radius: 3 }).render(ctx);
-        });
-
-        createText({
-            x: w / 2, y: h - 16,
-            content: `t = ${t.toFixed(2)}  points = ${morphed.length} (${morphFrom.value}-gon → ${morphTo.value}-gon)`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(ctx);
+        morphFromOutline.render(ctx);
+        morphToOutline.render(ctx);
+        morphShape.render(ctx);
+        morphed.forEach((_, index) => morphVertices[index].render(ctx));
+        morphLabel.render(ctx);
     });
 }
 

--- a/apps/website/src/docs/core/advanced/math.md
+++ b/apps/website/src/docs/core/advanced/math.md
@@ -42,6 +42,7 @@ const wp = getWaypoint(points[0], points[3], 0.75);
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -72,82 +73,220 @@ const sides = ref(6);
 const waypoint = ref(50);
 let currentContext: Context | undefined;
 
+// The slider caps the polygon at this many sides, so the marker pool is sized once to match.
+const MAX_SIDES = 12;
+
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const polygon = createPolygon({
+        fill: 'rgba(58, 134, 255, 0.15)',
+        stroke: '#3a86ff',
+        lineWidth: 2,
+        cx: 0,
+        cy: 0,
+        radius: 0,
+        sides: 3,
+    });
+
+    const vertices = Array.from({ length: MAX_SIDES }, () => createCircle({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radius: 4,
+    }));
+
+    const vertexLabels = Array.from({ length: MAX_SIDES }, () => createText({
+        fill: '#666',
+        x: 0,
+        y: 0,
+        content: '',
+        font: '11px sans-serif',
+        textAlign: 'center',
+    }));
+
+    const chord = createLine({
+        stroke: '#999',
+        lineWidth: 1,
+        lineDash: [4, 4],
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+    });
+
+    const midpoint = createCircle({
+        fill: '#ff006e',
+        cx: 0,
+        cy: 0,
+        radius: 5,
+    });
+
+    const midpointLabel = createText({
+        fill: '#ff006e',
+        x: 0,
+        y: 0,
+        content: 'midpoint',
+        font: '11px sans-serif',
+    });
+
+    const waypointMarker = createCircle({
+        fill: '#8338ec',
+        cx: 0,
+        cy: 0,
+        radius: 5,
+    });
+
+    const waypointLabel = createText({
+        fill: '#8338ec',
+        x: 0,
+        y: 0,
+        content: '',
+        font: '11px sans-serif',
+    });
+
+    const boundingBox = createRect({
+        stroke: '#fb5607',
+        lineWidth: 1,
+        lineDash: [4, 4],
+        autoFill: false,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const boundingBoxLabel = createText({
+        fill: '#fb5607',
+        x: 0,
+        y: 0,
+        content: 'bounding box',
+        font: '11px sans-serif',
+    });
+
+    const readouts = Array.from({ length: 3 }, () => createText({
+        fill: '#333',
+        x: 0,
+        y: 0,
+        content: '',
+        font: '13px sans-serif',
+    }));
+
+    return {
+        polygon,
+        vertices,
+        vertexLabels,
+        chord,
+        midpoint,
+        midpointLabel,
+        waypointMarker,
+        waypointLabel,
+        boundingBox,
+        boundingBoxLabel,
+        readouts,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        polygon,
+        vertices,
+        vertexLabels,
+        chord,
+        midpoint,
+        midpointLabel,
+        waypointMarker,
+        waypointLabel,
+        boundingBox,
+        boundingBoxLabel,
+        readouts,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const cx = w * 0.35;
     const cy = h / 2;
     const r = Math.min(w * 0.25, h * 0.35);
 
-    context.batch(() => {
-        const points = getPolygonPoints(sides.value, cx, cy, r, false);
+    const points = getPolygonPoints(sides.value, cx, cy, r, false);
 
-        createPolygon({
-            fill: 'rgba(58, 134, 255, 0.15)',
-            stroke: '#3a86ff',
-            lineWidth: 2,
-            cx, cy, radius: r, sides: sides.value,
-        }).render(context);
+    polygon.cx = cx;
+    polygon.cy = cy;
+    polygon.radius = r;
+    polygon.sides = sides.value;
 
-        points.forEach(([px, py], i) => {
-            createCircle({ fill: '#3a86ff', cx: px, cy: py, radius: 4 }).render(context);
-            createText({
-                fill: '#666', x: px, y: py - 10,
-                content: `P${i}`, font: '11px sans-serif', textAlign: 'center',
-            }).render(context);
-        });
+    vertices.forEach((vertex, index) => {
+        const point = points[index];
 
-        if (points.length >= 2) {
-            const p0 = points[0];
-            const pLast = points[Math.floor(points.length / 2)];
+        vertex.opacity = point ? 1 : 0;
+        vertexLabels[index].opacity = point ? 1 : 0;
 
-            createLine({
-                stroke: '#999', lineWidth: 1, lineDash: [4, 4],
-                x1: p0[0], y1: p0[1], x2: pLast[0], y2: pLast[1],
-            }).render(context);
-
-            const mid = getMidpoint(p0, pLast);
-            createCircle({ fill: '#ff006e', cx: mid[0], cy: mid[1], radius: 5 }).render(context);
-            createText({
-                fill: '#ff006e', x: mid[0] + 10, y: mid[1] - 8,
-                content: 'midpoint', font: '11px sans-serif',
-            }).render(context);
-
-            const wp = getWaypoint(p0, pLast, waypoint.value / 100);
-            createCircle({ fill: '#8338ec', cx: wp[0], cy: wp[1], radius: 5 }).render(context);
-            createText({
-                fill: '#8338ec', x: wp[0] + 10, y: wp[1] + 14,
-                content: `waypoint(${waypoint.value}%)`, font: '11px sans-serif',
-            }).render(context);
+        if (!point) {
+            return;
         }
 
-        const bbox = getContainingBox(points, ([x, y]) => new Box(y, x, y, x));
-        createRect({
-            stroke: '#fb5607', lineWidth: 1, lineDash: [4, 4],
-            autoFill: false,
-            x: bbox.left, y: bbox.top,
-            width: bbox.width, height: bbox.height,
-        }).render(context);
+        vertex.cx = point[0];
+        vertex.cy = point[1];
 
-        createText({
-            fill: '#fb5607', x: bbox.left, y: bbox.top - 6,
-            content: 'bounding box', font: '11px sans-serif',
-        }).render(context);
+        vertexLabels[index].x = point[0];
+        vertexLabels[index].y = point[1] - 10;
+        vertexLabels[index].content = `P${index}`;
+    });
 
-        const infoX = w * 0.68;
-        const infoY = h * 0.2;
-        const info = [
-            `Sides: ${sides.value}`,
-            `Vertices: ${points.length}`,
-            `Box: ${Math.round(bbox.width)}×${Math.round(bbox.height)}`,
-        ];
+    const p0 = points[0];
+    const pLast = points[Math.floor(points.length / 2)];
+    const mid = getMidpoint(p0, pLast);
+    const wp = getWaypoint(p0, pLast, waypoint.value / 100);
 
-        info.forEach((line, i) => {
-            createText({
-                fill: '#333', x: infoX, y: infoY + i * 22,
-                content: line, font: '13px sans-serif',
-            }).render(context);
-        });
+    chord.x1 = p0[0];
+    chord.y1 = p0[1];
+    chord.x2 = pLast[0];
+    chord.y2 = pLast[1];
+
+    midpoint.cx = mid[0];
+    midpoint.cy = mid[1];
+    midpointLabel.x = mid[0] + 10;
+    midpointLabel.y = mid[1] - 8;
+
+    waypointMarker.cx = wp[0];
+    waypointMarker.cy = wp[1];
+    waypointLabel.x = wp[0] + 10;
+    waypointLabel.y = wp[1] + 14;
+    waypointLabel.content = `waypoint(${waypoint.value}%)`;
+
+    const bbox = getContainingBox(points, ([x, y]) => new Box(y, x, y, x));
+
+    boundingBox.x = bbox.left;
+    boundingBox.y = bbox.top;
+    boundingBox.width = bbox.width;
+    boundingBox.height = bbox.height;
+
+    boundingBoxLabel.x = bbox.left;
+    boundingBoxLabel.y = bbox.top - 6;
+
+    const info = [
+        `Sides: ${sides.value}`,
+        `Vertices: ${points.length}`,
+        `Box: ${Math.round(bbox.width)}×${Math.round(bbox.height)}`,
+    ];
+
+    readouts.forEach((readout, index) => {
+        readout.x = w * 0.68;
+        readout.y = h * 0.2 + index * 22;
+        readout.content = info[index];
+    });
+
+    context.batch(() => {
+        polygon.render(context);
+        vertices.forEach(vertex => vertex.render(context));
+        vertexLabels.forEach(vertexLabel => vertexLabel.render(context));
+        chord.render(context);
+        midpoint.render(context);
+        midpointLabel.render(context);
+        waypointMarker.render(context);
+        waypointLabel.render(context);
+        boundingBox.render(context);
+        boundingBoxLabel.render(context);
+        readouts.forEach(readout => readout.render(context));
     });
 }
 

--- a/apps/website/src/docs/core/advanced/navigator.md
+++ b/apps/website/src/docs/core/advanced/navigator.md
@@ -52,6 +52,7 @@ navigator.fitBounds({ x0: 0, y0: 0, x1: 1800, y1: 1100 }, { padding: 24 });
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -100,56 +101,116 @@ const nodes = Array.from({ length: NODE_COUNT }, (_, index) => {
 
 let currentNavigator: DOMNavigator | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const backdrop = createRect({
+        fill: '#0d1117',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const worldOutline = createRect({
+        stroke: '#30363d',
+        lineWidth: 1,
+        autoFill: false,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const nodeMarkers = nodes.map(node => createCircle({
+        fill: swatch(node.index),
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    }));
+
+    const brushRect = createRect({
+        fill: setColorAlpha('#3a86ff', 0.15),
+        stroke: '#3a86ff',
+        lineWidth: 1,
+        lineDash: [4, 4],
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const hint = createText({
+        fill: '#8b949e',
+        x: 12,
+        y: 0,
+        content: '',
+        font: '12px sans-serif',
+    });
+
+    return {
+        backdrop,
+        worldOutline,
+        nodeMarkers,
+        brushRect,
+        hint,
+    };
+});
+
 function renderDemo(context: Context, navigator: DOMNavigator) {
+    const {
+        backdrop,
+        worldOutline,
+        nodeMarkers,
+        brushRect,
+        hint,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const transform = navigator.transform;
 
+    const [ox, oy] = navigator.applyPoint([0, 0]);
+    const brush = navigator.brush;
+
+    backdrop.width = w;
+    backdrop.height = h;
+
+    worldOutline.x = ox;
+    worldOutline.y = oy;
+    worldOutline.width = WORLD.width * transform.k;
+    worldOutline.height = WORLD.height * transform.k;
+
+    const visible = nodes.filter((node, index) => {
+        const [cx, cy] = navigator.applyPoint([node.x, node.y]);
+        const radius = node.radius * transform.k;
+
+        nodeMarkers[index].cx = cx;
+        nodeMarkers[index].cy = cy;
+        nodeMarkers[index].radius = radius;
+
+        return cx + radius >= 0 && cx - radius <= w && cy + radius >= 0 && cy - radius <= h;
+    });
+
+    if (brush) {
+        brushRect.x = brush.x0;
+        brushRect.y = brush.y0;
+        brushRect.width = brush.x1 - brush.x0;
+        brushRect.height = brush.y1 - brush.y0;
+    }
+
+    hint.y = h - 14;
+    hint.content = `zoom ${transform.k.toFixed(2)}× · drag to pan · wheel to zoom · shift-drag to zoom to region`;
+
     context.batch(() => {
-        createRect({
-            fill: '#0d1117', x: 0, y: 0, width: w, height: h,
-        }).render(context);
-
-        const [ox, oy] = navigator.applyPoint([0, 0]);
-
-        createRect({
-            stroke: '#30363d', lineWidth: 1,
-            x: ox, y: oy,
-            width: WORLD.width * transform.k,
-            height: WORLD.height * transform.k,
-        }).render(context);
-
-        nodes.forEach(node => {
-            const [cx, cy] = navigator.applyPoint([node.x, node.y]);
-            const radius = node.radius * transform.k;
-
-            if (cx + radius < 0 || cx - radius > w || cy + radius < 0 || cy - radius > h) {
-                return;
-            }
-
-            createCircle({
-                fill: swatch(node.index),
-                cx, cy, radius,
-            }).render(context);
-        });
-
-        const brush = navigator.brush;
+        backdrop.render(context);
+        worldOutline.render(context);
+        visible.forEach(node => nodeMarkers[node.index].render(context));
 
         if (brush) {
-            createRect({
-                fill: setColorAlpha('#3a86ff', 0.15),
-                stroke: '#3a86ff', lineWidth: 1, lineDash: [4, 4],
-                x: brush.x0, y: brush.y0,
-                width: brush.x1 - brush.x0,
-                height: brush.y1 - brush.y0,
-            }).render(context);
+            brushRect.render(context);
         }
 
-        createText({
-            fill: '#8b949e', x: 12, y: h - 14,
-            content: `zoom ${transform.k.toFixed(2)}× · drag to pan · wheel to zoom · shift-drag to zoom to region`,
-            font: '12px sans-serif',
-        }).render(context);
+        hint.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/advanced/pattern-fills.md
+++ b/apps/website/src/docs/core/advanced/pattern-fills.md
@@ -179,6 +179,7 @@ Custom contexts can call `getPatternTileGeometry(pattern)` to obtain the rendere
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -221,7 +222,39 @@ const swatches = [
     },
 ];
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const tiles = swatches.map(() => createRect({
+        stroke: '#d0d0d0',
+        lineWidth: 1,
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        borderRadius: 8,
+    }));
+
+    const labels = swatches.map(swatch => createText({
+        content: swatch.label,
+        fill: '#666',
+        font: '13px sans-serif',
+        textAlign: 'center',
+        x: 0,
+        y: 0,
+    }));
+
+    return {
+        tiles,
+        labels,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        tiles,
+        labels,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const gap = w * 0.03;
@@ -230,30 +263,22 @@ function renderDemo(context: Context) {
     const left = (w - (width * swatches.length + gap * (swatches.length - 1))) / 2;
     const top = h / 2 - height / 2;
 
+    swatches.forEach((swatch, index) => {
+        const x = left + index * (width + gap);
+
+        tiles[index].fill = swatch.fill(tileSize.value);
+        tiles[index].x = x;
+        tiles[index].y = top;
+        tiles[index].width = width;
+        tiles[index].height = height;
+
+        labels[index].x = x + width / 2;
+        labels[index].y = top + height + 20;
+    });
+
     context.batch(() => {
-        swatches.forEach((swatch, index) => {
-            const x = left + index * (width + gap);
-
-            createRect({
-                fill: swatch.fill(tileSize.value),
-                stroke: '#d0d0d0',
-                lineWidth: 1,
-                x,
-                y: top,
-                width,
-                height,
-                borderRadius: 8,
-            }).render(context);
-
-            createText({
-                content: swatch.label,
-                fill: '#666',
-                font: '13px sans-serif',
-                textAlign: 'center',
-                x: x + width / 2,
-                y: top + height + 20,
-            }).render(context);
-        });
+        tiles.forEach(tile => tile.render(context));
+        labels.forEach(label => label.render(context));
     });
 }
 

--- a/apps/website/src/docs/core/advanced/scales.md
+++ b/apps/website/src/docs/core/advanced/scales.md
@@ -54,6 +54,7 @@ sqrt(25); // 200
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -92,7 +93,91 @@ function getScale(type: string, range: number[]): Scale<number> {
     }
 }
 
+const TICK_STEP = 20;
+const TICK_COUNT = 100 / TICK_STEP + 1;
+
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const plot = createRect({
+        fill: '#f8f9fa',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const ticks = Array.from({ length: TICK_COUNT }, () => createLine({
+        stroke: '#e9ecef',
+        lineWidth: 1,
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+    }));
+
+    const tickLabels = Array.from({ length: TICK_COUNT }, () => createText({
+        fill: '#999',
+        x: 0,
+        y: 0,
+        content: '',
+        textAlign: 'center',
+        font: '11px sans-serif',
+    }));
+
+    const curve = createPolyline({
+        stroke: '#3a86ff',
+        lineWidth: 2,
+        points: [],
+        renderer: 'linear',
+    });
+
+    const marker = createCircle({
+        fill: '#ff006e',
+        cx: 0,
+        cy: 0,
+        radius: 6,
+    });
+
+    const markerLabel = createText({
+        fill: '#333',
+        x: 0,
+        y: 0,
+        content: '',
+        textAlign: 'center',
+        font: 'bold 12px sans-serif',
+    });
+
+    const caption = createText({
+        fill: '#666',
+        x: 0,
+        y: 0,
+        content: '',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        plot,
+        ticks,
+        tickLabels,
+        curve,
+        marker,
+        markerLabel,
+        caption,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        plot,
+        ticks,
+        tickLabels,
+        curve,
+        marker,
+        markerLabel,
+        caption,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const pad = 50;
@@ -102,57 +187,57 @@ function renderDemo(context: Context) {
     const scale = getScale(currentScale.value, [0, chartW]);
     const yScale = scaleContinuous([0, chartW], [chartH, 0]);
 
+    const axisScale = scaleContinuous([0, 100], [0, chartW]);
+
+    plot.x = pad;
+    plot.y = pad;
+    plot.width = chartW;
+    plot.height = chartH;
+
+    ticks.forEach((tick, index) => {
+        const x = pad + axisScale(index * TICK_STEP);
+
+        tick.x1 = x;
+        tick.y1 = pad;
+        tick.x2 = x;
+        tick.y2 = pad + chartH;
+
+        tickLabels[index].x = x;
+        tickLabels[index].y = pad + chartH + 16;
+        tickLabels[index].content = String(index * TICK_STEP);
+    });
+
+    const points: [number, number][] = [];
+    const domainMin = currentScale.value === 'logarithmic' ? 1 : 0;
+
+    for (let i = domainMin; i <= 100; i += 1) {
+        points.push([pad + axisScale(i), pad + yScale(scale(i))]);
+    }
+
+    curve.points = points;
+
+    const val = Math.max(domainMin, inputValue.value);
+    const mapped = scale(val);
+
+    marker.cx = pad + axisScale(val);
+    marker.cy = pad + yScale(mapped);
+
+    markerLabel.x = marker.cx;
+    markerLabel.y = marker.cy - 14;
+    markerLabel.content = `${val} → ${Math.round(mapped)}`;
+
+    caption.x = w / 2;
+    caption.y = h - 6;
+    caption.content = `Scale: ${currentScale.value}`;
+
     context.batch(() => {
-        createRect({
-            fill: '#f8f9fa', x: pad, y: pad, width: chartW, height: chartH,
-        }).render(context);
-
-        for (let i = 0; i <= 100; i += 20) {
-            const x = pad + scaleContinuous([0, 100], [0, chartW])(i);
-            createLine({
-                stroke: '#e9ecef',
-                lineWidth: 1,
-                x1: x,
-                y1: pad,
-                x2: x,
-                y2: pad + chartH,
-            }).render(context);
-            createText({
-                fill: '#999',
-                x,
-                y: pad + chartH + 16,
-                content: String(i),
-                textAlign: 'center',
-                font: '11px sans-serif',
-            }).render(context);
-        }
-
-        const points: [number, number][] = [];
-        const domainMin = currentScale.value === 'logarithmic' ? 1 : 0;
-        for (let i = domainMin; i <= 100; i += 1) {
-            const sx = scale(i);
-            points.push([pad + scaleContinuous([0, 100], [0, chartW])(i), pad + yScale(sx)]);
-        }
-
-        createPolyline({ stroke: '#3a86ff', lineWidth: 2, points, renderer: 'linear' }).render(context);
-
-        const val = Math.max(domainMin, inputValue.value);
-        const mapped = scale(val);
-        const px = pad + scaleContinuous([0, 100], [0, chartW])(val);
-        const py = pad + yScale(mapped);
-
-        createCircle({ fill: '#ff006e', cx: px, cy: py, radius: 6 }).render(context);
-        createText({
-            fill: '#333', x: px, y: py - 14,
-            content: `${val} → ${Math.round(mapped)}`,
-            textAlign: 'center', font: 'bold 12px sans-serif',
-        }).render(context);
-
-        createText({
-            fill: '#666', x: w / 2, y: h - 6,
-            content: `Scale: ${currentScale.value}`,
-            textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+        plot.render(context);
+        ticks.forEach(tick => tick.render(context));
+        tickLabels.forEach(tickLabel => tickLabel.render(context));
+        curve.render(context);
+        marker.render(context);
+        markerLabel.render(context);
+        caption.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/arc.md
+++ b/apps/website/src/docs/core/elements/arc.md
@@ -48,6 +48,7 @@ createArc({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -71,31 +72,58 @@ const padAngleVal = ref(2);
 const borderRadiusVal = ref(4);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const arc = createArc({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radius: 0,
+        innerRadius: 0,
+        startAngle: 0,
+        endAngle: 0,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        arc,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        arc,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const r = Math.min(w, h) / 3;
 
+    arc.cx = w / 2;
+    arc.cy = h / 2;
+    arc.radius = r;
+    arc.innerRadius = r * (innerRadiusPct.value / 100);
+    arc.endAngle = TAU * (endAnglePct.value / 100);
+    arc.padAngle = padAngleVal.value * 0.01;
+    arc.borderRadius = borderRadiusVal.value;
+
+    label.x = w / 2;
+    label.y = h / 2 + r + 24;
+    label.content = `endAngle: ${Math.round(endAnglePct.value)}%  inner: ${innerRadiusPct.value}%  pad: ${padAngleVal.value}  radius: ${borderRadiusVal.value}`;
+
     context.batch(() => {
-        const endAngle = TAU * (endAnglePct.value / 100);
-        const innerRadius = r * (innerRadiusPct.value / 100);
-        const padAngle = padAngleVal.value * 0.01;
-
-        createArc({
-            fill: '#3a86ff',
-            cx: w / 2, cy: h / 2, radius: r,
-            innerRadius,
-            startAngle: 0,
-            endAngle,
-            padAngle,
-            borderRadius: borderRadiusVal.value,
-        }).render(context);
-
-        createText({
-            x: w / 2, y: h / 2 + r + 24,
-            content: `endAngle: ${Math.round(endAnglePct.value)}%  inner: ${innerRadiusPct.value}%  pad: ${padAngleVal.value}  radius: ${borderRadiusVal.value}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+        arc.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/circle.md
+++ b/apps/website/src/docs/core/elements/circle.md
@@ -42,6 +42,7 @@ createCircle({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -63,26 +64,54 @@ const lineWidth = ref(3);
 const opacity = ref(100);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const circle = createCircle({
+        fill: '#3a86ff',
+        stroke: '#1a56db',
+        cx: 0,
+        cy: 0,
+        radius: 0,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        circle,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        circle,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const r = Math.min(w, h) / 3 * (radius.value / 100 + 0.4);
 
-    context.batch(() => {
-        createCircle({
-            fill: '#3a86ff',
-            stroke: '#1a56db',
-            lineWidth: lineWidth.value,
-            opacity: opacity.value / 100,
-            cx: w / 2, cy: h / 2,
-            radius: r,
-        }).render(context);
+    circle.lineWidth = lineWidth.value;
+    circle.opacity = opacity.value / 100;
+    circle.cx = w / 2;
+    circle.cy = h / 2;
+    circle.radius = r;
 
-        createText({
-            x: w / 2, y: h / 2 + r + 24,
-            content: `radius: ${Math.round(r)}  stroke: ${lineWidth.value}  opacity: ${opacity.value}%`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + r + 24;
+    label.content = `radius: ${Math.round(r)}  stroke: ${lineWidth.value}  opacity: ${opacity.value}%`;
+
+    context.batch(() => {
+        circle.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/ellipse.md
+++ b/apps/website/src/docs/core/elements/ellipse.md
@@ -46,6 +46,7 @@ createEllipse({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -68,27 +69,58 @@ const ryPct = ref(45);
 const rotationDeg = ref(0);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const ellipse = createEllipse({
+        fill: '#3a86ff',
+        cx: 0,
+        cy: 0,
+        radiusX: 0,
+        radiusY: 0,
+        startAngle: 0,
+        endAngle: TAU,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        ellipse,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        ellipse,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const maxR = Math.min(w, h) / 3;
     const rx = maxR * (rxPct.value / 100);
     const ry = maxR * (ryPct.value / 100);
 
-    context.batch(() => {
-        createEllipse({
-            fill: '#3a86ff',
-            cx: w / 2, cy: h / 2,
-            radiusX: rx, radiusY: ry,
-            rotation: rotationDeg.value * Math.PI / 180,
-            startAngle: 0, endAngle: TAU,
-        }).render(context);
+    ellipse.cx = w / 2;
+    ellipse.cy = h / 2;
+    ellipse.radiusX = rx;
+    ellipse.radiusY = ry;
+    ellipse.rotation = rotationDeg.value * Math.PI / 180;
 
-        createText({
-            x: w / 2, y: h / 2 + maxR + 24,
-            content: `rx: ${Math.round(rx)}  ry: ${Math.round(ry)}  rotation: ${rotationDeg.value}°`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + maxR + 24;
+    label.content = `rx: ${Math.round(rx)}  ry: ${Math.round(ry)}  rotation: ${rotationDeg.value}°`;
+
+    context.batch(() => {
+        ellipse.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/line.md
+++ b/apps/website/src/docs/core/elements/line.md
@@ -44,6 +44,7 @@ createLine({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -65,7 +66,37 @@ const dashGap = ref(0);
 const angleDeg = ref(45);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const line = createLine({
+        stroke: '#3a86ff',
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        line,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        line,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const cx = w / 2;
@@ -74,22 +105,20 @@ function renderDemo(context: Context) {
     const angle = angleDeg.value * Math.PI / 180;
     const dash = dashGap.value > 0 ? [dashGap.value, dashGap.value] : [];
 
-    context.batch(() => {
-        createLine({
-            stroke: '#3a86ff',
-            lineWidth: lineWidthVal.value,
-            lineDash: dash,
-            x1: cx - Math.cos(angle) * len,
-            y1: cy - Math.sin(angle) * len,
-            x2: cx + Math.cos(angle) * len,
-            y2: cy + Math.sin(angle) * len,
-        }).render(context);
+    line.lineWidth = lineWidthVal.value;
+    line.lineDash = dash;
+    line.x1 = cx - Math.cos(angle) * len;
+    line.y1 = cy - Math.sin(angle) * len;
+    line.x2 = cx + Math.cos(angle) * len;
+    line.y2 = cy + Math.sin(angle) * len;
 
-        createText({
-            x: w / 2, y: h - 16,
-            content: `width: ${lineWidthVal.value}  dash: ${dashGap.value}  angle: ${angleDeg.value}°`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h - 16;
+    label.content = `width: ${lineWidthVal.value}  dash: ${dashGap.value}  angle: ${angleDeg.value}°`;
+
+    context.batch(() => {
+        line.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/path.md
+++ b/apps/website/src/docs/core/elements/path.md
@@ -61,6 +61,7 @@ const star = createPath({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -162,26 +163,57 @@ const colors: Record<string, string> = {
     cross: '#8338ec',
 };
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const shape = createPath({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        pathRenderer: starRenderer,
+        // The renderer is swapped from outside element state, so a cached path would go stale.
+        cachePath: false,
+    });
+
+    const label = createText({
+        fill: '#666',
+        x: 0,
+        y: 0,
+        content: '',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    return {
+        shape,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        shape,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const s = size.value;
 
-    context.batch(() => {
-        createPath({
-            fill: colors[currentShape.value],
-            x: w / 2 - s / 2,
-            y: h / 2 - s / 2,
-            width: s,
-            height: s,
-            pathRenderer: renderers[currentShape.value],
-        }).render(context);
+    shape.fill = colors[currentShape.value];
+    shape.x = w / 2 - s / 2;
+    shape.y = h / 2 - s / 2;
+    shape.width = s;
+    shape.height = s;
+    shape.setPathRenderer(renderers[currentShape.value]);
 
-        createText({
-            fill: '#666', x: w / 2, y: h / 2 + s / 2 + 24,
-            content: `Path: ${currentShape.value} (${s}×${s})`,
-            textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + s / 2 + 24;
+    label.content = `Path: ${currentShape.value} (${s}×${s})`;
+
+    context.batch(() => {
+        shape.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/polygon.md
+++ b/apps/website/src/docs/core/elements/polygon.md
@@ -41,6 +41,7 @@ createPolygon({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -74,25 +75,55 @@ const sides = ref(6);
 const radiusPct = ref(70);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const polygon = createPolygon({
+        fill: '#3a86ff',
+        stroke: '#1a56db',
+        lineWidth: 2,
+        cx: 0,
+        cy: 0,
+        radius: 0,
+        sides: 3,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        polygon,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        polygon,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const r = Math.min(w, h) / 3 * (radiusPct.value / 100);
 
-    context.batch(() => {
-        createPolygon({
-            fill: '#3a86ff',
-            stroke: '#1a56db',
-            lineWidth: 2,
-            cx: w / 2, cy: h / 2,
-            radius: r, sides: sides.value,
-        }).render(context);
+    polygon.cx = w / 2;
+    polygon.cy = h / 2;
+    polygon.radius = r;
+    polygon.sides = sides.value;
 
-        createText({
-            x: w / 2, y: h / 2 + r + 24,
-            content: `${NAMES[sides.value] || sides.value + '-gon'}  (${sides.value} sides, r=${Math.round(r)})`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + r + 24;
+    label.content = `${NAMES[sides.value] || sides.value + '-gon'}  (${sides.value} sides, r=${Math.round(r)})`;
+
+    context.batch(() => {
+        polygon.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/polyline.md
+++ b/apps/website/src/docs/core/elements/polyline.md
@@ -42,6 +42,7 @@ createPolyline({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -77,7 +78,44 @@ const currentRenderer = ref<PolylineRenderer>('spline');
 
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const polyline = createPolyline({
+        stroke: '#3a86ff',
+        lineWidth: 3,
+        points: [],
+    });
+
+    const markers = Array.from({ length: 7 }, () => createCircle({
+        fill: '#ff006e',
+        cx: 0,
+        cy: 0,
+        radius: 4,
+    }));
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '13px sans-serif',
+    });
+
+    return {
+        polyline,
+        markers,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        polyline,
+        markers,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const pad = 40;
@@ -92,26 +130,22 @@ function renderDemo(context: Context) {
         [w - pad, h * 0.5],
     ];
 
+    polyline.points = points;
+    polyline.renderer = currentRenderer.value;
+
+    points.forEach(([x, y], index) => {
+        markers[index].cx = x;
+        markers[index].cy = y;
+    });
+
+    label.x = w / 2;
+    label.y = h - 12;
+    label.content = `renderer: '${currentRenderer.value}'`;
+
     context.batch(() => {
-        createPolyline({
-            stroke: '#3a86ff',
-            lineWidth: 3,
-            points,
-            renderer: currentRenderer.value,
-        }).render(context);
-
-        points.forEach(([x, y]) => {
-            createCircle({
-                fill: '#ff006e',
-                cx: x, cy: y, radius: 4,
-            }).render(context);
-        });
-
-        createText({
-            x: w / 2, y: h - 12,
-            content: `renderer: '${currentRenderer.value}'`,
-            fill: '#666', textAlign: 'center', font: '13px sans-serif',
-        }).render(context);
+        polyline.render(context);
+        markers.forEach(marker => marker.render(context));
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/rect.md
+++ b/apps/website/src/docs/core/elements/rect.md
@@ -44,6 +44,7 @@ createRect({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -65,27 +66,55 @@ const heightPct = ref(50);
 const borderRadiusVal = ref(8);
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const rect = createRect({
+        fill: '#3a86ff',
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const label = createText({
+        x: 0,
+        y: 0,
+        content: '',
+        fill: '#666',
+        textAlign: 'center',
+        font: '12px sans-serif',
+    });
+
+    return {
+        rect,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        rect,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
     const rw = w * 0.7 * (widthPct.value / 100);
     const rh = h * 0.6 * (heightPct.value / 100);
 
-    context.batch(() => {
-        createRect({
-            fill: '#3a86ff',
-            x: w / 2 - rw / 2,
-            y: h / 2 - rh / 2,
-            width: rw,
-            height: rh,
-            borderRadius: borderRadiusVal.value,
-        }).render(context);
+    rect.x = w / 2 - rw / 2;
+    rect.y = h / 2 - rh / 2;
+    rect.width = rw;
+    rect.height = rh;
+    rect.borderRadius = borderRadiusVal.value;
 
-        createText({
-            x: w / 2, y: h / 2 + rh / 2 + 22,
-            content: `${Math.round(rw)}×${Math.round(rh)}  radius: ${borderRadiusVal.value}`,
-            fill: '#666', textAlign: 'center', font: '12px sans-serif',
-        }).render(context);
+    label.x = w / 2;
+    label.y = h / 2 + rh / 2 + 22;
+    label.content = `${Math.round(rw)}×${Math.round(rh)}  radius: ${borderRadiusVal.value}`;
+
+    context.batch(() => {
+        rect.render(context);
+        label.render(context);
     });
 }
 

--- a/apps/website/src/docs/core/elements/text.md
+++ b/apps/website/src/docs/core/elements/text.md
@@ -75,6 +75,7 @@ createText({
 
 <script lang="ts" setup>
 import {
+    useDemoElements,
     useRiplExample,
 } from '../../../.vitepress/compositions/example';
 
@@ -95,46 +96,95 @@ const fontSize = ref(28);
 const textAlign = ref('center');
 let currentContext: Context | undefined;
 
+// Built once, on first render, so ids stay stable and every id-keyed cache hits.
+const getElements = useDemoElements(() => {
+    const guide = createLine({
+        stroke: '#e9ecef',
+        lineWidth: 1,
+        lineDash: [4, 4],
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+    });
+
+    const filled = createText({
+        fill: '#3a86ff',
+        x: 0,
+        y: 0,
+        content: 'Filled Text',
+        textBaseline: 'middle',
+    });
+
+    const stroked = createText({
+        stroke: '#ff006e',
+        lineWidth: 1,
+        x: 0,
+        y: 0,
+        content: 'Stroked Text',
+        textBaseline: 'middle',
+    });
+
+    const label = createText({
+        fill: '#666',
+        x: 0,
+        y: 0,
+        content: '',
+        font: '13px sans-serif',
+        textAlign: 'center',
+        textBaseline: 'middle',
+    });
+
+    return {
+        guide,
+        filled,
+        stroked,
+        label,
+    };
+});
+
 function renderDemo(context: Context) {
+    const {
+        guide,
+        filled,
+        stroked,
+        label,
+    } = getElements();
+
     const w = context.width;
     const h = context.height;
 
+    const anchorX = textAlign.value === 'left' ? w * 0.1
+        : textAlign.value === 'right' ? w * 0.9
+            : w / 2;
+
+    const font = `bold ${fontSize.value}px sans-serif`;
+    const align = textAlign.value as CanvasTextAlign;
+
+    guide.x1 = anchorX;
+    guide.y1 = 0;
+    guide.x2 = anchorX;
+    guide.y2 = h;
+
+    filled.x = anchorX;
+    filled.y = h * 0.3;
+    filled.font = font;
+    filled.textAlign = align;
+
+    stroked.x = anchorX;
+    stroked.y = h * 0.55;
+    stroked.font = font;
+    stroked.textAlign = align;
+
+    label.x = w / 2;
+    label.y = h * 0.8;
+    label.content = `font: ${fontSize.value}px  align: ${textAlign.value}`;
+
     context.batch(() => {
-        const anchorX = textAlign.value === 'left' ? w * 0.1
-            : textAlign.value === 'right' ? w * 0.9
-                : w / 2;
-
-        createLine({
-            stroke: '#e9ecef', lineWidth: 1, lineDash: [4, 4],
-            x1: anchorX, y1: 0, x2: anchorX, y2: h,
-        }).render(context);
-
-        createText({
-            fill: '#3a86ff',
-            x: anchorX, y: h * 0.3,
-            content: 'Filled Text',
-            font: `bold ${fontSize.value}px sans-serif`,
-            textAlign: textAlign.value as CanvasTextAlign,
-            textBaseline: 'middle',
-        }).render(context);
-
-        createText({
-            stroke: '#ff006e',
-            lineWidth: 1,
-            x: anchorX, y: h * 0.55,
-            content: 'Stroked Text',
-            font: `bold ${fontSize.value}px sans-serif`,
-            textAlign: textAlign.value as CanvasTextAlign,
-            textBaseline: 'middle',
-        }).render(context);
-
-        createText({
-            fill: '#666',
-            x: w / 2, y: h * 0.8,
-            content: `font: ${fontSize.value}px  align: ${textAlign.value}`,
-            font: '13px sans-serif',
-            textAlign: 'center', textBaseline: 'middle',
-        }).render(context);
+        guide.render(context);
+        filled.render(context);
+        stroked.render(context);
+        label.render(context);
     });
 }
 
@@ -150,30 +200,36 @@ function redraw() {
     if (currentContext) renderDemo(currentContext);
 }
 
+const curvedText = createText({
+    fill: '#3a86ff',
+    x: 0,
+    y: 0,
+    content: 'Text along a curved path!',
+    font: 'bold 20px sans-serif',
+});
+
+const arcText = createText({
+    stroke: '#ff006e',
+    lineWidth: 1,
+    x: 0,
+    y: 0,
+    content: 'Stroked text on an arc',
+    font: 'bold 18px sans-serif',
+});
+
 const {
     contextChanged: pathContextChanged
 } = useRiplExample(context => {
-    const w = context.width;
-    const h = context.height;
-
     const render = () => {
-        context.batch(() => {
-            createText({
-                fill: '#3a86ff',
-                x: 0, y: 0,
-                content: 'Text along a curved path!',
-                font: 'bold 20px sans-serif',
-                pathData: `M ${w * 0.05},${h * 0.5} C ${w * 0.3},${h * 0.1} ${w * 0.7},${h * 0.9} ${w * 0.95},${h * 0.5}`,
-            }).render(context);
+        const w = context.width;
+        const h = context.height;
 
-            createText({
-                stroke: '#ff006e',
-                lineWidth: 1,
-                x: 0, y: 0,
-                content: 'Stroked text on an arc',
-                font: 'bold 18px sans-serif',
-                pathData: `M ${w * 0.1},${h * 0.85} A ${w * 0.4},${w * 0.4} 0 0 1 ${w * 0.9},${h * 0.85}`,
-            }).render(context);
+        curvedText.pathData = `M ${w * 0.05},${h * 0.5} C ${w * 0.3},${h * 0.1} ${w * 0.7},${h * 0.9} ${w * 0.95},${h * 0.5}`;
+        arcText.pathData = `M ${w * 0.1},${h * 0.85} A ${w * 0.4},${w * 0.4} 0 0 1 ${w * 0.9},${h * 0.85}`;
+
+        context.batch(() => {
+            curvedText.render(context);
+            arcText.render(context);
         });
     };
 


### PR DESCRIPTION
Website only — no library code. 18 pages, 20 demos.

## Problem

Every demo rebuilt its whole element set inside `renderDemo`, so each element got a fresh `stringUniqueId()` on every redraw. Since `Shape2D` passes `this.id` to `context.createPath(id)`, that means every id-keyed cache missed by construction: the SVG reconciler tore down and recreated the entire tree each frame and the `<defs>` sweep churned. `AGENTS.md:553` asks for the opposite.

It also modelled the wrong thing. These pages teach the API, and they were teaching readers to rebuild the world every frame rather than use the update path.

## Change

Elements are built once and mutated per redraw:

```ts
const getElements = useDemoElements(() => {
    const circle = createCircle({ fill: '#3a86ff', cx: 0, cy: 0, radius: 0 });
    const label = createText({ x: 0, y: 0, content: '', /* … */ });

    return { circle, label };
});

function renderDemo(context: Context) {
    const { circle, label } = getElements();

    circle.cx = w / 2;
    // …
    context.batch(() => {
        circle.render(context);
        label.render(context);
    });
}
```

**Construction is deferred to first render rather than hoisted to module scope.** I hoisted it first and the site build surfaced why that's wrong: module scope evaluates during VitePress SSR, where `@ripl/web`'s platform bindings aren't installed, so `createGroup` throws `TypeError: factory.now is not a function` and the demo's `setup()` aborts. `useDemoElements` in the shared composition defers it.

Demos with a variable element count (polyline markers, polygon vertices, morph vertices) allocate a pool sized to the control's maximum and render only the live slice.

`path.md` opts out of the path cache with `cachePath: false` — it swaps the renderer callback via `setPathRenderer`, which lives outside element state, so a cached path would go stale. That's the documented purpose of the flag.

## Verification

- `yarn workspace @ripl/website build` — **0 errors** (it reported per-page `TypeError`s before the lazy-build change)
- `yarn lint`, `yarn test` pass
- A scan for factory calls reachable from any render/redraw function reports none remaining

Pages already building once (`context.md`, `element.md`, `transforms.md`, `group.md`, `image.md`, `scene.md`, `renderer.md`, and the chart pages) were left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1KGv3Mu5uJguQqEQnCgTz)_