### PR TITLE
Audit every rendering context against the base contract

### DIFF
--- a/docs/audits/3d-webgpu.md
+++ b/docs/audits/3d-webgpu.md
@@ -1,0 +1,812 @@
+# Audit — `@ripl/3d` and `@ripl/webgpu` rendering contexts
+
+Read-only investigation. No file in `/home/user/ripl` was modified. All findings below were
+traced through the source; those marked **CONFIRMED** were additionally reproduced with throwaway
+probes run against the real packages (vitest + jsdom + `@ripl/test-utils` canvas stub, and the
+`packages/webgpu/test/mock-gpu.ts` harness). Probe files lived in the scratchpad and have been
+deleted; each finding carries a sketch of the test that pins it.
+
+Base contract read first: `packages/core/src/context/context.ts` (`Context`),
+`packages/dom/src/context.ts` (`DOMContext`), `packages/canvas/src/mixins.ts`
+(`canvas2DStateMixin`), `packages/canvas/src/context.ts` (`CanvasContext`, the 2D reference
+implementation), and the driving pipeline in `packages/core/src/core/{element,group,scene,renderer,shape}.ts`.
+
+---
+
+## 0. How the two contexts actually work (needed to read the findings)
+
+`CanvasContext3D` = `canvas2DStateMixin(Context3D)`, i.e. a *deferred* renderer bolted onto an
+*immediate* one:
+
+* `Element.render` (element.ts:877) → `markRenderStart` → `save` → `applyElementTransform` →
+  apply `CONTEXT_OPERATIONS` → callback → `restore` → `markRenderEnd`.
+* `Shape3D.render` (shape.ts:253) runs inside that callback but **draws nothing**. It projects
+  each face and pushes a `ProjectedFace3D` record (screen points + fill string + stroke string +
+  lineWidth + depth) onto `context.faceBuffer`.
+* Only when `renderDepth` returns to 0 — i.e. inside `Context.batch`'s `finally`, *after* every
+  element `restore()` and every `popGroup()` has already unwound — does
+  `CanvasContext3D.markRenderEnd` (context.ts:279) sort the buffer back-to-front and paint it.
+
+Everything in §1 flows from that single structural fact: **the drawing state and transform in
+effect when a 3D face is painted are the ones at `batch()`'s save point, not the ones the element
+was rendered with.**
+
+`WebGPUContext3D` extends `Context3D` directly (no canvas mixin). `Shape3D.submitMesh`s an
+interleaved mesh; `markRenderEnd` at depth 0 writes uniforms, flushes pooled buffers and encodes
+one render pass. Hardware depth testing replaces the painter's sort.
+
+---
+
+## 1. `@ripl/3d` — CONFIRMED findings
+
+### 3D-1 (HIGH) A `Shape3D` whose `fill` is not hex/rgb/hsl crashes the whole render pass
+
+`packages/3d/src/core/shape.ts:258` + `:265` + `:392`
+
+```ts
+const baseRGBA = parseColor(baseFillStyle) as ColorRGBA;   // :258  cast hides `undefined`
+ctx.submitMesh({ vertices: triangulateFacesFlat(faces, baseRGBA), ... });  // :265  UNGUARDED
+...
+const cr = color[0] / 255;                                  // :392  throws
+```
+
+`parseColor` (packages/core/src/color/index.ts:82) only matches hex / rgb / rgba / hsl / hsla /
+hsv / hsva. **Named CSS colours are not supported** — `parseColor('red')` returns `undefined`.
+`_renderCPU` guards this at :289 (`baseRGBA ? … : baseFillStyle`), but the `submitMesh` call at
+:265 runs *first* and is unguarded, so the guard is dead code.
+
+Failure scenario: `new Cube({ size: 1, fill: 'red' })` in a scene →
+`TypeError: Cannot read properties of undefined (reading '0')` thrown out of `Scene.render`. Same
+for `'steelblue'`, `'currentColor'`, `'transparent'`, any `linear-gradient(...)`, any
+`pattern(...)`, any CSS variable. Affects the GPU path identically (the call is on the shared path).
+
+Amplifier: `Renderer._tick` (renderer.ts:281-287) re-arms `requestAnimationFrame` *after* the
+`batch` call, so the exception escapes before the loop is rescheduled while `_running` stays
+`true` — `start()` then no-ops. **One bad fill colour permanently kills the animation loop.**
+(Verified: after the throw `renderDepth` and `saveDepth` are correctly unwound by `batch`'s
+`finally`, so the damage is purely the dead loop.)
+
+Test: `expect(() => { scene.add(new Cube({ size: 1, fill: 'red' })); scene.render(); }).not.toThrow()`
+and assert `context.faceBuffer[0].fillColor === 'red'` (the documented degrade path).
+
+---
+
+### 3D-2 (HIGH) The deferred face draw discards every piece of context state, including all 2D transforms
+
+`packages/3d/src/core/context.ts:279-304` (`markRenderEnd`) and `:306-343` (`_drawFace`)
+
+`_drawFace` writes directly to the raw `CanvasRenderingContext2D` using only
+`face.fillColor` / `face.strokeStyle` / `face.lineWidth`. Everything else the element and its
+ancestor groups pushed onto the context has been restored away by the time it runs.
+
+Reproduced op sequence for `group{translateX:100,translateY:50} > Cube{translateX:7}` (real
+save/restore semantics installed on the stub):
+
+```
+save                      // batch()
+save  translate(100,50)   // pushGroup(group)
+save  translate(7,0)      // Cube render
+restore                   // Cube render end
+restore                   // popGroup
+save                      // markRenderEnd -> layer()
+moveTo(223.6,173.6) FILL  x6   <-- faces painted here, all transforms gone
+restore
+restore
+```
+
+Concretely dropped for every 3D face:
+
+| state | evidence |
+|---|---|
+| element `opacity` and group `opacity` | `globalAlpha` measured as `1` at all six fills for `group{opacity:0.25} > Cube{opacity:0.5}` |
+| `globalCompositeOperation` | measured `'source-over'` for `Cube{globalCompositeOperation:'multiply'}` |
+| `filter`, `shadow*`, `lineDash*`, `lineJoin`, `lineCap`, `miterLimit` | never carried in `ProjectedFace3D` |
+| element `translateX/Y`, `rotation`, `transformScaleX/Y`, `transformOrigin*` | applied then unwound before the draw |
+| every ancestor group transform | same |
+| any group-scoped clip | `popGroup` unwinds it before `markRenderEnd` (see 3D-13) |
+
+Failure scenario: `scene > group{opacity: 0.2} > Cube` renders the cube fully opaque. Putting a
+3D chart inside a `group{translateX: 40}` axis-inset group leaves the 3D content unmoved while the
+2D axes shift — and `cube.getBoundingBox()` *does* include the translate, so the model's idea of
+where the shape is diverges from what is painted and from what `hitPath` covers.
+
+This is the root cause behind 3D-3, 3D-8 and 3D-9 as well.
+
+Test: install a save/restore-honouring canvas stub, render
+`group{opacity:0.25} > Cube{opacity:0.5}`, and assert `globalAlpha === 0.125` at each `fill()`;
+separately assert that a group `translateX: 100` shifts the recorded `moveTo` x by 100.
+
+---
+
+### 3D-3 (HIGH) Faces that declare a `normal` are shaded with the **local**, untransformed normal
+
+`packages/3d/src/core/shape.ts:287`
+
+```ts
+const transformed = this.transformVertices(face.vertices, matrix);  // world space
+const normal = face.normal ?? computeFaceNormal(transformed);       // LOCAL when declared
+```
+
+The `??` branch is world-space and correct; the declared branch is model-space and is never
+multiplied by the model matrix. Every element that hard-codes normals is affected:
+`Cube` (all 6 faces, elements/cube.ts:53-78), `Plane` (elements/plane.ts:56),
+`Cylinder` caps (elements/cylinder.ts:101,110), `Cone` base (elements/cone.ts:86).
+
+Failure scenario: `cube.rotationY = 0.6435; cube.rotationX = 0.3` — the six projected polygons
+move correctly but the six fill colours are **byte-identical** to the unrotated cube
+(`["rgba(77,0,0,1)","rgba(180,0,0,1)", …]` before and after). A rotating cube looks like a moving
+flat sticker. A `Sphere` (no declared normals) re-shades correctly under the same rotation,
+confirming the mechanism.
+
+Note the GPU path is *right*: the WGSL vertex shader does
+`normalize((model.normalMatrix * vec4f(input.normal, 0.0)).xyz)` (shaders.ts:35), and
+`triangulateFacesFlat` correctly emits the local normal for the shader to transform
+(shape.ts:401). So **CPU and GPU rendering of the same scene disagree** — CPU shading is the
+broken one.
+
+Test: render a `Cube` at `rotationY = 0`, snapshot `faceBuffer.map(f => f.fillColor)`, set
+`rotationY = Math.PI / 4`, re-render, and assert the colour multiset changed.
+
+---
+
+### 3D-4 (HIGH) Geometry properties do not animate — transitions bypass the face cache
+
+`packages/3d/src/core/shape.ts:184` + `:187-190`, against `packages/core/src/core/element.ts:864-874`
+
+`Shape3D` caches `computeFaces()` and only invalidates it from its `setStateValue` override:
+
+```ts
+protected override setStateValue<TKey extends keyof TState>(key, value) {
+    super.setStateValue(key, value);
+    this._getCachedFaces.invalidate();      // :189
+}
+```
+
+But `Element.interpolate`'s per-frame tick writes straight to the state bag:
+
+```ts
+objectForEach(mappedIntpls, (key, value) => {
+    this.state[key] = value(time) as TState[keyof TState];   // element.ts:871 — no setter
+});
+```
+
+so the cache is never invalidated during a transition.
+
+Failure scenario: `renderer.transition(cube, { duration: 500, state: { size: 3 } })` finishes with
+`cube.size === 3` while the rendered geometry is still the size-1 mesh. Measured screen span:
+57.735 px before, **57.735 px after** the interpolation to `size: 3` (the direct setter
+`cube.size = 3` correctly yields 222.692 px). Affects `Cube.size`, `Sphere.radius/segments/rings`,
+`Cylinder.radiusTop/radiusBottom/height/segments`, `Cone.radius/height/segments`,
+`Plane.width/height`, `Torus.radius/tube/radialSegments/tubularSegments`.
+
+Confusingly *partial*: `x/y/z/rotationX/Y/Z` still animate, because `getModelMatrix()` (shape.ts:196)
+reads the live accessors rather than the cache. So a transition on `{ x, size }` moves but does
+not grow. It also poisons `_getLocalBoundingBox` (shape.ts:225) for the same reason.
+
+Test: `const tick = cube.interpolate({ size: 3 }); tick(1); scene.render();` then assert the
+projected x-span grew.
+
+---
+
+### 3D-5 (MEDIUM) `lightMode: 'world'` and `'camera'` are swapped
+
+`packages/3d/src/core/context.ts:192-198`
+
+```ts
+public getLightDirectionForRender(): Vector3 {
+    if (this.lightMode === 'world') {
+        return mat4TransformDirection(this.viewMatrix, this.lightDirection);  // -> VIEW space
+    }
+    return this.lightDirection;                                               // stays WORLD space
+}
+```
+
+Both consumers dot this against a **world-space** normal — CPU: `computeFaceBrightness(normal,
+normalizedLight, true)` where `normal` came from world-space vertices (shape.ts:287-288); GPU:
+`dot(worldNormal, normalize(-uniforms.lightDirection))` (shaders.ts:57-59). Transforming the light
+into view space and dotting it with a world normal makes the result camera-dependent, which is the
+exact opposite of "fixed in world space".
+
+Measured with `lightDirection: [0, 0, -1]`:
+
+| camera | `world` mode | `camera` mode |
+|---|---|---|
+| `[0,0,5]` | `[0, 0, -1]` | `[0, 0, -1]` |
+| `[5,0,0]` | `[1, 0, 0]` ← rotated with the camera | `[0, 0, -1]` ← fixed |
+
+Failure scenario: with the documented default `lightMode: 'world'`, orbiting the camera around a
+static cube re-lights every face as though the lamp were bolted to the camera; selecting
+`'camera'` freezes the lighting in world space. The two branches are simply exchanged (or,
+equivalently, the normals should be transformed to view space too).
+
+Test: `context.lightMode = 'world'`; render, snapshot face colours, `setCamera` to an orbited
+position, re-render, assert colours unchanged. Then the inverse for `'camera'`.
+
+---
+
+### 3D-6 (MEDIUM) `Shape3D`'s bounding box is camera-dependent but cached against element state
+
+`packages/3d/src/core/shape.ts:218-251` against `packages/core/src/core/element.ts:776` / `:801`
+
+`Shape3D._getLocalBoundingBox()` is not a local box at all — it projects every transformed vertex
+through `context.project(...)` and returns a **screen-space** box. `Element.getBoundingBox` caches
+that against `this._stateVersion` (and, for the world box, against the world matrix identity).
+Neither key includes the camera or the context, and `Shape3D` invalidates only its face cache
+(:189), never the box caches.
+
+Failure scenario (reproduced): render a `Cube` with the camera at `[0,0,5]` →
+`getBoundingBox()` = 57.74 × 57.74 at (171.13, 121.13). Move the camera to `[0,0,40]`, re-render →
+`getBoundingBox()` **still returns 57.74 × 57.74 at (171.13, 121.13)**. Touching any state
+property (`cube.fill = '#00ff00'`) makes the next read jump to the correct 6.58 × 6.58.
+
+This is the "paint cached in a way that confuses the two" hazard the audit brief asked about. It
+poisons three consumers: `CanvasContext3D.gradientBounds()` (context.ts:248), so a 3D shape's
+gradient bounds freeze at the first camera; `Renderer._renderBoundingBoxes` (renderer.ts:300), which
+outlines stale rectangles; and `Element.intersectsWith`'s fallback box test (element.ts:832) when
+`hitPath` is absent. It would also mis-answer for one element rendered into two contexts.
+
+Test: render, read `getBoundingBox()`, `context.setCamera` further away, render again, assert the
+box shrank.
+
+---
+
+### 3D-7 (MEDIUM) The `gradientBounds()` override double-applies the transform for 2D elements, and is dead for 3D shapes
+
+`packages/3d/src/core/context.ts:247-250`
+
+```ts
+// 3D faces project into screen space, so gradients resolve against the world box, not the local box.
+protected gradientBounds(): Box | undefined {
+    return this.currentRenderElement?.getBoundingBox?.();      // world box
+}
+```
+vs. the 2D backend's `packages/canvas/src/mixins.ts:332-334`, which uses `getBoundingBox(true)`
+(local box).
+
+The override is **incoherent on both sides**:
+
+*For 3D shapes it is dead.* `Shape3D._getLocalBoundingBox()` already returns projected screen
+coordinates, so `getBoundingBox(true)` and `getBoundingBox(false)` differ only by the (ignored, see
+3D-2) 2D transform. And `_drawFace` (context.ts:324-328) assigns `ctx.fillStyle = face.fillColor`
+per face, so the `CanvasGradient` the mixin's `fill` setter built is overwritten before any face is
+drawn. Nothing in the 3D path consumes it. (And as of 3D-1 a gradient fill on a `Shape3D` throws
+before reaching it at all.)
+
+*For plain 2D elements hosted in a 3D scene it is actively wrong.* Canvas gradients are resolved in
+user space at paint time, so the CTM already carries the element's and its groups' transforms;
+feeding it the world box applies them a second time. Reproduced with an identical graph —
+`group{translateX:100,translateY:50} > circle{cx:20,cy:20,r:10, fill:'linear-gradient(...)'}`:
+
+```
+CanvasContext3D : translate(100,50) -> createLinearGradient(120,80,120,60) -> FILL
+CanvasContext   : translate(100,50) -> createLinearGradient( 20,30, 20,10) -> FILL
+```
+
+The 2D backend paints the gradient exactly over the circle at (120,70). The 3D backend paints it at
+(220,120) — a 100 × 50 px offset, i.e. the transform counted twice. With a rotated or scaled group
+the gradient also skews.
+
+Test: as above — assert `createLinearGradient` receives the same arguments for the same graph on
+both contexts.
+
+---
+
+### 3D-8 (MEDIUM) `_drawFace`'s style cache records a `lineWidth` it never applied
+
+`packages/3d/src/core/context.ts:294-341`
+
+```ts
+this._drawFace(face, lastFill, lastStroke, lastLineWidth);
+lastFill      = face.fillColor;
+lastStroke    = face.strokeStyle ?? '';
+lastLineWidth = face.lineWidth ?? -1;      // :301 — recorded unconditionally
+```
+```ts
+ctx.fill();
+if (!face.strokeStyle) { return; }                                        // :330 — early exit
+if (face.lineWidth !== undefined && face.lineWidth !== lastLineWidth) {   // :338
+    ctx.lineWidth = face.lineWidth;
+}
+```
+
+A face with a `lineWidth` but no `strokeStyle` returns at :330 without touching `ctx.lineWidth`,
+yet the loop still records that width as "last applied". The next stroked face with the same width
+sees a cache hit and never assigns it.
+
+Failure scenario (reproduced): `Cube{z:-2, lineWidth:8}` (no stroke) and
+`Cube{z:2, lineWidth:8, stroke:'#000'}`. Back-to-front sorting draws the un-stroked cube first; all
+six strokes on the near cube then execute at **`lineWidth = 1`** (the value restored by
+`markRenderEnd`'s `layer()`), not 8. Measured: `[1,1,1,1,1,1]`.
+
+`strokeStyle` avoids the same trap only by luck (`lastStroke` is reset to `''` on the early exit).
+
+Test: the two-cube setup above with a `lineWidth` accessor spy; assert every `stroke()` sees 8.
+
+---
+
+### 3D-9 (MEDIUM) 2D elements always paint *beneath* 3D geometry, regardless of scene order
+
+`packages/3d/src/core/context.ts:279`
+
+2D shapes draw immediately during their `render`; 3D faces are flushed once at depth 0, after every
+element has drawn. Reproduced: `scene.add(cube); scene.add(circle)` (circle later in paint order)
+gives `["2D-path", "3D-face" × 6]` — the circle is painted first and then covered.
+
+Failure scenario: a `Text` label or legend added after a 3D chart is hidden behind the geometry
+with no way to bring it forward (`Shape3D.zIndex` is derived from depth and its setter only warns,
+shape.ts:165-171).
+
+Same class, debug-only: `Renderer._renderBoundingBoxes` and `_renderDebugOverlay` run inside the
+`batch` body, so `markRenderEnd`'s face flush paints over them. Measured order:
+`["stroke(bbox)", "fill(fps-bg)", "fillText(fps)", "fill(3d-face)" × 6]`.
+
+Test: `scene.add(cube); scene.add(circle);` assert the circle's `fill(path)` is recorded after the
+last bare `fill()`.
+
+---
+
+### 3D-10 (MEDIUM) A resize silently reverts an orthographic projection to perspective
+
+`packages/3d/src/core/context.ts:149-159` and `:265` (mirrored at `packages/webgpu/src/context.ts:144`)
+
+`updateProjectionMatrix()` unconditionally builds `mat4Perspective`, and `rescale` calls it on every
+size change. `setOrthographic` (context.ts:178-189) writes the matrix directly and records no mode,
+and `Camera` only flushes when its own state is dirtied — a resize does not dirty it.
+
+Failure scenario (reproduced): `context.setOrthographic(-4,4,-3,3,0.1,100)` → `m[11]=0, m[15]=1`.
+Resize the container → `m[11]=-1, m[15]=0`, i.e. a perspective matrix; the chart silently gains
+perspective distortion on the first window resize. `camera.projection` still reports
+`'orthographic'`.
+
+Test: `createCamera(context, { projection: 'orthographic' }); rescale(800,600);` and assert
+`projectionMatrix[15] === 1`.
+
+---
+
+### 3D-11 (MEDIUM) Picking order (per-shape mean depth) disagrees with paint order (per-face depth)
+
+`packages/3d/src/core/shape.ts:307-309` and `:165-167`, against `packages/core/src/context/context.ts:676-696`
+
+The CPU renderer sorts **faces** globally by their own depth, but `Shape3D._depth` is the *mean*
+of that shape's face depths and `zIndex` is `-_depth`, which is what `Context.hitTest` sorts by.
+For a shape that spans depth, its nearest face can be in front of another shape while its mean is
+behind.
+
+Measured with a rotated 4-unit `Cube` (`rotationX: 1.2`) and a small cube in front of its near
+edge: slab `zIndex = -0.96243`, chip `zIndex = -0.95465` (chip wins the hit test), while the
+globally nearest face has depth `0.95031` and belongs to the **slab**. Wherever that face covers
+the chip, the pixel shows the slab but a click reports the chip.
+
+Note the GPU path uses `_depth = context.project([x,y,z])[2]` (shape.ts:323) — the shape origin —
+which is a different metric again, so picking is not consistent between the two strategies either.
+
+Test: build the overlap above, assert `hitTest` at a pixel where the slab is painted on top
+returns the slab.
+
+---
+
+### 3D-12 (MEDIUM) `Camera` hijacks touch even when every interaction is disabled
+
+`packages/3d/src/core/camera.ts:392-489`
+
+The mouse/wheel blocks are guarded (`if (zoomConfig.enabled)`, `if (pivotConfig.enabled ||
+panConfig.enabled)`), but the touch block at :392-489 is unconditional, as is
+`element.style.touchAction = 'none'` at :330. Every handler calls `event.preventDefault()` before
+consulting the per-interaction flags.
+
+Failure scenario (reproduced): `createCamera(context, { interactions: { zoom: false, pivot: false,
+pan: false } })` attaches `touchstart`, `touchmove`, `touchend` and sets `touch-action: none`.
+On a phone the user cannot scroll the page past the chart, and no camera motion happens either.
+
+Test: attach with all three disabled and assert no touch listeners were added and
+`element.style.touchAction === ''`.
+
+---
+
+### 3D-13 (LOW) Clip scoping for 3D faces is inconsistent between group and root clips
+
+`packages/3d/src/core/context.ts:279` with `packages/core/src/context/context.ts:565-571`
+
+A `Shape2D { clip: true }` renders with `skipRestore`, deliberately leaving a dangling `save()`.
+`popGroup` (context.ts:565) unwinds to the recorded depth, so a **group-scoped** clip is gone
+before `markRenderEnd` flushes the faces. A **root-level** clip is only unwound by `batch`'s final
+`restore()`, which runs *after* `markRenderEnd` — so it *does* mask the 3D geometry. Identical
+markup therefore clips or doesn't depending on whether the clip shape sits in a group.
+
+Related (shared with the 2D backend, not 3D-specific): a root-level clip shape leaks one native
+save per frame. Reproduced on a plain `CanvasContext`: `saveDepth` after four `scene.render()`
+calls is `[1, 2, 3, 4]` — unbounded growth of the canvas state stack. Worth fixing in
+`Context.batch`/`Scene.render` rather than here.
+
+Test: render `group > clipCircle + cube` and `clipCircle + cube` at root, assert the same clip
+call count is in effect at face-draw time.
+
+---
+
+### 3D-14 (LOW) The CPU path builds and throws away a full GPU mesh every frame
+
+`packages/3d/src/core/shape.ts:263-269`
+
+```ts
+// This is noop for CPU render strategies. Safe to call on all paths.
+ctx.submitMesh({ vertices: triangulateFacesFlat(faces, baseRGBA), indices: triangulateFacesIndices(faces), … });
+```
+
+Safe, but not free. Measured on `CanvasContext3D` (`renderStrategy === 'cpu'`, `submitMesh` is a
+no-op): one 16 × 12 `Sphere` allocates **7 360 floats (29 KB) + 1 056 indices (4 KB) per frame**,
+immediately garbage. At 60 fps with 20 spheres that is ~40 MB/s of pure churn, plus the O(vertices)
+copy loop. Gate it on `ctx.renderStrategy === 'gpu'`.
+
+Test: `vi.spyOn(context, 'submitMesh')`; assert 0 calls when `renderStrategy === 'cpu'`.
+
+---
+
+### 3D-15 (LOW) `CanvasContext3D` loses path caching for the 2D elements it hosts
+
+`packages/3d/src/core/context.ts:228`
+
+`CanvasContext.supportsPathCaching` is overridden to `true` (canvas/src/context.ts:29-31) because
+`createPath` is a side-effect-free `new CanvasPath()`. `CanvasContext3D` composes the same mixin
+but never overrides it, so it inherits the base `false` (context.ts:627). Measured: `false` on
+`CanvasContext3D`, `true` on `CanvasContext`. Every `Shape2D` in a 3D scene re-traces its path every
+frame even when unchanged (`Shape2D.render`, core/shape.ts:143-147).
+
+Test: `expect(createContext3D(target).supportsPathCaching).toBe(true)`.
+
+---
+
+### 3D-16 (LOW) No back-face culling on the CPU path
+
+`packages/3d/src/core/shape.ts:285-304`
+
+Every face is transformed, shaded, projected, buffered, sorted and filled. Measured: 192 faces
+buffered for a single 16 × 12 sphere, roughly half of which face away and are overdrawn. Doubles
+fill cost and sort cost, and with any `fill` alpha < 1 the hidden back faces visibly bleed through
+(the painter's algorithm blends each of them separately). A `dot(normal, viewDir) <= 0` reject
+before the `faceBuffer.push` would halve the work. (Marked "by design gap", not "implemented
+wrongly": the GPU pipeline deliberately sets `cullMode: 'none'`, pipeline.ts:141.)
+
+---
+
+### 3D-17 (LOW) Degenerate camera/lookAt inputs produce silent NaN or a collapsed view
+
+* `packages/3d/src/core/camera.ts:254-272` — `orbit` divides by `dist`; with `position === target`
+  the result is `[NaN, NaN, NaN]` and the view matrix becomes all-NaN (reproduced), permanently
+  blanking the scene with no error.
+* `packages/3d/src/math/matrix.ts:117-121` — `mat4LookAt` with `up` parallel to the view direction
+  yields `xAxis = [0,0,0]` (via `vec3Normalize`'s zero-length early return, vector.ts:47) and a
+  rank-deficient view matrix. Reproduced: `setCamera([0,5,0],[0,0,0],[0,1,0])` makes *every* point
+  project to the viewport centre `(200, 150)`. `Camera.orbit` clamps `phi` to avoid this, but
+  `setCamera` / `camera.position = …` do not.
+* `packages/3d/src/core/camera.ts:299-307` — `zoom` clamps to `dist - 0.01`, letting the eye reach
+  0.01 units from the target while `near` defaults to 0.1, so a full zoom-in empties the frustum
+  (and on WebGPU also trips 3D-18/WGPU-1).
+
+---
+
+### 3D-18 (LOW, by design but undefended) No near-plane clipping in the CPU projection
+
+`packages/3d/src/math/matrix.ts:200-212`
+
+`mat4TransformPoint` performs the perspective divide with no `w` sign test and forces `invW = 1`
+when `w === 0`. Reproduced with the default 60°/0.1/1000 frustum:
+
+| world point | projected |
+|---|---|
+| in front `(1, 0, -5)` | `x = 0.2598` |
+| behind `(1, 0, +5)` | `x = -0.2598` ← mirrored through the origin |
+| at the eye plane `(1, 0, 0)` | `x = 1.2990`, no divide |
+
+So geometry that straddles the camera renders inside-out on the CPU path. The GPU path clips
+correctly, so this is another CPU/GPU divergence. Reasonable to document as a limitation of the
+painter's renderer, but `mat4TransformPoint` silently swallowing `w <= 0` makes it invisible.
+
+---
+
+### 3D-19 (LOW) Depth bookkeeping is undefended
+
+* `packages/core/src/context/context.ts:497-499` — `markRenderEnd` decrements without a floor.
+  Reproduced: a stray `markRenderEnd()` drives `renderDepth` to `-1`; the following
+  `markRenderStart()` reaches `0`, so `CanvasContext3D`'s `renderDepth === 1` guard
+  (context.ts:273) never fires and the face buffer is not cleared for that frame. All in-tree call
+  sites are `try/finally`-balanced, so this is **SUSPECTED-unreachable** through the public
+  pipeline — a robustness gap, not a live bug.
+* `packages/3d/src/core/context.ts:100` — the base `Context3D` owns `faceBuffer` but only
+  `CanvasContext3D` ever clears it. Reproduced: a `Context3D` running the default
+  `renderStrategy: 'cpu'` accumulates faces across frames without bound and paints none.
+* `packages/3d/src/core/context.ts:121-127` and `packages/webgpu/src/context.ts:75-81` — the meta
+  spread puts `...options?.meta` **after** the hard-coded strategy, so
+  `new WebGPUContext3D(…, { meta: { renderStrategy: 'cpu' } })` downgrades a GPU context into CPU
+  mode: blank canvas plus the unbounded `faceBuffer` above. Put the invariant last.
+
+---
+
+### 3D-20 (item 10) Driving a 3D element from a plain 2D context is a hard crash
+
+`packages/3d/src/core/shape.ts:264`
+
+Reproduced: a `Cube` in a `CanvasContext` scene throws
+`TypeError: ctx.submitMesh is not a function` — the very first thing `Shape3D.render` does is cast
+`context as Context3D` (:255) and call `submitMesh`, which exists only on `Context3D`. It would
+subsequently also need `renderStrategy`, `faceBuffer`, `getLightDirectionForRender` and `project`.
+Not graceful. A `typeIsContext3D` guard falling back to `super.render` (or a clear
+`"Shape3D requires a Context3D"` error) would be.
+
+The reverse direction is graceful on `CanvasContext3D` (2D elements draw normally, modulo 3D-9 and
+3D-15) and **silent** on `WebGPUContext3D` — see WGPU-3.
+
+---
+
+## 2. `@ripl/webgpu` — findings
+
+### WGPU-1 (MEDIUM) The projection uses the OpenGL `[-1, 1]` depth convention; WebGPU NDC z is `[0, 1]`
+
+`packages/3d/src/math/matrix.ts:148-162` (`mat4Perspective`) and `:165-188` (`mat4Orthographic`),
+consumed by `packages/webgpu/src/context.ts:266` and `packages/webgpu/src/pipeline.ts:144-148`.
+
+`out[10] = (near + far) / (near - far)`, `out[14] = 2·near·far / (near - far)` is the GL mapping:
+near → `-1`, far → `+1`. WebGPU clips to `0 ≤ z ≤ w`. Measured for `fov 60°, near 0.1, far 1000`:
+
+| view-space distance | `z_ndc` |
+|---|---|
+| 0.1 (near plane) | **-1.0000** |
+| 0.15 | **-0.3333** |
+| 0.2 | 0.0001 |
+| 1 | 0.8002 |
+| 5 | 0.9602 |
+| 1000 (far plane) | 1.0000 |
+
+Two consequences on the GPU path only (the CPU painter uses `z` purely as a monotonic sort key, so
+it is unaffected):
+
+1. **Everything between `near` and ≈`2·near·far/(near+far)` (≈0.2 units here) is clipped away.**
+   Concrete: `camera.zoom` until the target is 0.15 units from the eye — the mesh vanishes on
+   `WebGPUContext3D` while it still renders on `CanvasContext3D`. `Camera.zoom` allows the eye to
+   reach 0.01 units, so this is easy to hit.
+2. Only the `[0, 1]` half of the depth buffer is usable, and the scene is compressed into its top
+   end (`[0.80, 1.00]` for the 1–5 unit range) — roughly a 2× loss of depth resolution on top of the
+   usual `1/z` non-linearity, which makes z-fighting between coplanar faces more likely than it
+   should be.
+
+Fix shape: a WebGPU/D3D-style matrix (`out[10] = far / (near - far)`, `out[14] = far·near /
+(near - far)`, and `out[10] = 1/(near-far)`, `out[14] = near/(near-far)` for ortho), which also
+keeps `depthClearValue: 1.0` + `depthCompare: 'less'` correct.
+
+Test: `expect(mat4TransformPoint(mat4Perspective(fov, aspect, 0.1, 1000), [0,0,-0.1])[2]).toBe(0)`
+and `…[0,0,-1000])[2]).toBe(1)`.
+
+---
+
+### WGPU-2 (MEDIUM) `rescale` reads `window.devicePixelRatio` instead of `factory.devicePixelRatio`
+
+`packages/webgpu/src/context.ts:119`
+
+```ts
+const dpr = window.devicePixelRatio;
+```
+
+Every other backend goes through the injectable factory —
+`packages/canvas/src/utilities.ts:237` (`rescaleCanvas`) and
+`packages/core/src/context/context.ts:412` (`scaleDPR`). Because `scaleX`/`scaleY`/`scaleDPR` are
+derived from the factory value while the canvas backing store and the hit canvas transform
+(context.ts:127-133) are derived from `window`, any consumer that overrides
+`factory.devicePixelRatio` (tests, offscreen/server rendering, a DPR cap) desynchronises the two:
+pointer coordinates are scaled by one ratio and the hit paths by another, so picking silently
+misses by that factor. `window` may also be absent in a non-DOM environment, yielding
+`element.width = NaN`.
+
+Test: `factory.set({ devicePixelRatio: 2 })` with `window.devicePixelRatio === 1`; assert
+`context.element.width === logicalWidth * 2`.
+
+---
+
+### WGPU-3 (MEDIUM, item 10) 2D elements silently render nothing but remain in the hit-test set
+
+`packages/webgpu/src/context.ts:50` (no `applyFill` / `applyStroke` / `applyClip` / `drawImage` /
+`createText` override)
+
+`WebGPUContext3D` extends `Context3D` directly, so those five stay as the base no-ops
+(context.ts:641-659). `createPath` (webgpu/context.ts:215) *does* return a real `CanvasPath`, so
+`Shape2D.render` happily traces its path and then paints nothing.
+
+Reproduced: a `Circle` and a `Text` added to a WebGPU scene produce **zero** encoded draws and
+throw nothing. Because the path is still populated, `Shape2D.intersectsWith` (core/shape.ts:96)
+still runs against it — the elements are invisible but clickable.
+
+Failure scenario: a chart author mixes a 3D series with 2D axis labels; on canvas it works, on
+WebGPU the labels disappear with no diagnostic while their tooltips still fire.
+
+Either implement the 2D ops against the existing `_hitContext` compositing pass, or make the
+no-ops loud (`console.warn` once, or throw on first use).
+
+---
+
+### WGPU-4 (MEDIUM) Inherits 3D-10 (orthographic → perspective on resize) and 3D-19 (meta override)
+
+`packages/webgpu/src/context.ts:144` and `:75-81`. Same mechanism, same failure; see above. The
+meta case is worse here because the class's whole contract depends on `renderStrategy === 'gpu'`:
+a caller-supplied `meta` silently routes rendering into `Shape3D._renderCPU`, filling a
+`faceBuffer` that `WebGPUContext3D` never clears and never draws → blank canvas plus an unbounded
+array.
+
+---
+
+### WGPU-5 (LOW) `GeometryManager.flush()` has no destroyed guard
+
+`packages/webgpu/src/geometry.ts:73-132` / `:135-149`
+
+`destroy()` nulls the buffers and empties the pools; `flush()` then happily recreates GPU buffers
+on the device. Reproduced: `destroy()` → `beginFrame()` → `submit()` → `flush()` creates three new
+buffers with **no error** (on a real, destroyed device those calls raise validation errors).
+
+Unreachable through `WebGPUContext3D` (`submitMesh` :182, `markRenderStart` :193 and
+`_executeRenderPass` :253 are all `_destroyed`-guarded — verified: rendering a scene after
+`context.destroy()` is a silent no-op that allocates nothing). But `GeometryManager` is a public
+export (`packages/webgpu/src/index.ts:2`), so a direct consumer can hit it. A `_destroyed` flag
+returning `null` from `flush` would close it.
+
+---
+
+### WGPU-6 (LOW) Per-frame texture-view churn and destroy-path loose ends
+
+`packages/webgpu/src/context.ts:280`, `:310`, `:339-346`
+
+* `this._depthTexture.createView()` and `this._msaaTexture.createView()` are called on **every
+  frame**. Views are immutable and cheap to cache alongside the textures in
+  `_recreateDepthTexture` / `_recreateMSAATexture`; allocating two per frame is avoidable garbage.
+* `destroy()` does not `this._gpuContext.unconfigure()`, leaving the swap chain configured on a
+  detached canvas (**SUSPECTED** minor GPU retention until GC — I could not verify browser behaviour
+  from here).
+* `destroy()` leaves `_depthTexture` / `_msaaTexture` non-null after destroying them, and
+  `rescale` (:118) has no `_destroyed` guard — a resize delivered post-destroy would allocate
+  textures that are never released. Not reachable in-tree (the `ResizeObserver` disposer runs during
+  `super.destroy()`), so **SUSPECTED-unreachable**, but the guard is one line.
+* `GeometryManager.destroy()` does not clear `_submissions`, so the last frame's vertex/index typed
+  arrays stay reachable from a destroyed manager. Trivial.
+
+---
+
+### WGPU-7 (LOW) A container that is exactly the default canvas size never initialises
+
+`packages/webgpu/src/context.ts:123-125` (and `packages/canvas/src/utilities.ts:241-243`)
+
+```ts
+if (scaledWidth === this.element.width && scaledHeight === this.element.height) { return; }
+```
+
+A freshly created `<canvas>` is 300 × 150. If the host element measures exactly 300 × 150 CSS px at
+DPR 1, `rescale` returns before `super.rescale`, so `this.width/height` stay `0`,
+`_recreateDepthTexture` is never called, and `_executeRenderPass` bails at :260 forever — a
+permanently blank canvas. `CanvasContext3D` has the same hole via `rescaleCanvas` (the projection
+matrix stays identity, verified: `project([0,0,0]) === [0,0,0]` with a zero-size container). Compare
+against `this.width`/`this.height` rather than the canvas backing store, or force a first pass.
+
+---
+
+### WGPU-8 (LOW) `clearColor` is documented as straight RGBA but the surface is premultiplied
+
+`packages/webgpu/src/context.ts:45-46` and `:380`
+
+`gpuContext.configure({ alphaMode: 'premultiplied' })`, so `clearValue` must be premultiplied too.
+`clearColor: [1, 0, 0, 0.5]` is out of gamut for a premultiplied surface (r > a) and is
+implementation-defined. Either document it as premultiplied or premultiply it on the way in. The
+default `[0,0,0,0]` is fine.
+
+---
+
+## 3. Explicitly verified as correct (no defect found)
+
+Checked and clean — recording these so the negative results are visible:
+
+**Matrix / shader math.** `mat4Multiply` implements `A·B` for the documented column-major layout;
+`mat4TransformPoint` indexes columns correctly; `getModelMatrix` composes `T·Rx·Ry·Rz` (rotation
+about the shape's own origin, then translation) which matches the WGSL
+`modelMatrix * vec4f(position, 1.0)`; `mat4Orthographic` is the standard GL form. Passing the
+model matrix as the normal matrix is valid here because the shader multiplies with `w = 0`, so the
+translation column drops out, and `Shape3D` exposes no scale.
+
+**WGSL uniform layout.** `SCENE_UNIFORM_SIZE = 80` matches `mat4x4f`(0..63) + `vec3f`(64..75,
+align 16) + `f32`(76..79), and the JS writes float slots 16/17/18/19 accordingly.
+`MODEL_UNIFORM_SIZE = 128` matches two `mat4x4f`. Bind-group visibility flags (`0x3` scene =
+VERTEX|FRAGMENT, `0x1` model = VERTEX) match the shaders' actual usage. `Float32Array.set(Float64Array)`
+does perform the element-wise narrowing conversion.
+
+**Blend / MSAA.** `src-alpha / one-minus-src-alpha` colour with `one / one-minus-src-alpha` alpha
+onto a zeroed target yields a correctly premultiplied framebuffer, matching
+`alphaMode: 'premultiplied'`. The MSAA attachment correctly uses `resolveTarget` +
+`storeOp: 'discard'`. `depthClearValue: 1.0` + `depthCompare: 'less'` is right (given WGPU-1 is fixed).
+
+**Buffer pooling and lifecycle (checklist item 7).** Exercised across 20 simulated scene rebuilds
+alternating 1 ↔ 30 meshes and 2 ↔ 25 spheres through a real `WebGPUContext3D`:
+staging arrays and GPU buffers grow in powers of two and only when exceeded; the superseded buffer
+is destroyed on growth; buffers are *not* recreated when a frame shrinks; `writeBuffer` uploads only
+the used prefix; per-mesh indices are rebased into the shared buffer with `baseVertex = 0` passed to
+`drawIndexed`, which is self-consistent; the model-uniform pool ratchets to the peak per-frame mesh
+count (30 buffers / 30 bind groups for a peak of 30) and is then reused, never reallocated;
+`GeometryManager.destroy()` + `WebGPUContext3D.destroy()` leave **0 live buffers and 0 live
+textures**. Stale bytes beyond `indexCount` remain in the index buffer but are never read. No leak
+found across repeated rebuilds.
+
+**Coordinate spaces for hit testing (checklist item 6).** `project()` yields logical CSS pixels;
+`_drawFace` paints them through a CTM carrying the DPR scale; `Context.hitTest` receives device
+pixels from `DOMContext` via `scaleX`; `isPointInPath` compares a CTM-transformed path against a
+canvas-space point — so `CanvasContext3D` is consistent. `WebGPUContext3D` matches it by setting
+`_hitContext.setTransform(dpr,0,0,dpr,0,0)` while the GPU rasterises NDC across the device-pixel
+viewport. `Shape3D` deliberately does **not** consult `hitTestHonorsTransform` (its hit path is
+already screen-space, so the inverse-world-transform mapping `Shape2D` applies would be wrong here)
+— correct in isolation, though it is the same divergence as 3D-2: `getWorldTransform`/`getBoundingBox`
+account for 2D transforms that neither the render nor the hit path does.
+
+**`export()` (checklist item 8).** Both contexts inherit `Context3D.export()` →
+`createCanvasExport(this.element)` (dom/src/export.ts:30), which snapshots into an offscreen 2D
+canvas immediately and returns `{ toString, toURL, toImage }` — the right shape for a WebGPU
+surface whose presented texture is transient. Confirmed the returned object exposes exactly those
+three keys. On `CanvasContext3D` the faces are already flushed by `markRenderEnd` before `batch`
+returns, so a post-render export captures them.
+
+**Paint caches (checklist item 5).** `gradientCache` (canvas/src/utilities.ts:85) stores only the
+*parsed, bounds-independent* `Gradient`, and a fresh `CanvasGradient` is built per use — safe.
+`patternCache` (:105) stores bounds-independent `CanvasPattern`s shared across every context
+instance — safe in practice. `Shape2D`'s path cache is keyed on `_cachedContext === context`, so it
+cannot leak between a 2D and a 3D context. The **one** cache that does confuse the two is
+`Element._localBoxCache` / `_worldBoxCache` — see 3D-6.
+
+**Save/restore and push/pop balance (checklist items 1–3).** `pushGroup`/`popGroup` depth unwinding
+is sound; `Element.render` and `Context.batch` are `try/finally`-balanced (verified: after a thrown
+render callback both `renderDepth` and `saveDepth` return to 0). `markRenderStart`/`markRenderEnd`
+nest correctly at every in-tree call site including a bare `Group.render` outside a `batch`. The
+only imbalance found is the `clip: true` root-level `save` leak, which is a shared core issue
+(3D-13), not a 3D one.
+
+---
+
+## 4. Ranked summary
+
+### `@ripl/3d`
+
+| # | Sev | Finding | Location |
+|---|---|---|---|
+| 3D-1 | **HIGH** | Any non-hex/rgb/hsl `fill` (e.g. `'red'`, a gradient) crashes the render pass and kills the rAF loop | `core/shape.ts:258,265,392` |
+| 3D-2 | **HIGH** | Deferred face draw drops element+group opacity, composite, filter, shadow, clip **and all 2D transforms** | `core/context.ts:279-343` |
+| 3D-3 | **HIGH** | Declared face normals are never transformed by the model matrix — shading frozen under rotation (CPU only; GPU is correct) | `core/shape.ts:287` |
+| 3D-4 | **HIGH** | Geometry-property transitions are visually inert: `Element.interpolate` bypasses the face-cache invalidation | `core/shape.ts:184-190` |
+| 3D-5 | MED | `lightMode` `'world'` / `'camera'` semantics are swapped | `core/context.ts:192-198` |
+| 3D-6 | MED | Camera-dependent bounding box cached against element state → stale gradient bounds, debug boxes, fallback hits | `core/shape.ts:218-251` |
+| 3D-7 | MED | `gradientBounds()` world-box override double-applies the CTM for 2D elements; dead for 3D shapes | `core/context.ts:247-250` |
+| 3D-8 | MED | `_drawFace` caches a `lineWidth` it never applied → strokes at the wrong width | `core/context.ts:294-341` |
+| 3D-9 | MED | 2D elements (and debug overlays) always paint beneath 3D geometry regardless of order | `core/context.ts:279` |
+| 3D-10 | MED | Resize silently reverts an orthographic projection to perspective | `core/context.ts:149-159,265` |
+| 3D-11 | MED | Picking sorts by per-shape mean depth while painting sorts per-face → wrong element picked | `core/shape.ts:165,307` |
+| 3D-12 | MED | `Camera` attaches touch handlers and `touch-action: none` even with all interactions disabled | `core/camera.ts:392-489` |
+| 3D-13 | LOW | Group clips don't reach the face flush but root clips do (+ shared per-frame save leak) | `core/context.ts:279` |
+| 3D-14 | LOW | CPU path builds and discards a full interleaved mesh every frame (~33 KB/sphere/frame) | `core/shape.ts:263-269` |
+| 3D-15 | LOW | `supportsPathCaching` not overridden → hosted 2D shapes re-trace every frame | `core/context.ts:228` |
+| 3D-16 | LOW | No back-face culling on the CPU path (2× fill, alpha bleed-through) | `core/shape.ts:285-304` |
+| 3D-17 | LOW | Degenerate camera inputs give silent NaN / collapsed view matrices | `core/camera.ts:254`, `math/matrix.ts:117` |
+| 3D-18 | LOW | No near-plane clipping: geometry behind the eye projects mirrored (CPU only) | `math/matrix.ts:200-212` |
+| 3D-19 | LOW | `renderDepth` unclamped; base `Context3D` never clears `faceBuffer`; user `meta` overrides `renderStrategy` | `core/context.ts:100,121` |
+| 3D-20 | LOW | `Shape3D` in a plain 2D context throws `ctx.submitMesh is not a function` | `core/shape.ts:264` |
+
+### `@ripl/webgpu`
+
+| # | Sev | Finding | Location |
+|---|---|---|---|
+| WGPU-1 | MED | GL `[-1,1]` depth convention against WebGPU's `[0,1]` NDC → near-band geometry clipped, ~2× depth precision lost | `3d/src/math/matrix.ts:148-188` (consumed at `context.ts:266`) |
+| WGPU-2 | MED | `rescale` uses `window.devicePixelRatio` instead of `factory.devicePixelRatio` → DPR desync breaks picking | `context.ts:119` |
+| WGPU-3 | MED | 2D elements render nothing (base no-op `applyFill`/`applyStroke`/…) yet stay hit-testable | `context.ts:50` |
+| WGPU-4 | MED | Inherits 3D-10 (ortho→perspective on resize) and 3D-19 (`meta` can force `'cpu'` → blank canvas + unbounded `faceBuffer`) | `context.ts:75-81,144` |
+| WGPU-5 | LOW | `GeometryManager.flush()` has no destroyed guard (unreachable via the context, reachable via the public export) | `geometry.ts:73-149` |
+| WGPU-6 | LOW | `createView()` twice per frame; `destroy()` doesn't `unconfigure()`, doesn't null textures, doesn't clear `_submissions`; `rescale` unguarded | `context.ts:280,310,339` |
+| WGPU-7 | LOW | A 300×150 CSS-px container at DPR 1 trips the `rescale` early return → permanently blank | `context.ts:123` |
+| WGPU-8 | LOW | `clearColor` documented as straight RGBA on a premultiplied surface | `context.ts:45,380` |
+
+**Highest-value fixes, in order:** 3D-1 (guard `parseColor` before `triangulateFacesFlat`), 3D-4
+(invalidate the face cache from the interpolator tick, or drop the cache), 3D-3 (transform declared
+normals by the model matrix), 3D-2 (carry the resolved opacity/composite into `ProjectedFace3D`, or
+re-apply the element's state around each face draw), then WGPU-1 (WebGPU-convention projection
+matrices).
+
+**Cross-cutting note for the core package** (out of scope for these two packages but surfaced by
+them): `Renderer._tick` re-arms `requestAnimationFrame` only on the success path, so any exception
+inside `batch` permanently stops the loop; and a root-level `clip: true` shape leaks one native
+canvas `save` per frame on every canvas-backed context.

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,97 @@
+# Rendering context audit
+
+Every `Context` implementation audited against the base contract in
+`packages/core/src/context/context.ts`, one investigation per backend, using a uniform checklist:
+save/restore symmetry · render-depth handling · `pushGroup`/`popGroup` balance and clip scoping ·
+transform composition · paint resolution and def lifecycle · text metrics · hit testing · `export()` ·
+`destroy()` · **parity with canvas for an identical scene**.
+
+| Report | Scope | Confirmed | Highest severity |
+|---|---|---|---|
+| [canvas.md](./canvas.md) | `CanvasContext`, `canvas2DStateMixin`, `CanvasPath` | 18 of 21 | 4 high |
+| [svg.md](./svg.md) | `SVGContext`, definitions, diff, path, text | 17 of 21 | 7 high |
+| [dom-node.md](./dom-node.md) | `DOMContext`, reconciler, navigator, `@ripl/node` | 27 of 28 | 4 high |
+| [terminal.md](./terminal.md) | `TerminalContext`, rasterizer, path | 24 | 5 high |
+| [3d-webgpu.md](./3d-webgpu.md) | `Context3D`, `CanvasContext3D`, `WebGPUContext3D` | 28 | 4 high |
+
+## How to read these
+
+Each finding carries a `file:line`, a concrete failure scenario, a severity, and a test sketch.
+Findings are split into **CONFIRMED** (a code path was traced *and* executed) and **SUSPECTED**
+(reasoning only — typically needing a real browser). Each report also lists what was checked and
+found **correct**, so the negative results are auditable too.
+
+One seed lead was **refuted**: `createFrameBuffer` was suspected of starving the hover hit test
+during a fast drag. It doesn't — `requestAnimationFrame` has an absolute deadline, so cancel and
+reschedule still leaves exactly one callback registered per frame. Measured at 20× a browser's
+delivery rate it produced exactly one hover emission per frame. See `dom-node.md`.
+
+## Verification status
+
+These reports are investigation output. Findings marked CONFIRMED were reproduced by executing the
+real sources, but **only the following were independently re-verified while writing this index**,
+and those are the ones encoded as regression tests in `packages/canvas/test/audit.test.ts`:
+
+- `rescaleCanvas` no-ops on a 300×150 host — `context.width`/`height` stay `0` and `scaleX(150)`
+  returns `0`, so `clear()` becomes `clearRect(0, 0, 0, 0)` and the surface never clears
+- a scene-root `clip: true` shape leaks one `save()` per frame — measured depth `1, 2, 3, 4, 5`
+- `context.fill` reports the inner scope's paint after a `restore()`
+
+Everything else should be re-confirmed before a fix is written against it.
+
+`mockCanvasContext` uses no-op `save`/`restore`, which structurally hides every state-stack defect
+in the canvas package — a test cannot distinguish a context that correctly restores its paint from
+one that never restores anything. `mockCanvasState` (added with this audit) upgrades the stub with a
+real state stack, and is what made the third finding above testable.
+
+## Already fixed
+
+Several findings were fixed in the branches this audit ran alongside, and are marked here rather
+than re-reported:
+
+| Finding | Fixed by |
+|---|---|
+| Group gradient resolves against the previously rendered leaf (`canvas.md` 3, `svg.md` S-4) | `claude/paint-materialization` |
+| A fresh `CanvasGradient` per element per frame (`canvas.md` 12) | `claude/paint-materialization` |
+| Cross-context `CanvasPattern` sharing (`canvas.md` 11) | `claude/paint-materialization` |
+| A group that empties keeps its DOM children (`svg.md` S-1, `dom-node.md` F3) | `claude/svg-commit-model` |
+
+The canvas/SVG group-gradient **parity** gap is characterized in `svg.md` S-4 but deliberately not
+fixed: canvas resolves once at the group boundary against the group's box, SVG emits a `url(#…)` per
+leaf against each leaf's own box, so a group gradient still renders differently between backends.
+S-4 scopes what a fix would have to change.
+
+## Suggested triage
+
+Grouped so each branch is one reviewable PR, with the riskiest changes bundled together.
+
+1. **`fix/canvas-surface-sizing`** — `rescaleCanvas` early return (`canvas.md` 1). Self-contained,
+   high impact: a 300×150 chart never renders at all.
+2. **`fix/root-clip-save-leak`** — the scene-root clip leak (`canvas.md` 2, `terminal.md` F24,
+   `svg.md` S-9). One core defect, three backends observe it; fix in `Context`/`Scene`, verify in each.
+3. **`fix/interaction-lifecycle`** — the pointer-state cluster: drag stranded by an off-surface
+   `mouseup` (`dom-node.md` F2), no element `mouseleave` on surface leave (F4, which leaves chart
+   tooltips painted), `click` after drag (F6), stale `dragElement` (F7), teardown races (F8, F9).
+   These interact; fixing them apart would mean re-reasoning about the same state machine repeatedly.
+4. **`fix/hit-test-ordering`** — `hitTest` sorts by additive z-index rather than paint order
+   (`dom-node.md` F1), plus the memo staleness (F10, F11). `renderedElements` is already exact paint
+   order, so the z-sort discards correct information.
+5. **`fix/svg-clip-and-dpr`** — `applyClip` replaces instead of intersects (`svg.md` S-2), clip
+   user-space displacement under group transforms (S-3), and box hit testing off by DPR (S-6).
+6. **`fix/3d-paint-and-state`** — the deferred-draw cluster: a non-hex fill crashing the render loop
+   (`3d-webgpu.md` 3D-1), discarded state and transforms (3D-2), local-normal shading (3D-3), and
+   geometry not animating (3D-4). Same root cause — a deferred renderer inside an immediate one.
+7. **`fix/terminal-paint`** — ANSI colour bleed (`terminal.md` F1), named colours and `#rgb`
+   resolving to nothing (F2), zero-alpha still drawing (F3), `opacity` ignored (F4), stroked text
+   drawing nothing (F5).
+8. **`fix/webgpu-depth-range`** — the `[-1, 1]` vs `[0, 1]` NDC convention (`3d-webgpu.md` WGPU-1).
+
+Lower-severity findings are listed in each report and are best folded into whichever branch above
+touches the same file.
+
+## Still outstanding from the audit plan
+
+A canvas↔SVG parity harness — the same gallery rendered through both backends and diffed against
+each other rather than a stored baseline — was scoped but not built. `packages/charts/test/visual/`
+is the place for it, and `svg.md` S-4/S-5 (group gradient, group opacity) are the two divergences it
+would catch first.

--- a/docs/audits/canvas.md
+++ b/docs/audits/canvas.md
@@ -1,0 +1,724 @@
+# Canvas rendering-context audit — `packages/canvas/src/*`
+
+Read-only investigation. No file under `/home/user/ripl` was modified.
+
+**Method.** Traced the base contract (`packages/core/src/context/context.ts`), the DOM layer
+(`packages/dom/src/context.ts`), and the drive path (`element.ts`, `group.ts`, `scene.ts`,
+`renderer.ts`, `shape.ts`) into `packages/canvas/src/{context,mixins,path,utilities}.ts`.
+Everything marked **CONFIRMED** below was reproduced by executing the real code against a
+`CanvasRenderingContext2D` stub that implements a *real* save/restore stack and a real CTM.
+(The repo's own `mockCanvasContext` in `packages/test-utils/src/canvas.ts:99` uses `vi.fn()`
+no-ops for `save`/`restore`, which structurally hides every state-stack defect in this package —
+see finding **13**.) Scratch harness has been deleted; the reproductions are reproduced inline as
+test sketches.
+
+---
+
+## Checklist verdicts
+
+| # | Item | Verdict |
+|---|------|---------|
+| 1 | save/restore symmetry & state-stack integrity | **Partially holds.** `saveDepth` bookkeeping is correct and the `currentState`/`states` bypass is benign (nothing on the canvas path reads them). But a `clip: true` shape at scene root leaks one native `save()` **per frame**, unbounded → findings **1**, **2**. |
+| 2 | markRenderStart/markRenderEnd depth | **Holds for the normal path**, but `Element.render` orders `currentRenderElement =` *before* `markRenderStart()`, so a direct `element.render(ctx)` silently drops the element from `renderedElements` → finding **9**. |
+| 3 | pushGroup/popGroup balance, group opacity, clip scoping | **Balance holds.** Group opacity does **not** composite multiplicatively with a child's own opacity → finding **5**. A clip shape's transform/paint leaks to later siblings → finding **2**. |
+| 4 | transform composition & ordering | **HOLDS.** Verified numerically: the native CTM at draw time equals `DPR · element.getWorldTransform()` for a nested group + rotated/translated/scaled child. `matrixMultiply` post-multiplies, matching canvas accumulation. |
+| 5 | gradient/pattern/shadow resolution & cache lifecycle | **Does not hold.** Group-level gradients resolve against the *previously drawn element's* box → finding **3**. Pattern cache is global and outlives the context that made it → finding **11**. A fresh `CanvasGradient` is allocated per element per frame → finding **12**. `shadowBlur`/`filter` do not scale with DPR → finding **10** (SUSPECTED). |
+| 6 | text metrics & text-along-path | **Does not hold.** Glyphs are placed at their mid-point but drawn with `textAlign: 'start'` → half-glyph drift, finding **6**. `measureText` drops the context's `textAlign`/`textBaseline` → finding **7**. |
+| 7 | hit testing (isPointInPath/Stroke, DPR, world transform) | **Path/DPR/world mapping HOLDS.** Stroke hit testing does not: it runs with the *residual* line style (`lineWidth === 1`), never the element's → finding **4**. DPR is frozen at module load → finding **8**. |
+| 8 | `export()` | **Holds** (snapshot-on-call, guards zero-size). Two nits: `toURL()` never revokes its object URL; on a context hit by finding **1** it exports a blank 300×150. |
+| 9 | `destroy()` cleanup & leak surface | **Does not hold.** `renderedElements`/`renderElement` retain the whole element graph, which retains the context back (`Element.context`); the canvas backing store is not released; module-level pattern/gradient caches are never pruned → finding **11**. |
+
+---
+
+# Findings
+
+## SEED LEAD — verified and characterised
+
+### 1a. `_fillCSS` / `_strokeCSS` are not part of the save/restore stack (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:152-153` (fields), `:155-157` / `:159-169` (fill
+get/set), `:299-301` / `:303-313` (stroke get/set), `:341-348` (`restore`).
+
+**Defect** — `restore()` rolls the native `fillStyle`/`strokeStyle` back via `this.context.restore()`
+but leaves the plain instance fields `_fillCSS`/`_strokeCSS` holding the inner scope's value, so the
+public `context.fill` / `context.stroke` getters report a paint the context is not using.
+
+**Failure scenario** (executed):
+
+```
+ctx.fill = '#ff0000';   // _fillCSS='#ff0000', native fillStyle='#ff0000'
+ctx.save();
+ctx.fill = '#0000ff';   // _fillCSS='#0000ff', native fillStyle='#0000ff'
+ctx.restore();          // native fillStyle back to '#ff0000'
+ctx.fill                // -> '#0000ff'   WRONG (native is '#ff0000')
+```
+
+Worse variant, also executed — the getter can never return to the native default once written
+inside any scope:
+
+```
+ctx.save(); ctx.fill = '#123456'; ctx.restore();
+ctx.fill                // -> '#123456'   WRONG; the outer scope never had this value
+```
+
+Identical behaviour for `stroke` (`:299-313`).
+
+**Blast radius — the real answer.** I grepped the whole monorepo (all `.ts`/`.vue`, including
+`packages/charts`, `packages/devtools`, `apps/website`) for reads of these getters:
+
+* **No product code reads `Context.fill` or `Context.stroke`.** The only reads are in tests:
+  `packages/canvas/test/context.test.ts:74,85` and `packages/core/test/context/context.test.ts:105,114`.
+* The only `Context`-getter read anywhere in element code is
+  `packages/core/src/elements/polyline.ts:362-363` (`context.lineDash` / `lineDashOffset`), which the
+  mixin maps to genuine native state (`:227-241`) and is therefore correctly restored.
+* The render pipeline only ever *writes* paint — `CONTEXT_OPERATIONS`
+  (`packages/core/src/core/constants.ts:34-65`) is setters-only; `Element.render`
+  (`element.ts:889-895`) and `Context.applyGroupPaint` (`context.ts:545-557`) read the *element's*
+  state, never the context's.
+
+**Conclusion: this is a lying getter, not a rendering bug.** No pixel is currently wrong because of
+it. It is a latent API-contract defect: the first consumer (or a future backend/devtools inspector)
+that reads `context.fill` after a `restore()` gets a wrong answer, and it silently invalidates the
+"getter mirrors the drawing state" contract the base class documents at
+`packages/core/src/context/context.ts:145-152`. Note the fields exist for a real reason — once a
+gradient/pattern is set, `context.fillStyle` is a `CanvasGradient`/`CanvasPattern` object and
+`as string` would be a different lie — so the fix must be stack-aware (push/pop the two strings
+inside the overridden `save`/`restore`, or store them in a `BaseState`-shaped stack), not a deletion.
+
+**Severity: low** (medium if a consumer starts reading it — it is public API).
+
+**Test sketch** (needs a stub whose `restore()` actually rolls state back):
+
+```ts
+test('fill getter tracks the restored native paint', () => {
+    const ctx = createContext(host);          // stateful stub
+    ctx.fill = '#ff0000';
+    ctx.save();
+    ctx.fill = '#0000ff';
+    ctx.restore();
+    expect(ctx.fill).toBe('#ff0000');         // fails today: '#0000ff'
+});
+
+test('a paint set only inside a scope does not survive the restore', () => {
+    const ctx = createContext(host);
+    ctx.save(); ctx.fill = '#123456'; ctx.restore();
+    expect(ctx.fill).toBe('#000000');         // fails today: '#123456'
+});
+```
+
+### 1b. Same lines: `ctx.fill = ''` is a silent no-op that then unmasks the native value (CONFIRMED by trace)
+
+`mixins.ts:159-169` — an empty string is neither a gradient nor a pattern, so it takes
+`this.context.fillStyle = ''`, which native canvas **ignores** (invalid CSS colour). `_fillCSS` is
+then `''`, so the `||` in the getter falls through to the *stale* native value. Setting an element's
+fill to `''` therefore neither clears the paint nor reports the failure. **Severity: low.**
+
+---
+
+## State-stack / clip
+
+### 2. A top-level `clip: true` shape leaks one native `save()` per frame; two or more corrupt the next frame's `clear()` (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:336-348` (`save`/`restore`), interacting with
+`packages/core/src/context/context.ts:502-513` (`batch`),
+`packages/core/src/core/shape.ts:157-160,170` (`clip` ⇒ `skipRestore`) and
+`packages/core/src/core/element.ts:899-901`.
+
+**Defect** — a clipping shape deliberately skips its own `restore()` so the clip persists to later
+siblings; `Context.popGroup` (`context.ts:565-571`) is what absorbs that dangling save. A clip shape
+added **directly to the `Scene`** has no enclosing `pushGroup`, so nothing absorbs it: `batch()`'s
+single `restore()` pops the *clip element's* save and leaves `batch()`'s own save outstanding
+forever. Net **+1 outstanding native `save()` per clip shape per frame**, unbounded.
+
+**Failure scenario** (executed):
+
+```
+scene.add(createRect({ clip: true, ... }));   // one clip shape at scene root
+5 x scene.render()  ->  outstanding native saves: [1, 2, 3, 4, 5]
+```
+
+With **two** top-level clip shapes it stops being a pure leak and becomes visible corruption,
+because the leftover state is a *transformed, clipped* state and `batch()` calls `clear()`
+**before** `save()` (`context.ts:503-505`):
+
+```
+scene.add([
+    createRect({ clip: true, translateX: 40 }),
+    createRect({ clip: true, translateY: 25 }),
+]);
+frame 1 clear(): CTM [1,0,0,1, 0,0]  active clips 0
+frame 2 clear(): CTM [1,0,0,1,40,0]  active clips 1   <- clears the wrong rect, masked
+frame 3 clear(): CTM [1,0,0,1,80,0]  active clips 2   <- drift grows every frame
+outstanding native saves after 3 frames: 6
+```
+
+That is progressive ghosting/trails plus an unbounded browser-side canvas state stack (60 fps ⇒
+~7 200 stacked states per minute). In-repo usage is currently safe — the only `clip: true` producer
+is `packages/charts/src/components/annotation.ts:172`, which always sits inside a group — so this is
+reachable only through the public element API today.
+
+**Severity: high** (unbounded leak + visible corruption; latent for chart users, live for direct
+`@ripl/core` consumers).
+
+**Test sketch:**
+
+```ts
+test('a top-level clip shape does not leak native saves', async () => {
+    const scene = createScene(ctx);
+    scene.add(createRect({ id: 'c', x: 0, y: 0, width: 50, height: 50, clip: true }));
+    await flushGraphRebuild();                     // Scene rebuilds on rAF
+    for (let i = 0; i < 5; i++) scene.render();
+    expect(nativeSaveDepth()).toBe(0);             // fails today: 5
+});
+```
+
+### 3. A clip shape's transform *and* paint leak onto its later siblings (CONFIRMED)
+
+**Location** — `packages/core/src/core/element.ts:885-901` reached from
+`packages/core/src/core/shape.ts:170` (`}, this.clip)`), applied on canvas via
+`mixins.ts:358-378`.
+
+**Defect** — `skipRestore` suppresses the *whole* `restore()`, not just the clip. Everything
+`Element.render` applied before the callback — `applyElementTransform` **and** every
+`CONTEXT_OPERATIONS` write (opacity, fill, lineWidth, filter, shadow…) — stays in force for every
+later sibling in the group.
+
+**Failure scenario** (executed) — group containing `[clipRect{translateX:100, opacity:0.25},
+siblingRect{fill:'#f00'}]`:
+
+```
+sibling CTM:         [1,0,0,1,100,0]   (expected [1,0,0,1,0,0])
+sibling globalAlpha: 0.25              (expected 1)
+```
+
+So a transformed clip mask silently shifts every subsequent sibling by its own translate, and a
+clip rect that happens to carry an opacity dims the whole rest of the group.
+
+**Severity: medium** (silent, geometry-corrupting; only bites when the clip shape carries a
+transform/paint, which is easy to do by accident).
+
+**Test sketch:**
+
+```ts
+test('a clip shape does not leak its transform to later siblings', async () => {
+    const group = createGroup();
+    group.add([
+        createRect({ id: 'clip', clip: true, translateX: 100, x: 0, y: 0, width: 100, height: 100, zIndex: 0 }),
+        createRect({ id: 'sib', fill: '#f00', x: 0, y: 0, width: 10, height: 10, zIndex: 1 }),
+    ]);
+    scene.add(group);
+    await flushGraphRebuild();
+    scene.render();
+    expect(ctmAtLastFill()).toEqual([1, 0, 0, 1, 0, 0]);   // fails today: [1,0,0,1,100,0]
+});
+```
+
+---
+
+## Gradients / paint resolution
+
+### 4. A group's gradient fill resolves its bounds against the *previously drawn element* (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:159-169` and `:332-334`
+(`gradientBounds() => this.currentRenderElement?.getBoundingBox?.(true)`), driven by
+`packages/core/src/context/context.ts:526-538` (`pushGroup`) → `:545-557` (`applyGroupPaint`).
+
+**Defect** — canvas bakes gradient geometry at **set** time. `pushGroup` never assigns
+`currentRenderElement`, so when `applyGroupPaint` writes the group's inherited `fill`, the
+"current render element" is still whatever leaf was drawn last (or `undefined` on the first group
+of a pass). The gradient's coordinates therefore come from an unrelated element's box — and because
+the group's paint is what descendants *inherit* (`shape.ts:163` uses `getComputedValue('fill')`),
+none of them ever re-resolves it.
+
+**Failure scenario A** (executed) — scene = `[leafRect(0,0,10,10), group{fill: 'linear-gradient(90deg,#f00,#00f)'} → childRect(200,100,100,50)]`:
+
+```
+createLinearGradient(0, 5, 10, 5)          <- the LEAF's box
+expected createLinearGradient(200, 125, 300, 125)   <- the group's content box
+```
+
+The child renders effectively single-colour (it sits 190px past the end of a 10px-wide ramp).
+
+**Failure scenario B** (executed) — the same group as the *first* thing in the scene:
+
+```
+createLinearGradient(0, 150, 400, 150)     <- full-surface fallback (getGradientBounds, gradient/bounds.ts:40-45)
+```
+
+so the ramp spans the whole canvas instead of the group. Both are wrong, in different directions,
+and both are non-deterministic w.r.t. sibling order. SVG does not have this: it re-resolves the
+gradient per element at draw time (`packages/svg/src/context.ts:633,644`), so the two backends
+render the same scene differently.
+
+**Severity: high** (silent, visible mis-paint; ordering-dependent).
+
+**Test sketch:**
+
+```ts
+test('a group gradient resolves against the group, not the previous sibling', async () => {
+    scene.add([
+        createRect({ id: 'leaf', x: 0, y: 0, width: 10, height: 10, fill: '#000', zIndex: 0 }),
+        withChild(createGroup({ zIndex: 1, fill: 'linear-gradient(90deg,#f00,#00f)' }),
+                  createRect({ x: 200, y: 100, width: 100, height: 50 })),
+    ]);
+    await flushGraphRebuild();
+    scene.render();
+    expect(lastCreateLinearGradientArgs()).toEqual([200, 125, 300, 125]);  // fails: [0,5,10,5]
+});
+```
+
+*(Minimal fix direction: have `pushGroup` set `currentRenderElement = group` around
+`applyGroupPaint`, or make the canvas `fill`/`stroke` setters lazy so the gradient is materialised
+at `applyFill`/`applyStroke` time against the element actually being painted.)*
+
+---
+
+## Hit testing
+
+### 5. `isPointInStroke` runs with the residual line style, never the element's (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:412-418` →
+`packages/canvas/src/utilities.ts:336-338` (`ctx.isPointInStroke(path.ref, x, y)`), called from
+`packages/core/src/core/shape.ts:48,123-135`.
+
+**Defect** — native `isPointInStroke` strokes the path using the context's *current*
+`lineWidth`/`lineCap`/`lineJoin`/`miterLimit`/dash. Hit tests happen outside a render pass, at which
+point `batch()`'s trailing `restore()` (`context.ts:511`) has rolled the line style back to the
+pre-frame value — i.e. the canvas default `lineWidth === 1`. Nothing re-applies the element's stroke
+width before testing.
+
+**Failure scenario** (executed) — a rect with `lineWidth: 24, pointerEvents: 'stroke'`, rendered,
+then hit-tested:
+
+```
+native lineWidth after the frame: 1
+native lineWidth at isPointInStroke: 1   (expected 24)
+```
+
+Real-world impact: `packages/charts/src/charts/sankey.ts:499` creates every Sankey link with
+`pointerEvents: 'stroke'` and `lineWidth: link.width` (the ribbon thickness, routinely 10–100 px).
+On canvas those ribbons are only hoverable within ~1 CSS px of their centreline; on SVG they work,
+because `SVGContext._isPointIn` (`packages/svg/src/context.ts:343-354`) delegates to the DOM element
+which carries its own `stroke-width`. Same class of error for any thin-stroke element
+(`lineWidth < 1` over-hits) and for `pointerEvents: 'all'` elements with no fill (lines/polylines),
+where `isPointInStroke` is the only test that can succeed (`shape.ts:123-126`).
+
+**Severity: high** (interaction silently broken for stroke-hit elements; backend divergence).
+
+**Test sketch:**
+
+```ts
+test('stroke hit testing uses the element line width', async () => {
+    const rect = createRect({ x: 10, y: 10, width: 100, height: 100,
+                              stroke: '#f00', lineWidth: 24, pointerEvents: 'stroke' });
+    scene.add(rect); await flushGraphRebuild(); scene.render();
+    const widths: number[] = [];
+    spyOnNative('isPointInStroke', () => widths.push(native.lineWidth));
+    rect.intersectsWith(10, 10, { isPointer: true });
+    expect(widths[0]).toBe(24);                 // fails today: 1
+});
+```
+
+### 6. What *does* hold in hit testing (verified)
+
+* **World-transform mapping** — `shape.ts:104-117` inverts `getWorldTransform()` and applies the
+  `/dpr … *dpr` round trip; native `isPointInPath(path2d, x, y)` transforms the Path2D by the CTM
+  (which is the DPR matrix at rest) and treats `x,y` as untransformed device coordinates. The two
+  agree. **Correct.**
+* **Transform composition** — verified numerically: native CTM at draw time ==
+  `DPR · child.getWorldTransform()` for a scaled+translated group containing a rotated+translated
+  child. **Correct.**
+* **Sub-pixel DPR skew (SUSPECTED, low)** — `DOMContext` maps pointer coords with
+  `scaleX = scaleContinuous([0,width],[0,floor(width*dpr)])` (`utilities.ts:251`) while
+  `Element.intersectsWith` divides by the exact `scaleDPR(1)` (`element.ts:834`). When
+  `width*dpr` is not an integer these disagree by up to `dpr/width` per pixel (≈0.3 px at the far
+  edge of a 300 px canvas). Not reproduced; arithmetic only.
+
+---
+
+## Sizing / DPR
+
+### 7. A container whose device size matches the canvas default leaves the context completely uninitialised (CONFIRMED)
+
+**Location** — `packages/canvas/src/utilities.ts:231-254` (`rescaleCanvas`) and
+`packages/canvas/src/context.ts:51-62` (`CanvasContext.rescale`).
+
+**Defect** — `rescaleCanvas` early-returns `undefined` when `floor(width*dpr) === canvas.width &&
+floor(height*dpr) === canvas.height`, and `CanvasContext.rescale` then returns **before**
+`super.rescale(width, height)`. A brand-new `<canvas>` defaults to **300×150**, so at `dpr === 1`
+any container measuring `300×150` (or anything in `[300,301) × [150,151)`) short-circuits on the
+very first `init()`: `this.width`/`this.height` stay `0`, `scaleX`/`scaleY` stay the degenerate
+`[0,0]→[0,0]` scales from the `Context` constructor (`context.ts:413-414`), and no `resize` is
+emitted.
+
+**Failure scenario** (executed) — host element 300×150, `devicePixelRatio: 1`:
+
+```
+ctx.width / ctx.height : 0 / 0        (canvas backing store: 300 x 150)
+ctx.scaleX(150)        : 0            -> every pointer coordinate collapses to 0
+ctx.clear()            : clearRect(0, 0, 0, 0)   -> nothing is ever cleared -> full-frame ghosting
+```
+
+Downstream: `getGradientBounds` falls back to a `0×0` surface, `Scene.width/height` report 0, and
+`export()` returns a blank 300×150. `300×150` is a very common explicit chart-container size, and
+the failure is total (garbage rendering) rather than degraded.
+
+**Severity: high** (total failure, plausible trigger).
+
+**Test sketch:**
+
+```ts
+test('a 300x150 container at dpr 1 still initialises the context', () => {
+    mockElementSize(300, 150);
+    const ctx = createContext(host);
+    expect([ctx.width, ctx.height]).toEqual([300, 150]);   // fails today: [0, 0]
+    ctx.clear();
+    expect(nativeClearRectArgs()).toEqual([0, 0, 300, 150]); // fails today: [0,0,0,0]
+});
+```
+
+### 8. `reset()` silently discards the DPR transform and desynchronises `saveDepth` (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:354-356`.
+
+**Defect** — `this.context.reset()` resets the native context to defaults: it clears the state
+stack, the clip, **and the transform**. The DPR matrix installed by `rescaleCanvas`
+(`utilities.ts:248`) is thrown away and never reinstalled, and `Context.saveDepth` keeps counting
+saves the native stack no longer holds.
+
+**Failure scenario** (executed):
+
+```
+ctx.save(); ctx.save();  -> native stack depth 2, saveDepth 2
+ctx.reset();             -> native stack depth 0, saveDepth 2   (desynced)
+                         -> CTM back to identity (was [dpr,0,0,dpr,0,0])
+```
+
+After `reset()` on a 2× display everything renders at half size in the top-left quadrant, and the
+next two `restore()` calls decrement `saveDepth` while doing nothing natively — so a later
+`popGroup()` unwinds to the wrong depth and paint leaks between groups. The same state-stack
+desync occurs on every resize, because assigning `canvas.width` inside `rescaleCanvas`
+(`utilities.ts:245-246`) also clears the native stack while `saveDepth` is untouched (harmless at
+`saveDepth === 0`, compounding once finding **2** is active).
+
+**Severity: medium** (`reset()` is public API; the resize path is only harmful in combination).
+
+**Test sketch:**
+
+```ts
+test('reset() restores the DPR transform and zeroes saveDepth', () => {
+    factory.set({ devicePixelRatio: 2 });
+    const ctx = createContext(host);
+    ctx.save(); ctx.save();
+    ctx.reset();
+    expect(nativeMatrix()).toEqual([2, 0, 0, 2, 0, 0]);       // fails today: identity
+    expect((ctx as any).saveDepth).toBe(0);                   // fails today: 2
+});
+```
+
+### 9. `resize` is emitted with stale `scaleX`/`scaleY` (CONFIRMED)
+
+**Location** — `packages/canvas/src/context.ts:51-62`. `super.rescale()`
+(`packages/core/src/context/context.ts:417-425`) installs *identity* scales and emits `resize`
+**before** `CanvasContext.rescale` overwrites them with the DPR-aware ones on lines 60-61.
+
+**Failure scenario** (executed, `dpr = 2`, resize to 800×600):
+
+```
+inside the resize handler: ctx.scaleX(100) === 100     (identity)
+immediately after:         ctx.scaleX(100) === 200     (correct)
+```
+
+`Scene`'s own resize handler (`scene.ts:162-169`) calls `render()` synchronously inside that window,
+and any user handler that reads `context.scaleX/scaleY` (or hit-tests) gets the identity mapping.
+
+**Severity: low** (narrow window; drawing itself uses the CTM, not the scales).
+
+**Test sketch:** subscribe to `resize`, capture `ctx.scaleX(100)` inside the handler, assert it
+equals `ctx.scaleX(100)` after the call returns.
+
+### 10. `factory.devicePixelRatio` is frozen at module load, so the canvas never re-rasterises after a zoom/monitor change (CONFIRMED)
+
+**Location** — `packages/web/src/index.ts:82-84` (`get devicePixelRatio() { return window.devicePixelRatio; }`)
+passed to `factory.set`, which spreads it at `packages/core/src/core/factory.ts:91-94`
+(`{ ...this._state, ...options }`). Object spread **invokes** the getter once and stores the number.
+
+**Failure scenario** (executed against `Factory` directly): after `factory.set({ get devicePixelRatio() { return live; } })`
+and `live = 3`, `factory.devicePixelRatio` still reads `1`.
+
+Consequence for this package: `rescaleCanvas` (`utilities.ts:237`) and
+`Context.scaleDPR` (`context.ts:412`) both consume that frozen value, so a browser zoom or a drag to
+a different-DPI monitor leaves the backing store at the old ratio — a permanently blurry (or
+over-sampled) chart. Compounding: `scaleDPR` is captured once in the constructor and never
+refreshed on rescale, so if an application *does* call `factory.set({ devicePixelRatio })` at
+runtime, `scaleX`/`scaleY` (recomputed) and `scaleDPR` (stale) disagree and hit testing shifts.
+
+**Severity: medium** (visible blur; the fix is outside `packages/canvas`, but canvas is the only
+consumer that cares).
+
+**Test sketch:** `factory.set({ get devicePixelRatio() { return live; } }); live = 3;
+expect(factory.devicePixelRatio).toBe(3);`
+
+---
+
+## Group compositing
+
+### 11. A child's own opacity replaces the group's composited alpha instead of multiplying (CONFIRMED)
+
+**Location** — `packages/core/src/core/constants.ts:40`
+(`opacity: basicContextSetter('opacity')` — an assignment) versus
+`packages/core/src/context/context.ts:532-537` (`this.opacity *= opacity` for groups), landing on
+`packages/canvas/src/mixins.ts:203-209` (`globalAlpha`).
+
+**Failure scenario** (executed) — `group{opacity: 0.5}` containing `rect{opacity: 0.5, fill:'#f00'}`:
+
+```
+globalAlpha at the child's fill: 0.5     (expected 0.25)
+```
+
+Nested *groups* compound correctly (`pushGroup` multiplies); only leaves clobber. SVG does not have
+this: `SVGContext.pushGroup` stamps the opacity on the `<g>` and zeroes `currentState.opacity`
+(`packages/svg/src/context.ts:536-542`), so the DOM multiplies — the two backends render the same
+scene at different alphas.
+
+**Severity: medium** (visible, cross-backend divergence).
+
+**Test sketch:** as above — assert `globalAlpha === 0.25` at the child's `fill()`.
+
+### 12. Group `globalCompositeOperation` is applied per-child, not to the group as a unit (SUSPECTED, by trace)
+
+`applyGroupPaint` (`context.ts:545-557`) pushes the group's blend mode onto the context, so each
+descendant blends against the backdrop independently. True group compositing needs an offscreen
+layer. SVG's `<g mix-blend-mode>` composites the subtree. Not reproduced (needs pixels).
+**Severity: low** (design limitation; worth documenting).
+
+---
+
+## Text
+
+### 13. Text along a path is offset by half a glyph under any non-`center` `textAlign` (CONFIRMED)
+
+**Location** — `packages/canvas/src/utilities.ts:257-285` (`renderTextAlongPath`).
+
+**Defect** — line 264 computes `midDistance = distance + charWidth / 2` and translates the context
+to that **mid-point** (`:272-274`), but the glyph is then drawn at `(0,0)` (`:277`) using whatever
+`textAlign` the context carries. That geometry is only correct for `textAlign: 'center'`; the canvas
+default is `'start'`, so every glyph is pushed forward along the path by half its own advance.
+
+**Failure scenario** (executed) — content `'AB'`, 10 px glyphs, straight 1000-unit path,
+`textAlign: 'start'`:
+
+```
+translate(5, 0);  fillText('A', 0, 0)   -> 'A' occupies 5..15   (should be 0..10)
+translate(15, 0); fillText('B', 0, 0)   -> 'B' occupies 15..25  (should be 10..20)
+```
+
+The whole string is shifted forward by half a glyph, and the shift varies per glyph for
+proportional fonts. SVG `<textPath>` (`packages/svg/src/text.ts:46-62`) places glyphs by advance, so
+the backends disagree. Related, same function: `element.maxWidth` is ignored, `startOffset` is not
+clamped (a negative value stacks the leading glyphs at the path start, because `samplePathPoint`
+clamps), and the loop `break`s on the first overflowing glyph.
+
+**Severity: medium** (visible mis-placement wherever `pathData` text is used).
+
+**Test sketch:**
+
+```ts
+test('glyphs are placed at their advance offset, not their mid-point', () => {
+    stubPathLength(1000);
+    renderTextAlongPath(native, new ContextText({ x: 0, y: 0, content: 'AB', pathData: 'M0,0 L1000,0' }), 'fill');
+    expect(translateLog()).toEqual(['translate(0,0)', 'translate(10,0)']);   // fails: 5,15
+});
+```
+
+*(Either set `ctx.textAlign = 'center'` for the duration of the run, or translate to
+`distance` instead of `midDistance`.)*
+
+### 14. `measureText` drops the context's `textAlign`/`textBaseline`, and its `context` option is dead (CONFIRMED)
+
+**Location** — `packages/canvas/src/mixins.ts:380-382` →
+`packages/canvas/src/utilities.ts:323-328`.
+
+**Defect** — `canvasMeasureText` forwards `{ context: ctx, font }` only. `actualBoundingBoxLeft/Right`
+are anchor-relative (they shift with `textAlign`) and `actualBoundingBoxAscent/Descent` shift with
+`textBaseline`, so measurements taken through the context are wrong whenever it is not at the
+defaults. Separately, **no factory implementation consumes `MeasureTextOptions.context`** —
+`domMeasureText` (`packages/web/src/index.ts:63-73`) measures on its own cached ref canvas and
+`nodeMeasureText` (`packages/node/src/index.ts:54`) ignores options entirely — so passing the live
+context is a no-op that reads as if it were meaningful.
+
+**Failure scenario** (executed): `ctx.font = '20px serif'; ctx.textAlign = 'center';
+ctx.measureText('hello')` forwards `{ context: <ctx>, font: '20px serif' }` — no `textAlign` — so
+the result reports `actualBoundingBoxLeft: 0, actualBoundingBoxRight: width` instead of
+`±width/2`. `Element._getLocalBoundingBox` for `Text` (`packages/core/src/elements/text.ts:98-102`)
+is unaffected because it calls the core `measureText` with explicit alignment; the defect is
+confined to consumers of `context.measureText`, e.g. `Renderer._renderDebugOverlay`
+(`renderer.ts:415-419`).
+
+**Severity: low.**
+
+**Test sketch:** spy on `factory.measureText`; assert the options object forwarded by
+`ctx.measureText('hello')` contains `textAlign: 'center'` after `ctx.textAlign = 'center'`.
+
+### 15. `renderTextAlongPath` re-parses the SVG path once per glyph (SUSPECTED perf, by trace)
+
+`utilities.ts:262-284` calls `samplePathPoint` per character; each call does
+`setAttribute('d', …)` + `getTotalLength()` + 3 × `getPointAtLength()` on a shared ref
+`<path>` (`packages/core/src/math/geometry.ts:201-213`), plus one `getPathLength` up front. That is
+O(chars) full path re-parses **per text element per frame**. **Severity: low** (perf only).
+
+---
+
+## Lifecycle / leaks
+
+### 16. `destroy()` retains the whole element graph, the backing store, and cached patterns (CONFIRMED)
+
+**Location** — `packages/canvas/src/context.ts` (no `destroy` override) →
+`packages/dom/src/context.ts:304-308` → `packages/core/src/context/context.ts:708-711`.
+
+**Defect** — nothing clears the render/interaction state:
+
+* `renderedElements` and `renderElement` still hold every element that was drawn
+  (executed: `renderedElements.length === 1` and `renderElement` truthy **after** `ctx.destroy()`).
+  Each of those elements holds `this.context = context` (`element.ts:878`), so the context and the
+  entire scene graph keep each other alive as long as anything references either.
+* `_getTrackedElements`'s memoize cache (`context.ts:671-673`) is not cleared
+  (`invalidateTrackedElements()` is never called from `destroy`).
+* The `<canvas>` is removed from the DOM but `this.element` / `this.context` still reference it;
+  its backing store (`width × height × 4` bytes — 7.7 MB at 1600×1200) is only freed at GC. The
+  standard release (`canvas.width = canvas.height = 0`) is not done.
+* Module-level `patternCache` (`utilities.ts:105`) retains `CanvasPattern` objects **created by the
+  destroyed context**, together with their offscreen tile canvases, and is never pruned. Executed:
+  after `first.destroy()`, a brand-new context asking for the same pattern string gets the old
+  object back with **zero** `createPattern` calls on its own context. Same for `gradientCache`
+  (`utilities.ts:85`) — bounded to 256 but never scoped to a context or cleared on teardown.
+* `export().toURL()` (`packages/dom/src/export.ts:51`) mints an object URL that is never revoked.
+
+**Severity: medium** (leaks scale with scene size and context churn — SPA route changes, dashboards
+that rebuild charts).
+
+**Test sketch:**
+
+```ts
+test('destroy() releases the rendered element list', async () => {
+    scene.add(createRect({ id: 'r', x: 0, y: 0, width: 10, height: 10, fill: '#f00' }));
+    await flushGraphRebuild(); scene.render();
+    ctx.destroy();
+    expect(ctx.renderedElements).toHaveLength(0);   // fails today: 1
+    expect(ctx.renderElement).toBeUndefined();      // fails today: the rect
+});
+```
+
+### 17. A fresh `CanvasGradient` is allocated per element per frame (CONFIRMED, perf)
+
+**Location** — `packages/canvas/src/mixins.ts:163-165` → `utilities.ts:187-193` →
+`toCanvasGradient` (`utilities.ts:68-81`). `parseGradientMemoized` (`:88-101`) memoises only the
+*parse*; the native object is rebuilt every time `fill`/`stroke` is assigned.
+
+**Failure scenario** (executed): 5 gradient-filled rects × 2 frames ⇒ **10** `createLinearGradient`
+calls plus 20 `addColorStop` calls. At 60 fps with 500 gradient elements that is 30 000
+`CanvasGradient` allocations per second. A `(gradientString, bounds)` keyed cache would collapse
+this. **Severity: low** (perf only; no wrong pixels).
+
+---
+
+## Cross-cutting / pipeline
+
+### 18. `Element.render` wipes the element it just registered when called at render depth 0 (CONFIRMED)
+
+**Location** — `packages/core/src/core/element.ts:878-881`:
+
+```ts
+context.currentRenderElement = this;   // pushes into renderedElements (context.ts:137-143)
+context.markRenderStart();             // if renderDepth === 0 -> renderedElements = []  (context.ts:488-494)
+```
+
+**Failure scenario** (executed) — a direct `rect.render(ctx)` (no `scene.render()` / `batch`):
+
+```
+ctx.renderedElements -> []      (the rect was pushed, then wiped)
+```
+
+so the element is drawn but can never be hit-tested. The normal path is safe because `batch()`
+raises `renderDepth` to 1 first (`context.ts:505`), but `Element.render` and `Group.render` are
+public. **Severity: low.** *Fix: swap the two lines.*
+
+**Test sketch:** `rect.render(ctx); expect(ctx.renderedElements.map(e => e.id)).toEqual(['r']);`
+
+### 19. Group/render bookkeeping is not exception-safe (SUSPECTED, by trace)
+
+`Group.render` (`group.ts:194-207`) and the instruction loops in `Scene.render`
+(`scene.ts:270-274`) / `Renderer._renderBuffer` (`renderer.ts:355-373`) have no `try/finally` around
+`pushGroup`/`popGroup`. A throw inside a child leaves `Context._groupDepthStack` (`context.ts:79`)
+permanently unbalanced, so every subsequent `popGroup()` unwinds to a stale depth and paint/clip
+leak between groups for the rest of the session. `_groupDepthStack` is also never cleared by
+`reset()` or `destroy()`. **Severity: low** (needs a throwing element).
+
+### 20. `canvasDrawImage` silently ignores a width given without a height (CONFIRMED, by trace)
+
+`packages/canvas/src/utilities.ts:314-320` — `if (width && height)`. `drawImage(img, x, y, 200)`
+falls through to the 3-argument form and draws at natural size; `width: 0` (a legitimate degenerate)
+does the same. **Severity: low.**
+
+### 21. `packages/test-utils/src/canvas.ts:99` structurally hides this whole class of bug (CONFIRMED)
+
+`mockCanvasContext`'s `save`/`restore` are bare `vi.fn()` no-ops and it has no CTM. Consequently
+`packages/canvas/test/context.test.ts:132-140` ("save and restore delegate without throwing") can
+never observe finding **1**, and no existing test can observe findings **2**, **3**, **5** or **8**.
+Any fix for those needs a stateful stub (a real state stack + a 2×3 matrix) added to
+`@ripl/test-utils` first. **Severity: medium** (test-infrastructure gap, not a runtime bug).
+
+---
+
+## Things that were checked and are correct
+
+* Transform composition/ordering on canvas matches `MatrixTransformTarget`, and the native CTM at
+  draw time equals `DPR · getWorldTransform()` (verified numerically for a nested group + rotated
+  child). `applyElementTransform`'s origin round-trip (`transform.ts:91-103`) is symmetric.
+* `saveDepth` accounting inside the mixin is correct: `save` increments, `restore` guards
+  `saveDepth === 0` and never over-pops the native stack.
+* The `currentState` / `states` bypass is **harmless on canvas**: every `BaseState` accessor except
+  `zIndex` is overridden by the mixin, `zIndex` is written by `CONTEXT_OPERATIONS` but never read on
+  this path (only `packages/svg/src/context.ts:322` reads it), and `pushGroup`/`popGroup`/`layer`/
+  `batch`/`applyGroupPaint` touch only `saveDepth` and the overridden accessors.
+* `markRenderStart`/`markRenderEnd` are balanced in `batch`, `Element.render` (`finally`) and
+  `Group.render`; nothing in the canvas backend reads `renderDepth`.
+* `popGroup` correctly absorbs the dangling `save()` of a group-scoped clip (verified: no leak for a
+  clip inside a group — the leak in finding **2** is specific to the scene root).
+* `isPointInPath` fill hit testing, the DPR round trip, and the world-transform inverse mapping all
+  agree with native `isPointInPath` semantics.
+* `CanvasPath` overrides every drawing primitive it needs; the one base method it does *not*
+  override, `ContextPath.polyline` (`packages/core/src/context/path.ts:81-86`), is implemented in
+  terms of `moveTo`/`lineTo` and therefore dispatches correctly.
+* `export()` snapshots the pixels at call time onto a detached canvas, so later frames cannot
+  mutate an already-returned exporter, and it guards zero-size canvases.
+* `supportsPathCaching = true` is safe: `Shape2D` always allocates a fresh `CanvasPath` when it
+  re-traces, so `Path2D` commands never accumulate.
+
+---
+
+## Ranked summary
+
+| Rank | Finding | Severity | Status |
+|------|---------|----------|--------|
+| 1 | **#7** `rescaleCanvas` no-ops on a 300×150 @ dpr 1 container → `width/height = 0`, degenerate scales, `clearRect(0,0,0,0)`, total render failure (`canvas/src/utilities.ts:241`) | **high** | CONFIRMED |
+| 2 | **#5** `isPointInStroke` uses the residual `lineWidth` (1), never the element's → thick-stroke elements (all Sankey links) are unhoverable (`canvas/src/mixins.ts:412`, `utilities.ts:336`) | **high** | CONFIRMED |
+| 3 | **#4** Group gradient fills resolve bounds against the previously drawn element (or the full surface) (`canvas/src/mixins.ts:159-169,332-334` + `core/context.ts:526-538`) | **high** | CONFIRMED |
+| 4 | **#2** Top-level `clip: true` shape leaks one native `save()` per frame; ≥2 corrupt the next frame's `clear()` with a drifting CTM and stacked clips (`canvas/src/mixins.ts:336-348` + `core/context.ts:502-513`) | **high** | CONFIRMED |
+| 5 | **#3** A clip shape's transform and paint leak onto later siblings (`core/element.ts:899` + `core/shape.ts:170`) | medium | CONFIRMED |
+| 6 | **#13** Text-along-path is offset by half a glyph under the default `textAlign` (`canvas/src/utilities.ts:264-277`) | medium | CONFIRMED |
+| 7 | **#11** A child's opacity replaces rather than multiplies the group's alpha (`core/constants.ts:40` + `canvas/src/mixins.ts:203-209`) | medium | CONFIRMED |
+| 8 | **#16** `destroy()` retains the element graph, the backing store and cached patterns (`canvas/src/context.ts`, `canvas/src/utilities.ts:105`) | medium | CONFIRMED |
+| 9 | **#8** `reset()` discards the DPR transform and desyncs `saveDepth` (`canvas/src/mixins.ts:354-356`) | medium | CONFIRMED |
+| 10 | **#10** `factory.devicePixelRatio` frozen at module load → no re-rasterisation on zoom/monitor change (`web/src/index.ts:82` + `core/factory.ts:91`) | medium | CONFIRMED |
+| 11 | **#21** `mockCanvasContext` has no-op `save`/`restore`, hiding this entire defect class from the suite (`test-utils/src/canvas.ts:99`) | medium | CONFIRMED |
+| 12 | **#1a/#1b** `_fillCSS`/`_strokeCSS` are outside the save/restore stack → `context.fill`/`context.stroke` lie after any `restore()`; `fill = ''` is a silent no-op (`canvas/src/mixins.ts:152-169,299-313`) — **no product code reads these getters, so no pixel is wrong today** | low | CONFIRMED |
+| 13 | **#14** `measureText` drops `textAlign`/`textBaseline`; its `context` option is dead everywhere (`canvas/src/utilities.ts:323-328`) | low | CONFIRMED |
+| 14 | **#18** `Element.render` wipes the element it just registered at render depth 0 (`core/element.ts:878-881`) | low | CONFIRMED |
+| 15 | **#9** `resize` fires with identity `scaleX`/`scaleY` (`canvas/src/context.ts:58-61`) | low | CONFIRMED |
+| 16 | **#17** A fresh `CanvasGradient` per element per frame (`canvas/src/utilities.ts:68-81`) | low | CONFIRMED (perf) |
+| 17 | **#15** `renderTextAlongPath` re-parses the SVG path once per glyph (`canvas/src/utilities.ts:262-284`) | low | SUSPECTED (perf) |
+| 18 | **#20** `canvasDrawImage` ignores a width supplied without a height (`canvas/src/utilities.ts:315`) | low | CONFIRMED |
+| 19 | **#19** `pushGroup`/`popGroup` bookkeeping is not exception-safe (`core/group.ts:194-207`, `core/scene.ts:270-274`) | low | SUSPECTED |
+| 20 | **#12** Group `globalCompositeOperation` applies per child, not to the subtree (`core/context.ts:545-557`) | low | SUSPECTED |
+| 21 | **#6 (skew)** Sub-pixel disagreement between `scaleX` (floored) and `scaleDPR` (exact) in pointer mapping (`canvas/src/utilities.ts:251` vs `core/element.ts:834`) | low | SUSPECTED |

--- a/docs/audits/dom-node.md
+++ b/docs/audits/dom-node.md
@@ -1,0 +1,670 @@
+# Audit — `@ripl/dom` context layer + `@ripl/node` runtime bindings
+
+**Tree audited:** `/home/user/ripl` @ `8121b9d` — verified `HEAD == main == origin/main` for
+`packages/{core,dom,node}` (`git diff --stat origin/main...HEAD` empty). Read-only; no repo file
+was modified.
+
+**Out of scope, confirmed present, not reported:** (a) stale `_interactionState.left/top`
+— being fixed on `origin/claude/pointer-origin`; (b) `_domCache` retaining descendants of removed
+subtrees — being fixed on `origin/claude/svg-commit-model`. I diffed both branches: **neither
+touches any finding below.** In particular `claude/svg-commit-model` keeps
+`if (childVNode.children.length > 0)` (F3) and the `desiredIds` Set (F5) unchanged.
+
+**Method.** Every finding marked CONFIRMED was reproduced by executing the real code under
+`vitest`/`node` against the repo sources (scratch harness outside the repo, now deleted). Findings
+marked SUSPECTED were reached by tracing only and are labelled as such.
+
+---
+
+## Checklist coverage
+
+| # | Area | Verdict |
+|---|---|---|
+| 1 | `DOMContext` interaction | 6 confirmed defects — F2, F4, F6, F7, F8, F9 (+F12) |
+| 2 | `hitTest` / memo / z-order | 3 confirmed defects — F1, F10, F11 |
+| 3 | **SEED LEAD** `createFrameBuffer` starvation | **REFUTED** — see §Seed Lead. Real defect in the same code is F8 |
+| 4 | `vdom.ts` reconciler | 2 confirmed defects — F3, F5 (+F20). Reorder / `getChildId` / `ensureGroupPath` / `getAncestorGroupIds` all verified correct |
+| 5 | Resize observation | 2 confirmed — F14, F15; rescale-during-render mechanism confirmed (F13), reachability suspected |
+| 6 | `export.ts` | 1 low — F21. Snapshot semantics correct |
+| 7 | `navigator.ts` | 4 low/medium — F22, F23, F24, F25. Feature detection + `preventDefault` verified correct |
+| 8 | `destroy()` cleanup | F8, F9 confirmed; observers/listeners otherwise fully released; double-destroy unsafe (F19) |
+| 9 | `packages/node/src/*` | 4 confirmed — F16, F17, F18, F27 (+F28) |
+
+---
+
+## SEED LEAD — verdict: **NOT REACHABLE. This is a correct throttle, not a starvation.**
+
+`createFrameBuffer` (`packages/core/src/animation/utilities.ts:10-21`) does cancel and reschedule
+on every call, and `_handleMouseMove` (`packages/dom/src/context.ts:146`) does drive
+`_handleHoverHitTest` through it. But the analogy to `0bc2fc4` does not hold, and I could not
+starve it.
+
+**Why `0bc2fc4` was a real starvation and this is not.** The slider used a *relative* deadline:
+`clearTimeout(timer); timer = setTimeout(flush, debounce)` pushes the firing time `debounce`ms
+into the future *on every event*. A stream faster than 120ms therefore moves the deadline forever
+and the trailing edge never arrives. `requestAnimationFrame`'s deadline is **absolute** — every
+`cancelAnimationFrame` + `requestAnimationFrame` pair lands in the *same* next rendering
+opportunity's callback list. Cancelling N-1 times before that opportunity still leaves exactly one
+callback registered when it arrives. The deadline cannot be pushed.
+
+**Measured.** Dispatching 20 synthetic `mousemove`s per frame for 10 frames (≈20× more than any
+browser delivers, since Chrome/Firefox/WebKit all rAF-align and coalesce mouse moves to ≤1 per
+frame) produced **9 element `mousemove` emissions — one per frame**, not zero. A 200-event
+*synchronous* burst with no frame boundary produced exactly 1 callback (the last position), which
+is the intended coalescing. Hover fires on every painted frame with the latest pointer position
+during a fast drag.
+
+The only way to get zero hover events is to saturate the main thread so no rendering opportunity
+occurs at all — in which case rAF, paint, and the drag itself are equally dead, so the frame buffer
+is not the cause.
+
+**Residual real defect in this code:** the buffer is *uncancellable* — it returns only a scheduling
+function. That is F8 below, and it is genuine.
+
+---
+
+## CONFIRMED findings
+
+### F1 — `hitTest` sorts by additive z-index, which is not paint order across groups — HIGH
+`packages/core/src/context/context.ts:689-695`
+
+The comparator sorts hits by `eb.zIndex - ea.zIndex` and only falls back to paint order on ties.
+`Element.zIndex` is **additive** (`packages/core/src/core/element.ts:468-470`:
+`(parent?.zIndex ?? 0) + (state.zIndex ?? 0)`), while `Scene._collectInstructions`
+(`packages/core/src/core/scene.ts:209-234`) paints groups as contiguous stacking contexts. A
+descendant's additive z-index therefore says nothing about its position relative to a descendant of
+a *different* group. `renderedElements` is already exact paint order, so the z-index sort actively
+destroys correct information.
+
+**Failure (measured).** `G1{zIndex:0} > A{zIndex:10}` and `G2{zIndex:5} > B{zIndex:0}`, both under
+the scene root, both hit by the pointer, both listening for `click`.
+- Paint order: `['a','b']` — B is drawn on top and is what the user sees under the cursor.
+- Additive z-index: `a=10`, `b=5`.
+- `hitTest(['click'], x, y)` → `['a','b']`, so `hitElements[0]` is **A**.
+
+Every `DOMContext` consumer takes `hitElements[0]` as topmost
+(`packages/dom/src/context.ts:125, 196, 256`), so the click/hover lands on the element the user
+cannot see. Any chart that layers furniture groups over series groups (grid, annotations, crosshair,
+legend all use groups) is exposed.
+
+**Test sketch.** Build the two-group scene above; assert `ctx.renderedElements.map(e => e.id)` is
+`['a','b']` and `hitTest(['click'],0,0)[0].id === 'b'`. Then assert the invariant generally: for any
+scene, `hitTest` order equals `renderedElements` reversed, filtered to the hits.
+
+---
+
+### F2 — a `mouseup` outside the surface strands the drag permanently — HIGH
+`packages/dom/src/context.ts:222-246` (handler), `:287` (attachment site)
+
+`mouseup` is bound to `this.element` only. There is no pointer capture, no window-level fallback,
+and `_handleMouseLeave` (`:111-113`) does not touch drag state. A gesture released off-canvas
+therefore never clears `state.dragElement` / `state.dragStarted`, and never emits `dragend`.
+
+**Failure (measured).** `mousedown` at (10,10) on a draggable element → two `mousemove`s → pointer
+leaves the canvas → button released outside. Re-enter and move with **no button held**: the element
+receives `drag` again. Sequence recorded after re-entry: `['drag']`. `dragend` is never emitted, so
+any consumer holding drag state (a brush, a navigator handle, a resizable annotation) stays latched
+and the shape follows the bare cursor.
+
+**Test sketch.** Dispatch `mousedown` → `mousemove`×2 → `mouseleave`; then `mouseenter` +
+`mousemove` and assert no `drag` is emitted and that a `dragend` was emitted at teardown.
+
+---
+
+### F3 — a group that empties keeps its stale DOM children painted — HIGH
+`packages/dom/src/vdom.ts:147-149`
+
+`reconcileNode` only recurses `if (childVNode.children.length > 0)`. A vnode whose children all
+disappeared is never descended into, so its live DOM children are never removed.
+
+This is reachable in SVG on every empty group: `SVGContext.pushGroup`
+(`packages/svg/src/context.ts`) unconditionally emits a `<g>` vnode with `children: []` and fills it
+during the pass, so a `Group` whose contents are removed produces exactly this shape.
+
+**Failure (measured).**
+```
+pass 1 vtree: root > g > [x, y]   DOM: <div id="g"><span id="x"/><span id="y"/></div>
+pass 2 vtree: root > g > []       DOM: <div id="g"><span id="x"/><span id="y"/></div>   ← unchanged
+```
+Concretely: a bar chart whose series is updated to an empty array, or a crosshair/annotation group
+that is emptied rather than removed, leaves its last-rendered shapes on screen forever. They are
+also still returned by `SVGContext._isPointIn`, so they stay hit-testable.
+
+Related to but distinct from out-of-scope item (b): (b) is about `_domCache` map entries; this is
+live DOM nodes that stay *painted*. The `claude/svg-commit-model` fix does not address it — its
+`evictDetachedNodes` only runs when `state.removed` is set, and nothing here is removed.
+
+**Test sketch.** Reconcile a populated group vnode, then the same group with `children: []`; assert
+`domParent.querySelector('#g').children.length === 0`.
+
+---
+
+### F4 — leaving the surface never emits element-level `mouseleave` — HIGH
+`packages/dom/src/context.ts:111-113`, `:191-220`
+
+`_activeElements` is only reconciled inside `_handleHoverHitTest`, which only runs from
+`_handleMouseMove`. `_handleMouseLeave` emits the *context* `mouseleave` and nothing else, so an
+element that was hovered when the pointer left the canvas stays in `_activeElements` and never
+receives its `mouseleave`.
+
+**Failure (measured).** `mouseenter` → `mousemove` over an element → `mouseleave` on the surface →
+recorded element events: `['enter']`. No `leave`. This is common in practice: any element touching
+the canvas edge (a bar at the plot boundary, a full-bleed background, a legend swatch in the
+gutter) is the last thing under the pointer as it exits.
+
+**Impact is visible, not theoretical.** `packages/charts/src/core/interaction.ts:140-152` binds
+`tooltip.hide()` **and** the `restore` transition to the element's `mouseleave`. The tooltip is a
+scene `Group` (`packages/charts/src/components/tooltip.ts:61,163`), so it stays **painted on the
+chart** with the bar left highlighted while the pointer is elsewhere on the page. The cartesian
+axis-tooltip is unaffected because it hides on the *context* `mouseleave`
+(`packages/charts/src/core/cartesian.ts:1274`) — only the per-element hover path is broken.
+
+**Test sketch.** Hover an element, dispatch `mouseleave` on the surface, assert the element received
+`mouseleave` and that `_activeElements` is empty.
+
+---
+
+### F5 — a duplicate id silently deletes one element and reorders the rest — MEDIUM-HIGH
+`packages/dom/src/vdom.ts:99` (`desiredIds` Set), `:121-150`
+
+`desiredIds` is a `Set`, and `domCache` is keyed by id, so two sibling vnodes sharing an id resolve
+to the **same DOM node**. The second `updateElement` overwrites the first's attributes, the second
+recursion overwrites the first's subtree, and the index arithmetic in the reorder step
+(`domParent.children[i]`) desynchronises because the DOM has fewer children than the vnode list.
+
+**Failure (measured).** vtree `[dup(red), other(green), dup(blue)]` →
+```html
+<span id="other" fill="green"></span><span id="dup" fill="blue"></span>
+```
+Two nodes for three vnodes: the red element vanished entirely, and the surviving order is wrong
+(`other` before `dup`, expected `dup, other, dup`).
+
+Reachable because DOM ids come straight from Ripl element ids —
+`Shape2D.render` calls `context.createPath(this.id)`
+(`packages/core/src/core/shape.ts:150`) and `SVGContext._reconcilerOptions.createElement` stamps
+that id onto the node. `Element.id` is caller-supplied (`packages/core/src/core/element.ts:540`),
+and charts build ids from data (`packages/charts/src/components/grid.ts:206`,
+`annotation.ts:204,245,280`, `navigator.ts:310`), so any duplicate key/tick value in user data
+silently drops a mark. There is no uniqueness assertion anywhere.
+
+**Test sketch.** Reconcile a vtree with two sibling vnodes sharing an id and assert
+`domParent.children.length === vnode.children.length`; or add a dev-mode duplicate-id assertion in
+`reconcileNode` and test it fires.
+
+---
+
+### F6 — `click` fires immediately after a drag on the same gesture — MEDIUM
+`packages/dom/src/context.ts:248-261`, `:222-246`
+
+The DOM fires `click` after `mouseup`, and `_handleMouseUp` clears `dragStarted`/`dragElement`
+*before* `_handleClick` runs, so nothing records that the gesture was a drag. There is no
+suppression flag and no distance check in `_handleClick`.
+
+**Failure (measured).** `mousedown(10,10)` → `mousemove(100,100)` → `mousemove(140,140)` →
+`mouseup` → `click`. Element events: `['dragstart','drag','dragend','click']`. Dragging a chart
+element that also has a click handler (drill-down, selection toggle, navigation) fires the click
+action at the end of every drag.
+
+**Test sketch.** Run the gesture above and assert `click` is absent; then run a plain
+`mousedown`/`mouseup`/`click` under the drag threshold and assert `click` *is* present.
+
+---
+
+### F7 — a stale `dragElement` survives a `mousedown` that hits nothing — MEDIUM
+`packages/dom/src/context.ts:124-129`
+
+`_handleMouseDown` only assigns drag state inside `if (hitElements.length > 0)`. It never clears it
+in the `else` branch, so a mousedown on empty canvas leaves the *previous* gesture's
+`dragElement`, `dragStartX`, and `dragStartY` in place.
+
+**Failure (measured).** Strand a drag per F2, move the element out from under the pointer, then
+`mousedown` at (300,300) on empty space and move: events `['dragstart','drag']` — the old element
+starts dragging, and the `dragstart` payload carries the **first** gesture's origin (10,10), not
+(300,300). So the delta baseline is wrong too.
+
+**Test sketch.** `mousedown` on a hit element, then `mousedown` on empty space, then `mousemove`;
+assert no `drag` is emitted.
+
+---
+
+### F8 — `destroy()` / `disableInteraction()` leave a scheduled hit test that fires after teardown — MEDIUM
+`packages/dom/src/context.ts:146`, `:292-301`, `:303-308`; `packages/core/src/animation/utilities.ts:10-21`
+
+`createFrameBuffer` returns only a scheduling function — there is no handle to cancel. `destroy()`
+disposes listeners and removes the element but cannot cancel the in-flight
+`scheduleHitTest(() => this._handleHoverHitTest(x, y))`. `_handleHoverHitTest` touches no
+`_interactionState`, so it runs happily after teardown: it re-reads `renderedElements`, mutates the
+already-cleared `_activeElements`, and emits on scene elements.
+
+**Failure (measured).** `mouseenter` → `mousemove` → `ctx.destroy()` → next frame: the scene element
+receives `mouseenter`. In charts that starts a `renderer.transition` and shows a tooltip on a
+context whose surface is already detached from the DOM.
+
+**Test sketch.** Dispatch a `mousemove`, call `ctx.destroy()` synchronously, await two frames, assert
+zero element events. Fix shape: have `createFrameBuffer` return a `{ schedule, cancel }` pair (or a
+`Disposable`) and `retain` it under `INTERACTION_KEY`.
+
+---
+
+### F9 — `disableInteraction()` drops active elements without emitting `mouseleave` — MEDIUM
+`packages/dom/src/context.ts:300`
+
+`this._activeElements.clear()` discards the set silently. Every element that was mid-hover keeps its
+highlight state and its tooltip, with no leave event to unwind it. Same visible consequence as F4,
+reached through the public API instead of the pointer.
+
+**Failure (measured).** Hover an element (`mouseenter` recorded), call `ctx.disableInteraction()`,
+await a frame: events `[]`. The bar stays enlarged and the tooltip stays on screen indefinitely,
+because interaction is now off and nothing will ever produce the leave.
+
+**Test sketch.** Hover, `disableInteraction()`, assert the element received `mouseleave`.
+
+---
+
+### F10 — the tracked-element memo is not invalidated by `off()`, `once()` self-removal, or `EventBus.destroy()` — MEDIUM
+`packages/core/src/context/context.ts:671-673`; `packages/core/src/core/element.ts:626-641`;
+`packages/core/src/core/event-bus.ts:121-143,174-178`
+
+`_getTrackedElements` memoizes a **snapshot array** per event name and is only cleared by
+`invalidateTrackedElements`. `Element.on` wraps its disposable to invalidate on dispose — but that
+is the *only* invalidation path for listener changes, and three common routes bypass it:
+`EventBus.off(type, handler)` called directly, `EventBus.once`'s internal `this.off(type, callback)`
+after firing (`:139`), and `EventBus.destroy()`'s `_listeners.clear()` (`:176`).
+
+**Failure (measured).**
+- `a.on('click', h)` → render → prime memo → `a.off('click', h)`. `a.has('click') === false`, yet
+  `hitTest(['click'])` still returns `['a']`.
+- `top.once('click', h)` over `under`: after the once fires and self-removes,
+  `hitTest(['click'])` still returns `['top','under']`. `_handleClick` takes `hitElements[0]` =
+  `top` and emits into a bus with no listeners — **the click is swallowed and `under` never gets
+  it.** The element beneath is permanently shadowed by a dead one.
+
+`hitTest` never re-checks `element.has(event)`, so the stale entry is load-bearing.
+
+**Test sketch.** Prime the memo, then remove the listener via each of the three routes and assert
+`hitTest` no longer returns the element. Cheapest fix: re-filter on `has(event)` inside `hitTest`,
+or move invalidation into `EventBus.off`.
+
+---
+
+### F11 — a destroyed element stays hit-testable until the deferred rebuild — MEDIUM-LOW
+`packages/core/src/context/context.ts:671-673`; `packages/core/src/core/scene.ts:152-177`
+
+`Element.destroy()` → `parent.remove()` → `'graph'` → `requestFrame(rebuild)`, so
+`invalidateTrackedElements()` is deferred by a frame; `renderedElements` clears only on the next
+paint. In between, `hitTest` still returns the destroyed element, and because it sorts to the front
+under F1 it consumes the `hitElements[0]` slot.
+
+**Failure (measured).** Two hit elements, `el.destroy()`, then `hitTest(['click'],0,0)` in the same
+tick → `['other','target']` — the destroyed `target` is still returned. Its bus is cleared, so the
+emit is a no-op and the live element beneath never receives the event. Self-heals after ~1 frame.
+
+Verified *not* an unbounded leak: a `scene.remove()` + render + `destroy()` sequence does clear
+correctly (`'graph'` always fires), so this is a one-frame window, not a permanent stale entry.
+
+**Test sketch.** Destroy an element and assert `hitTest` excludes it synchronously.
+
+---
+
+### F12 — element `mousemove` payloads are CSS pixels; `click` and `drag` payloads are device pixels — MEDIUM
+`packages/dom/src/context.ts:216-219` vs `:178-185`, `:250-259`
+
+`_handleHoverHitTest` emits `{x: rx, y: ry}` — the raw `clientX/Y`-relative values — while
+`_handleClick` emits `{x: this.scaleX(...), y: this.scaleY(...)}` and `_handleDrag` does the same.
+`scaleX` maps CSS px → device px (`rescaleCanvas`, `packages/canvas/src/utilities.ts:249-252`
+returns `scaleContinuous([0,width],[0,width*dpr])`).
+
+**Failure (measured).** Same pointer position, scale factor 2:
+```
+element 'mousemove' payload -> { x: 50,  y: 50  }
+element 'click'     payload -> { x: 100, y: 100 }
+```
+`packages/charts/src/core/interaction.ts:107-152` documents `InteractionPoint` as "chart pixels" and
+feeds `onEnter`/`onLeave` from the `mousemove` payload while `onClick` reads the `click` payload —
+so on any HiDPI display the two callbacks report positions differing by the DPR for the same spot.
+
+**Test sketch.** Force a 2× scale, dispatch `mousemove` twice then `click` at the same client
+coordinates, assert the two element payloads are equal.
+
+---
+
+### F13 — a synchronous nested render pass duplicates `renderedElements` (and the SVG vtree) — MEDIUM *(mechanism confirmed; reachability SUSPECTED)*
+`packages/core/src/context/context.ts:488-499`; `packages/svg/src/context.ts:384-398`;
+`packages/core/src/core/scene.ts:162-169`
+
+`markRenderStart` only resets at `renderDepth === 0`. A `scene.render()` entered while an outer pass
+is open therefore appends to the outer pass's `renderedElements` — and, for SVG, appends to the same
+`_vtree`, producing duplicate ids that F5 then collapses. `batch()` also calls `clear()` at any
+depth, wiping what the outer pass had already drawn.
+
+**Failure (measured).**
+```js
+ctx.batch(() => {
+    ctx.currentRenderElement = a;   // outer pass in flight
+    scene.render();                 // Scene's resize handler does exactly this
+});
+// ctx.renderedElements -> ['a', 'a']
+```
+Duplicated entries double-count in the F1 paint-order map and in `_getTrackedElements`.
+
+**Reachability — honest assessment.** The obvious trigger (`Scene`'s `'resize'` handler calling
+`this.render()` synchronously at `scene.ts:166-168`) is *unlikely* in practice: `ResizeObserver`
+callbacks run in the "gather and broadcast resize observations" step, after animation-frame
+callbacks, so they cannot land inside `Renderer._tick`. I found no in-tree caller that reliably
+re-enters. Marked SUSPECTED for that reason; the corruption itself is confirmed.
+
+**Test sketch.** The snippet above, asserting `renderedElements` has no duplicates; plus the SVG
+variant asserting `_vtree` has no duplicate child ids. A `renderDepth > 0` guard in `Scene`'s resize
+handler (defer to the next frame) closes it.
+
+---
+
+### F14 — the `window.resize` fallback measures the border box; `ResizeObserver` reports the content box — LOW-MEDIUM
+`packages/dom/src/dom.ts:43-52` vs `:62-72`
+
+The observer path reports `entry.contentRect` (content box). The fallback reports
+`element.getBoundingClientRect()`, which is the **border box** — padding and border included. The
+two branches of the same function therefore return different numbers for the same element.
+
+**Failure.** Root `<div>` with `padding: 8px`, content width 400. Observer path → `rescale(400,…)`.
+Fallback path → `rescale(416,…)`, so the canvas backing store is 16px wider than the CSS box it is
+stretched over and every drawn coordinate is scaled by 400/416. Only bites on engines without
+`ResizeObserver` (Safari < 13.1), so severity is bounded by the fallback being near-dead code.
+
+Note also `observer.observe(element, { box: 'border-box' })` (`:54-56`) selects which box's changes
+are *reported* in `borderBoxSize`, but the handler reads `contentRect` — the option is inert, and a
+padding-only change that leaves the border box constant fires no notification.
+
+**Test sketch.** Stub `ResizeObserver` away, give the root padding, fire `window.resize`, and assert
+the reported width matches what the observer path would report.
+
+---
+
+### F15 — `onDOMElementResize` dereferences `window` unconditionally — LOW
+`packages/dom/src/dom.ts:42`
+
+`if ('ResizeObserver' in window)` throws `ReferenceError: window is not defined` outside a browser.
+The same module exports `hasWindow` (`:27`) for exactly this guard and does not use it. `@ripl/dom`
+is a published package with `sideEffects: false`, so this is reachable by any SSR/Node consumer
+calling the helper directly (the `DOMContext` path fails earlier at `document.querySelector`, so
+it is not the exposure).
+
+**Test sketch.** Run the module under `environment: 'node'` and assert `onDOMElementResize` degrades
+to a no-op disposable rather than throwing.
+
+---
+
+### F16 — Node `measureText` disagrees with the terminal context by 4×/2.5× and ignores `MeasureTextOptions` — MEDIUM
+`packages/node/src/index.ts:54-69`
+
+`nodeMeasureText(value)` takes no `options` and hard-codes 8px/char, ascent 8, descent 2. Two
+consequences:
+
+1. **It disagrees with the renderer it feeds.** `TerminalContext.measureText`
+   (`packages/terminal/src/context.ts:412-431`) reports `BRAILLE_CELL_WIDTH / _rasterScale` = **2**
+   logical units per char and `BRAILLE_CELL_HEIGHT / _rasterScale` = **4** ascent, descent 0
+   (`packages/terminal/src/rasterizer.ts:51,54`). But `Text._getLocalBoundingBox`
+   (`packages/core/src/elements/text.ts:98-110`) calls the *free* `measureText`, which always goes
+   through `factory.measureText` and never sees the context override. **Measured:** `"hello"` →
+   factory says width 40, ascent 8, descent 2; the terminal paints it at width 10, ascent 4,
+   descent 0. Text bounding boxes in Node are ~4× too wide and ~2.5× too tall, so hit boxes, group
+   box composition, label-collision culling, and tooltip sizing are all wrong.
+2. **It ignores font, `textAlign`, and `textBaseline`.** Measured: `{font:'10px monospace'}` and
+   `{font:'40px monospace'}` both return width 40; `textAlign: 'center'` still returns
+   `actualBoundingBoxLeft: 0` where a real canvas (and the web binding — see the explicit comment in
+   `packages/web/src/index.ts` `domMeasureText`) returns `width/2`. Centred and right-aligned text
+   boxes are anchored wrongly.
+
+**Test sketch.** Assert `factory.measureText('hello', {font:'40px …'}).width >
+factory.measureText('hello', {font:'10px …'}).width`, and assert the Node metric agrees with
+`TerminalContext.measureText` for the same string.
+
+---
+
+### F17 — Node `createContext` discards its `target` — LOW-MEDIUM
+`packages/node/src/index.ts:78-81`
+
+```js
+createContext: (target, options) => createContext(createTerminalOutput(), options as …)
+```
+`target` is dropped. `new Scene('#chart')` or `createChart({ target: someElement })` silently
+produces a terminal context writing to `process.stdout` regardless of what was asked for — the
+caller gets no error and no way to detect the substitution. It also builds a **fresh**
+`createTerminalOutput()` per context, each registering its own `SIGWINCH` handler
+(`packages/node/src/output.ts:26`), so ten scenes trip Node's `MaxListenersExceededWarning` and
+every handler fires on every resize.
+
+**Test sketch.** Call `factory.createContext('#anything')` twice and assert either a thrown error
+for a non-`TerminalOutput` target, or at minimum that `process.listenerCount('SIGWINCH')` does not
+grow per context.
+
+---
+
+### F18 — Node `createElement` / `createElementNS` return `{}`, defeating core's graceful-degradation guards — MEDIUM
+`packages/node/src/index.ts:84-85`
+
+`FactoryOptions` declares these as returning real `HTMLElement`/`Element`
+(`packages/core/src/core/factory.ts:25-28`). Returning `{}` means callers get a `TypeError` on the
+first DOM call instead of a detectable failure.
+
+**Failures (measured, under the real Node bindings).**
+- `getPathLength('M0,0 L10,10')` (`packages/core/src/math/geometry.ts:192-198`, exported from
+  `@ripl/core`) → **`TypeError: pathEl.setAttribute is not a function`**.
+- `packages/core/src/elements/image.ts:44-51` was clearly written to degrade:
+  `const context = canvas.getContext('2d'); if (!context) return undefined;` and the image
+  interpolator has an `if (!ref)` fallback at `:89-91`. The Node stub has **no `getContext` at
+  all**, so it throws before the guard can run — the intended non-DOM path is unreachable.
+
+In-tree the path-length callers are canvas-only (`packages/canvas/src/utilities.ts:259,270`), so
+today's exposure is via the public `@ripl/core` surface rather than the chart pipeline. Returning a
+minimal duck-typed stub (or `undefined` and letting the guards fire) fixes both.
+
+**Test sketch.** Under the Node bindings, assert `getPathLength(...)` and the image interpolator
+either return a defined fallback or throw a typed Ripl error — not a raw `TypeError`.
+
+---
+
+### F19 — `destroy()` is not idempotent: a second call re-emits `destroyed` — LOW
+`packages/core/src/core/event-bus.ts:174-178`
+
+`destroy()` emits `destroyed`, clears listeners, disposes — with no guard. `DOMContext.destroy()`
+(`packages/dom/src/context.ts:303-308`) is safe on its own (the `_interactionEnabled` flag and
+`Element.remove()` are both idempotent), but the base re-emit is not.
+
+**Failure (measured).** `ctx.destroy()` → register a new `destroyed` listener → `ctx.destroy()`
+again: the listener fires. `Renderer` wires `scene.once('destroyed', () => this.destroy())`
+(`packages/core/src/core/renderer.ts:255`), so this is a real teardown-ordering hazard for anything
+that re-subscribes.
+
+**Test sketch.** `destroy(); destroy();` and assert `destroyed` fired exactly once total.
+
+---
+
+### F20 — excluded nodes drift to the end of the parent — LOW
+`packages/dom/src/vdom.ts:137-145`
+
+`excludeSelectors` skips excluded nodes in the removal pass but the reorder step indexes
+`domParent.children[i]` — which still counts them — so managed children are repeatedly inserted
+*before* an excluded node and push it rightward.
+
+**Failure (measured).** `<defs>` at index 0 plus one existing child, reconciled against
+`[a, b]` → `<span id=a><span id=b><defs>`; `defs` moved from index 0 to index 2. Harmless for SVG
+`<defs>` (position-independent, and it settles at a stable trailing position), but it contradicts
+the documented contract "existing DOM children to leave untouched" and would reorder a
+position-sensitive excluded node (an overlay, a watermark).
+
+**Test sketch.** Reconcile with a leading excluded node and assert its index is unchanged.
+
+---
+
+### F21 — `createCanvasExport().toURL()` leaks an object URL on every call — LOW
+`packages/dom/src/export.ts:51`
+
+`URL.createObjectURL(...)` with no matching `revokeObjectURL` and no revoke hook on `ContextExport`
+(`packages/core/src/context/types.ts:166-176`). The blob is pinned for the document's lifetime; a
+"save chart" button on a 4K canvas leaks a few MB per press. `SVGContext.export()` has the same
+shape, so the fix belongs on the shared `ContextExport` contract.
+
+The rest of `export.ts` checks out: the snapshot is taken eagerly onto a detached canvas so later
+rendering can't mutate it; `Math.max(1, …)` plus the `canvas.width > 0` guard keeps a 0×0 canvas
+from throwing; `dataURLToBlob`'s `split(',')` is safe because base64 has no comma. `toURL` does
+encode the PNG twice (`toDataURL` then re-parse) — perf only.
+
+**Test sketch.** Spy on `URL.revokeObjectURL` and assert the export exposes a way to release the URL.
+
+---
+
+### F22 — releasing one finger after a pinch leaves the other finger inert — LOW-MEDIUM
+`packages/dom/src/navigator.ts:247-258`, `:189-216`
+
+`endPointer` unconditionally clears `_brushing`, `_panning`, and `_dragStart`. Lifting one finger of
+a two-finger pinch therefore drops the *remaining* pointer into a state where `pointermove` matches
+neither the pinch branch (size is now 1) nor the pan/brush branches (both flags cleared). The user
+is still touching the surface and dragging, and nothing moves until they lift and re-press.
+
+**Test sketch.** `pointerdown`×2 → `pointermove` (pinch) → `pointerup` (one) → `pointermove`; assert
+`panBy` is called.
+
+---
+
+### F23 — a gesture that neither pans nor brushes leaks its pointer id — LOW
+`packages/dom/src/navigator.ts:189-216`
+
+`_pointers.set(...)` happens at the top of `pointerdown`, but the `if (!this._brushing &&
+!this._panning) return` at `:205-207` bails **before** `setPointerCapture`. Without capture, a
+`pointerup` outside the element never reaches `endPointer`, so the entry is never deleted. The
+second pointer of a pinch takes the same early return at `:196` and is likewise uncaptured.
+
+**Failure.** Touch: a right-button/secondary gesture, or the second finger of a pinch, released off
+the surface leaves a stale entry; the next single-touch `pointerdown` makes `_pointers.size === 2`
+and is misread as a pinch, so a one-finger pan zooms instead. Mouse is largely immune (pointerId is
+constant, so the entry is overwritten).
+
+**Test sketch.** `pointerdown` with `button: 2`, `pointerup` dispatched elsewhere, then a normal
+`pointerdown` + `pointermove`; assert `panBy` is called and `zoomBy` is not.
+
+---
+
+### F24 — `_localPoint` forces a layout on every `pointermove` — LOW (perf)
+`packages/dom/src/navigator.ts:127-137`
+
+`getBoundingClientRect()` per move event, synchronously flushing layout mid-gesture. `DOMContext`
+caches this origin (see out-of-scope item (a) and its fix on `claude/pointer-origin`); the navigator
+should reuse the same cached-with-invalidation approach.
+
+---
+
+### F25 — `touchAction` is clobbered even when no interaction is enabled — LOW
+`packages/dom/src/navigator.ts:145-186`
+
+`_attachInteractions` runs whenever `options.interactions` is truthy, and sets
+`element.style.touchAction = 'none'` (`:154-155`) *before* resolving anything. Passing
+`{ zoom: false, pan: false, brush: false }` — or `{}` — is truthy, so native scrolling over the
+chart is disabled while no gesture is wired up. Related: `fallback` is `false` for object form, so
+`{ zoom: { sensitivity: 2 } }` silently disables pan and brush; defensible, but undocumented in the
+`interactions` JSDoc (`:26`).
+
+Verified correct in the same file: the `isInteractiveElement` feature detection (`:43-47`) means a
+terminal context degrades to an inert navigator rather than crashing; `destroy()` releases both
+retention keys and `super.destroy()` sweeps the rest; and the `wheel` `preventDefault()` works
+because the listener is on the surface element, not `window`/`document`/`body`, so the
+passive-by-default rule does not apply.
+
+---
+
+### F27 — the Node `requestAnimationFrame` pins the event loop open forever — MEDIUM
+`packages/node/src/index.ts:72`
+
+`requestAnimationFrame: (cb) => setTimeout(cb, 16)` returns a **ref'd** timer. `Renderer._tick`
+reschedules itself every frame (`packages/core/src/core/renderer.ts:277,287`) and `autoStart`
+defaults to `true`, so the process can never exit. `autoStop` cannot rescue a static scene: it fires
+only from `context.on('mouseleave')` — which `TerminalContext` never emits — or from a transition
+completing (`renderer.ts:251,569,610`).
+
+**Failure (measured).** A script that builds a terminal context, a `Scene` with one circle, and a
+`Renderer` was **still alive at 1500ms** with no other ref'd handles. Control run with the
+`createRenderer` line removed exits immediately (code 0). A CLI that renders one chart and finishes
+hangs until killed. An *animated* chart does exit, because the transition's completion callback
+reaches `_stopOnIdle()`.
+
+**Test sketch.** Spawn a child process that creates a scene + renderer and assert it exits within a
+timeout. Fix: `.unref()` the timer (accepting that the loop no longer holds the process open) or
+have `@ripl/node` document/require an explicit `renderer.destroy()`.
+
+---
+
+### F28 — the Node `requestAnimationFrame` callback receives no timestamp — LOW
+`packages/node/src/index.ts:72`
+
+`FactoryOptions.requestAnimationFrame(callback: FrameRequestCallback)` promises a
+`DOMHighResTimeStamp` argument; `setTimeout(cb, 16)` invokes `cb()` with none. Harmless today —
+every in-tree consumer (`Renderer._tick`, `createFrameBuffer`, `Scene`'s rebuild,
+`SVGContext._commit`) ignores the argument and reads `factory.now()` instead — but it silently
+breaks any consumer written against the declared contract.
+
+---
+
+## Verified correct (no finding)
+
+- **Reconciler reordering.** The "insert before whatever currently sits at index `i`" algorithm is
+  correct for arbitrary permutations — checked `[C,A,B]`, `[B,C,A]`, and the full reverse `[C,B,A]`;
+  each converges in one pass with the minimum number of moves.
+- **`getAncestorGroupIds` / `ensureGroupPath`.** Correct (root→leaf order, scene root excluded,
+  intermediate nodes created idempotently) and well covered by `packages/dom/test/reconcile.test.ts`.
+  Note they have **no callers** anywhere in the monorepo — public API only.
+- **`getChildId`.** Default (`getAttribute('id')`) matches what `SVGContext.createElement` stamps.
+  Nodes with no id and no `excludeSelectors` match are removed — that is the documented purpose of
+  `excludeSelectors`, not a bug.
+- **Node moved between groups.** Node identity is preserved via `domCache` when the destination
+  group reconciles first; when the source reconciles first the node is recreated. No corruption
+  either way.
+- **`DOMContext` disposal.** Every listener (`INTERACTION_KEY`) and the `ResizeObserver` (default
+  key) is released: `Context.destroy()`'s unkeyed `dispose()` sweeps all keys, and
+  `EventBus.destroy()`'s second `dispose()` is a harmless no-op. The only unreleased resource is the
+  frame buffer (F8).
+- **`enableInteraction` after `disableInteraction`** correctly rebuilds state and re-attaches.
+- **Hit-test coordinate spaces.** `_handleMouseDown`, `_handleClick`, and `_handleHoverHitTest` all
+  scale into device pixels before calling `hitTest`, matching `Element.intersectsWith`'s documented
+  expectation. (The *emitted payloads* are inconsistent — that is F12.)
+- **`export.ts` snapshot semantics.** Eager copy onto a detached canvas; degenerate sizes guarded;
+  `dataURLToBlob` parsing sound.
+- **Navigator feature detection, disposal, and non-passive `wheel`.** All correct.
+- **Resize measurement target.** Both the initial `init()` measure and the observer read the same
+  effective box for a `width:100%` surface; the mismatch is confined to the fallback (F14).
+- **Node `factory.set` completeness.** All ten `FactoryOptions` members are supplied, and
+  `"sideEffects": true` correctly prevents the registration from being tree-shaken.
+
+---
+
+## Ranked summary
+
+| Rank | ID | Severity | Defect | Status |
+|------|----|----------|--------|--------|
+| 1 | F1 | High | `hitTest` sorts by additive z-index, not paint order — wrong element reported topmost across groups | CONFIRMED |
+| 2 | F2 | High | `mouseup` outside the surface strands the drag; no `dragend`, drag resumes with no button held | CONFIRMED |
+| 3 | F3 | High | A group that empties keeps its stale DOM children painted and hit-testable | CONFIRMED |
+| 4 | F4 | High | Leaving the surface never emits element `mouseleave` — tooltip and highlight stay stuck | CONFIRMED |
+| 5 | F5 | Med-High | Duplicate sibling id deletes one element and reorders the rest | CONFIRMED |
+| 6 | F6 | Medium | `click` fires immediately after every drag | CONFIRMED |
+| 7 | F27 | Medium | Node `rAF` pins the event loop — a static chart never lets the process exit | CONFIRMED |
+| 8 | F16 | Medium | Node `measureText` is 4×/2.5× off vs the terminal and ignores `MeasureTextOptions` | CONFIRMED |
+| 9 | F8 | Medium | `destroy()` cannot cancel the pending hit test; events fire after teardown | CONFIRMED |
+| 10 | F10 | Medium | Tracked-element memo survives `off()` / `once()` / `EventBus.destroy()`; dead element shadows the live one | CONFIRMED |
+| 11 | F12 | Medium | Element `mousemove` payload is CSS px, `click`/`drag` are device px | CONFIRMED |
+| 12 | F9 | Medium | `disableInteraction()` drops active elements without `mouseleave` | CONFIRMED |
+| 13 | F7 | Medium | Stale `dragElement` survives a `mousedown` that hits nothing | CONFIRMED |
+| 14 | F18 | Medium | Node `createElement`/`createElementNS` return `{}`, defeating core's degradation guards | CONFIRMED |
+| 15 | F13 | Medium | Nested render pass duplicates `renderedElements` / the SVG vtree | mechanism CONFIRMED, reachability SUSPECTED |
+| 16 | F11 | Med-Low | Destroyed element stays hit-testable for ~1 frame | CONFIRMED |
+| 17 | F22 | Low-Med | Releasing one finger after a pinch leaves the other inert | CONFIRMED (by trace) |
+| 18 | F14 | Low-Med | Resize fallback measures the border box; observer reports the content box | CONFIRMED (by trace) |
+| 19 | F17 | Low-Med | Node `createContext` discards `target`; one `SIGWINCH` handler leaked per context | CONFIRMED (by trace) |
+| 20 | F23 | Low | Uncaptured gesture leaks a pointer id; next gesture misread as a pinch | CONFIRMED (by trace) |
+| 21 | F19 | Low | `destroy()` re-emits `destroyed` on a second call | CONFIRMED |
+| 22 | F20 | Low | Excluded nodes drift to the end of the parent | CONFIRMED |
+| 23 | F21 | Low | `toURL()` never revokes its object URL | CONFIRMED (by trace) |
+| 24 | F15 | Low | `onDOMElementResize` dereferences `window` unguarded | CONFIRMED (by trace) |
+| 25 | F25 | Low | `touchAction` clobbered even with every interaction disabled | CONFIRMED (by trace) |
+| 26 | F24 | Low | `_localPoint` forces layout on every `pointermove` | CONFIRMED (by trace) |
+| 27 | F28 | Low | Node `rAF` callback receives no timestamp | CONFIRMED (by trace) |
+| — | SEED | — | `createFrameBuffer` mousemove starvation | **REFUTED** — correct per-frame throttle; measured 1 hover per frame at 20 moves/frame |

--- a/docs/audits/svg.md
+++ b/docs/audits/svg.md
@@ -1,0 +1,563 @@
+# SVG rendering-context audit (`packages/svg/src/*` + `packages/dom/src/vdom.ts`)
+
+**Baseline:** `main` (`8121b9d`). `packages/svg/**` and `packages/dom/**` are byte-identical between
+`main` and the checked-out branch, so every line reference below is a `main` line number.
+`yarn vitest run packages/svg packages/dom` is green on this baseline (139 tests) — everything below is
+a *new* finding, not a pre-existing failure.
+
+**Out of scope (as instructed, not reported):** gradient/pattern re-parse per resolve, `<stop>` rebuild
+per update, the `buffer` flag / rAF-deferred commit, `_domCache` retaining descendants of removed
+groups, `_isPointIn` resolving via `getElementById`.
+
+**Method:** every CONFIRMED finding below was reproduced against the real `SVGContext`/`CanvasContext`
+in jsdom (scratch spec, since deleted). SUSPECTED findings are code/spec reasoning I could not execute
+in jsdom (which implements neither SVG rendering nor `SVGGeometryElement.isPointInFill`).
+
+---
+
+## Checklist verification summary
+
+| # | Item | Verdict |
+|---|---|---|
+| 1 | save/restore symmetry, `_transformStack` / `_clipStack` | **Mostly correct** — stacks stay index-aligned with `states` under balanced use. Two defects: **S-9** (root-level clip grows all three stacks by one entry per frame, forever) and **S-14** (`restore()` pops the SVG stacks even when the base `restore()` no-ops). |
+| 2 | `markRenderStart`/`markRenderEnd` depth + vtree reset | **Correct for balanced use** — depth-0 gating resets `_vtree`/`_currentParentVNode`/`_vnodeStack`/`_usedDefs`, and `markRenderEnd` commits exactly once per outermost pass. Defect **S-13**: any imbalance is *permanently* unrecoverable. Note `markRenderStart` deliberately does **not** reset `_transformStack`/`_clipStack`/`saveDepth`, which is what lets **S-9** accumulate. |
+| 3 | push/popGroup balance, `_vnodeStack`, group opacity, group-scoped clip | `_vnodeStack` push/pop is balanced and defensively falls back to `_vtree`. Group opacity stamping is **correct in isolation** (`<g style="opacity">` + `currentState.opacity = 1`) — verified `OUTER 0.5 → INNER 0.5 → leaf` produces nested `<g opacity=.5>` with the leaf carrying only its own value. But it **diverges from canvas** (**S-5**). The group-scoped clip's dangling `save()` is correctly absorbed by `popGroup` *inside a group* — but not at the scene root (**S-9**) — and the clip itself is mis-scoped (**S-2**, **S-3**). |
+| 4 | Transform composition | **Correct.** `pushGroup` writes `_currentTransforms.join(' ')` onto the `<g>` and then resets `_currentTransforms = []` (ctx.ts:545), so a leaf carries only its own transform and the group transform is supplied once by the native `<g>`. Verified `<g OUTER translate(50,0)><g INNER translate(20,0)><path …>` — no double application. A `clip: true` shape's `skipRestore` leaks its own transform onto later siblings, but canvas leaks it identically (same CTM), so **parity holds**. |
+| 5 | `<defs>` lifecycle, `_usedDefs` keying, cache keys | **Correct.** All five namespaces round-trip: `gradient:${id}:fill|stroke`, `pattern:${id}:fill|stroke`, `clip:${pathId}`, `textpath:${textId}`, `shadow:${elementId}` are added in the resolvers and swept with matching namespaces in `_sweepDefs` (ctx.ts:300-306). `_usedDefs` is cleared only at depth 0; the sweep runs *after* the reconcile (ctx.ts:378-381), so no live node ever references a just-deleted def. `_shadowCache`/`_textPathCache` keys are stable because `Shape2D` passes `this.id` to `createPath` and `Text` passes `id: this.id` to `createText` (`core/src/elements/text.ts:116`). Verified a shadow filter is created, refreshed and then swept when the shadow is removed. Only caveat: a multi-path element (`Polyline` with `segments`) mints one gradient/shadow def **per path node** rather than per element (cosmetic/perf; the geometry is identical because bounds come from `currentRenderElement`). |
+| 6 | `_removeFromVTree` narrow search | See **S-16** — no *reachable* caller breaks it today (the only in-tree `applyClip` caller is `Shape2D.render`, which creates and clips within one `_currentParentVNode`), but it is latent, and its sibling defect (only the *primary* path is removed) is real. |
+| 7 | Text metrics, `<textPath>`, attribute handling | `<textPath>` wiring is **correct** — verified `<text id="T2"><textPath id="T2:textpath" href="#textpath-…" startOffset="25%">curved</textPath></text>` with the geometry `<path>` in `<defs>`, and `SVGText.definition.textContent` correctly returns `undefined` when `pathData` is set so the `<textPath>` child is not wiped. Defects: **S-11** (`maxWidth` dropped), **S-8** (scene font), **S-21** (`alignment-baseline` dead weight). |
+| 8 | `updateSVGElement` stale removal | **Correct.** Verified across frames: a `<path>` that had `filter="url(#shadow-…)"` and `transform="translate(10,10)"` in frame 1 has **both attributes removed** in frame 2 when the definition no longer carries them, and the orphaned shadow filter is swept from `<defs>`. Ordering is right (set-then-prune for both attributes and styles) and `id` is correctly exempted. The `APPLIED_DEFINITION` snapshot holds a *reference* to the previous frame's `attributes` object rather than a copy, which is safe only because every backend object is rebuilt per frame — worth a comment, not a bug. |
+| 9 | `export()` / `destroy()` | `export()` correctly forces a synchronous `_commit()` first. Defects: **S-10** (no `destroy()` override at all), **S-17** (no `width`/`height` in the exported markup). |
+| 10 | Canvas/SVG visual parity | **S-4** (group gradient — the assigned deep-dive), **S-5** (opacity), **S-2**/**S-3** (clip), **S-6** (hit testing), **S-8** (font), **S-11** (maxWidth), **S-12** (blend mode), **S-18** (shadow space), **S-20** (filter order). |
+
+---
+
+## CONFIRMED findings
+
+### S-1 · `packages/dom/src/vdom.ts:147` · HIGH
+**Defect:** `reconcileNode` only recurses into a child when `childVNode.children.length > 0`, so a
+container whose vnode has *zero* children is never reconciled and keeps the previous frame's DOM
+children forever.
+
+```ts
+if (childVNode.children.length > 0) {
+    reconcileNode(domChild, childVNode, domCache, options);
+}
+```
+
+**Failure scenario (reproduced):** `group = createGroup({ id: 'G' })` holding shapes `A` and `B`;
+render → `<g id="G"><path id="A"/><path id="B"/></g>`. Call `group.clear()` and render again.
+`Scene._collectInstructions` still emits a `push`/`pop` pair for the now-empty group, so
+`SVGContext.pushGroup` (ctx.ts:506) creates a `<g>` vnode with `children: []`, the guard skips the
+recursion, and the DOM is **unchanged**: `<g id="G"><path id="A"/><path id="B"/></g>`. The removed
+elements stay painted for the rest of the session. `_domCache` still lists `['G','A','B']`.
+
+The 2→1 transition works correctly (only 2→0 breaks), which is why this has gone unnoticed —
+it fires exactly when a group is emptied (chart series toggled off, `axis.set([])`, a filtered
+category dropping to zero, a legend clearing, `group.set([])` during a data update).
+A group that renders *only* a `clip: true` child hits the same path: it produces `<g id="GC"></g>`
+with zero vnode children, so any children it had last frame survive.
+
+**Severity:** HIGH — wrong pixels, permanent, common trigger.
+
+**Test sketch:**
+```ts
+test('Should remove every child when a group is emptied', () => {
+    const scene = createScene(ctx);
+    const group = createGroup({ id: 'G', children: [rectA, rectB] });
+    scene.add(group);
+    scene.render();
+    expect(ctx.element.querySelector('#G')!.children.length).toBe(2);
+
+    group.clear();
+    scene.render();
+    expect(ctx.element.querySelector('#G')!.children.length).toBe(0); // fails: still 2
+});
+```
+Also worth a `packages/dom/test/reconcile.test.ts` unit: reconcile `{id:'g', children:[a,b]}` then
+`{id:'g', children:[]}` against the same DOM parent.
+
+---
+
+### S-2 · `packages/svg/src/context.ts:596-623` (`applyClip`) · HIGH
+**Defect:** `_currentClipId` is a single scalar, so a second `applyClip` in the same scope **replaces**
+the active clip instead of intersecting with it; canvas's `ctx.clip()` always intersects.
+
+**Failure scenario (reproduced):** apply clip `rect(0,0,50,50)`, then clip `rect(25,25,50,50)`, then
+fill a `rect(0,0,100,100)`.
+- Canvas: `ctx.clip()` called twice → the leaf paints only in the intersection `25,25 → 50,50`.
+- SVG: leaf gets `clip-path="url(#clip-2)"` only → it paints across the whole `25,25 → 75,75`.
+Both `<clipPath>` defs are emitted into `<defs>`; only the last is referenced.
+
+The same defect covers the far more common nesting form: an outer group establishing a plot-area clip
+and an inner group establishing a brush/zoom clip — descendants of the inner group escape the outer
+clip entirely.
+
+**Severity:** HIGH — silently paints outside the intended region.
+
+**Test sketch:** two `clip: true` shapes as siblings, then a leaf; assert the leaf's `clip-path`
+resolves to a def whose geometry is the intersection (or that the leaf carries *two* clip references,
+e.g. a `<g clip-path>` wrapper plus the leaf's own).
+
+---
+
+### S-3 · `packages/svg/src/context.ts:338-340` + `506-546` · HIGH
+**Defect:** the clip is stamped on each **leaf** (`element.definition.attributes['clip-path']`) and never
+on the `<g>` that established it. `<clipPath>` defaults to `clipPathUnits="userSpaceOnUse"`, which is the
+user space of the *referencing element* — so a leaf nested inside further transformed `<g>` nodes has the
+clip geometry displaced by those transforms. On canvas the clip region is baked into device space at
+`ctx.clip()` time and is immune to later transforms.
+
+**Failure scenario (reproduced structurally):**
+```
+<g id="OUTER" transform="translate(50,0)">
+  <g id="INNER" transform="translate(20,0)">
+    <path id="LEAF" … clip-path="url(#clip-bd3f2273)"/>
+<defs><clipPath id="clip-bd3f2273"><path d="M 0,0 L 40,0 L 40,40 L 0,40 L 0,0"/></clipPath></defs>
+```
+The clip shape is a child of `OUTER`, so its geometry is authored in `OUTER`'s space (root-x `50..90`).
+`LEAF` sits inside `INNER`, so the browser resolves the clip in `OUTER ∘ INNER` space → root-x `70..110`.
+**20px off**, and the error grows with nesting depth. A rotated or scaled inner group also rotates/scales
+the clip.
+
+Note `applyClip` (ctx.ts:611-615) *does* write `_currentTransforms` onto the `<clipPath>`'s `<path>`,
+which correctly accounts for the clip shape's own transform — the bug is purely the ancestor `<g>`s
+between the clip's scope and the referencing leaf.
+
+**Severity:** HIGH — any nested-group scene with a group-scoped clip (cartesian plot area + a
+transformed series group is the canonical chart layout).
+
+**Test sketch:** build `OUTER(translate 50) > [clip rect(0,0,40,40), INNER(translate 20) > leaf]`;
+assert the leaf's clip is expressed in the space it was authored in — e.g. that `clip-path` lands on
+`<g id="OUTER">` rather than on the leaf, or that the `<clipPath>` path carries a compensating
+`transform`.
+
+---
+
+### S-4 · Group gradient fill — the assigned deep-dive · HIGH
+**Defect:** a `Group` carrying a gradient `fill` produces three different pictures depending on the
+backend, and *neither* backend resolves it against the group's own box.
+
+**Exactly how it diverges.** `Context.pushGroup` (`core/src/context/context.ts:526`) calls
+`applyGroupPaint`, which runs `CONTEXT_OPERATIONS.fill(this, group.fill)` — i.e. it assigns the
+gradient *string* to `context.fill` once, at the group boundary.
+
+*Canvas* (`packages/canvas/src/mixins.ts:159-169`): the `fill` setter resolves eagerly:
+```ts
+const bounds = getGradientBounds(this.gradientBounds(), this.width, this.height);
+setCanvasFill(this.context, value, bounds);
+```
+`gradientBounds()` (mixins.ts:332-334) returns `this.currentRenderElement?.getBoundingBox(true)`.
+**`currentRenderElement` is never the group.** `context.currentRenderElement = this` is assigned only in
+`Element.render` (`core/src/core/element.ts:859`); `Group.render` (group.ts:194) overrides `render`
+entirely without setting it, and `RENDER_OPERATIONS.push` (scene.ts:60) / `Renderer._renderBuffer`
+(renderer.ts:368) call `context.pushGroup(element)` directly. So the group's gradient resolves against
+whatever leaf was rendered **last**, or `undefined`. Reproduced:
+- group is the first thing in the frame → `createLinearGradient(0, 50, 200, 50)` — the fallback
+  full-surface box `{0,0,200,100}` from `getGradientBounds`.
+- a leaf with local box `(0,0,7,7)` drawn immediately before the group →
+  `createLinearGradient(0, 3.5, 7, 3.5)` — **the previous leaf's box**. The group's gradient therefore
+  depends on unrelated paint order.
+
+Exactly **one** `CanvasGradient` is created and every leaf under the group shares it, so the ramp runs
+continuously across the group (each leaf shows its slice of one ramp).
+
+*SVG* (`packages/svg/src/context.ts:631-635` → `_resolveGradientStyle`, ctx.ts:198-243): the group's
+`fill` string is only stored in `currentState`; it is resolved **per leaf**, in `applyFill`, with
+`cacheKey = \`${element.id}:fill\`` and bounds `this.currentRenderElement?.getBoundingBox(true)` — which
+at that point *is* the leaf. Reproduced with leaves A (local box `0..50`) and B (local box `100..200`)
+under a group with `linear-gradient(90deg,#f00,#00f)`:
+```html
+<g id="G">
+  <path id="A" style="fill:url(#gradient-b906e3fb)" …/>
+  <path id="B" style="fill:url(#gradient-66af74ba)" …/>
+</g>
+<defs>
+  <linearGradient id="gradient-b906e3fb" gradientUnits="userSpaceOnUse" x1="0"   y1="25" x2="50"  y2="25">…
+  <linearGradient id="gradient-66af74ba" gradientUnits="userSpaceOnUse" x1="100" y1="25" x2="200" y2="25">…
+```
+Two independent defs; each leaf shows the **full** red→blue ramp restarted over its own box.
+
+**Net picture for the same scene:** canvas paints one ramp spanning `x∈[0,200]` (so A is nearly all red
+and B is the blue half); SVG paints two complete red→blue ramps. Additionally the canvas result silently
+changes if you add or reorder an unrelated sibling before the group.
+
+**What a fix would have to change** (scoping only, not fixing):
+1. **Make the group the render element at its boundary.** `pushGroup` (or `RENDER_OPERATIONS.push` /
+   `Renderer._renderBuffer`) must set `context.currentRenderElement = group` for the duration of the
+   boundary and restore it afterwards, so `gradientBounds()`/`_resolveGradientStyle` see the group's
+   `getBoundingBox(true)`. `Group.getBoundingBox` (group.ts:178) already composes children, and
+   `Group._boundsCacheable` is `false`, so this is a live (uncached) union — note the cost.
+   Careful: `currentRenderElement`'s setter pushes non-abstract elements into `renderedElements`;
+   groups are `abstract = true` (element.ts:250 / group.ts:81), so they are correctly skipped.
+2. **Resolve the group's paint once at the boundary in SVG too.** `pushGroup` would have to run the
+   gradient/pattern resolution against the group box, key the def by the *group* id
+   (`gradient:${group.id}:fill`), stamp `fill="url(#…)"` on the `<g>`, and stop
+   `_resolveGradientStyle` from re-resolving for a leaf whose fill it did not itself set. The cheapest
+   discriminator is a flag in `currentState` (e.g. "the current fill is already a resolved `url(#…)`")
+   set by `pushGroup` and cleared by any leaf-level `CONTEXT_OPERATIONS.fill`.
+   Doing so also makes the SVG cascade match SVG's own `fill` inheritance instead of stamping a
+   redundant `fill` on every leaf.
+3. **Decide the semantics deliberately** and encode it in `getGradientBounds`' contract: "a group's
+   gradient resolves against the group's local box; a leaf's own gradient against the leaf's local box."
+   Today `getGradientBounds`' doc claims cross-backend identity, which is false at group boundaries.
+4. A group-box gradient must be invalidated when children move — `Group._boundsCacheable === false`
+   means it is recomputed each frame anyway, but the def would then need rewriting every frame
+   (bounds already are; the stops are the out-of-scope concern).
+
+**Severity:** HIGH.
+
+**Test sketch:** one spec, two contexts, one scene factory (group with a gradient fill + two leaves at
+disjoint boxes). Assert canvas records exactly one `createLinearGradient(x0,y0,x1,y1)` and SVG emits
+exactly one `<linearGradient>` with the *same* `x1/x2`, and that both equal the group's box, not the
+surface and not a leaf's box.
+
+---
+
+### S-5 · Group opacity vs a leaf's own opacity · HIGH
+**Defect:** `Context.pushGroup` composites group opacity **multiplicatively**
+(`this.opacity *= opacity`), but a leaf's own opacity is applied by
+`CONTEXT_OPERATIONS.opacity` → `basicContextSetter('opacity')` → plain **assignment**. On canvas that
+assignment overwrites `globalAlpha`, discarding the accumulated group alpha. In SVG the leaf's value is
+stamped as its own `opacity` style *inside* the ancestor `<g opacity>` nodes, so it multiplies.
+
+**Failure scenario (reproduced, both backends, same scene):**
+`OUTER(opacity .5) > INNER(opacity .5) > [LEAF_OWN(opacity .5), LEAF_NONE(no opacity)]`
+- Canvas fills: `LEAF_OWN` at `globalAlpha` **0.5**; `LEAF_NONE` at **0.25**.
+- SVG: `<g id="OUTER" style="opacity:.5"><g id="INNER" style="opacity:.5"><path id="LEAF_OWN" style="…opacity:.5"><path id="LEAF_NONE" style="…opacity:1">`
+  → effective **0.125** and **0.25**.
+
+`LEAF_NONE` matches; `LEAF_OWN` is 4× more transparent in SVG. This is the single most likely visual
+difference in practice, because chart enter/exit transitions animate `opacity` on leaves that sit inside
+groups (and `Element.interpolate` writes straight into `state`, so every animated frame hits this path).
+
+Note SVG's behaviour is the DOM-correct one; canvas's assignment is the anomaly. Either way the two
+backends disagree.
+
+**Severity:** HIGH.
+
+**Test sketch:** render the scene above into both contexts; assert the effective alpha of `LEAF_OWN` is
+identical (record `globalAlpha` at `fill()` on a stateful canvas stub; multiply the `<g>`/leaf `opacity`
+styles on the SVG side).
+
+---
+
+### S-6 · SVG box hit testing is off by the device pixel ratio · HIGH
+**Defect:** `Context.rescale` (`core/src/context/context.ts:417-425`) leaves `scaleX`/`scaleY` as an
+identity mapping — for SVG the hit point stays in **CSS pixels**. `rescaleCanvas`
+(`packages/canvas/src/utilities.ts:250-253`) maps to **device pixels**. But
+`Element.intersectsWith` (`core/src/core/element.ts` — the base, box-based test) divides by
+`scaleDPR(1)` unconditionally:
+```ts
+const dpr = this.context?.scaleDPR(1) ?? 1;
+return isPointInBox([x / dpr, y / dpr], this.getBoundingBox());
+```
+`scaleDPR` is built in the base `Context` constructor for *every* backend (context.ts:412), so on SVG it
+is the real device pixel ratio while the incoming point was never multiplied by it.
+
+**Failure scenario (reproduced with `devicePixelRatio = 2`):** a `Text` element at `(100,50)` with box
+`{left:100, top:42, right:150, bottom:52}`. `DOMContext._handleClick` produces
+`scaleX(125) = 125, scaleY(47) = 47` for a click at the box centre.
+`label.intersectsWith(125, 47)` → **false**. It only returns `true` at `(250, 94)`.
+The same canvas scene produces `scaleX(125) = 250` and hits correctly.
+
+Applies to every element whose hit test falls through to the base box test: `Text`, `ImageElement`,
+`Group`, and any `Shape2D` with no traced path. Path-backed shapes are unaffected (they route through
+`_isPointIn`). On a standard Retina/2× laptop, **no SVG text label, legend entry or axis label is
+clickable/hoverable at the right place** — clicks land at half coordinates.
+
+**Severity:** HIGH.
+
+**Test sketch:**
+```ts
+factory.set({ devicePixelRatio: 2 });
+// same Text element, same click coordinates, canvas vs svg
+expect(svgLabel.intersectsWith(ctx.scaleX(cx), ctx.scaleY(cy), { isPointer: true })).toBe(true);
+```
+
+---
+
+### S-7 · `packages/svg/src/context.ts:489` (`drawImage`) · HIGH (performance)
+**Defect:** `canvasImageSourceToDataURL(image, imgWidth, imgHeight)` is invoked on **every render pass**.
+It allocates a fresh `<canvas>`, draws the source into it and calls `toDataURL()` — a synchronous full
+PNG encode + base64 — and the resulting multi-megabyte string is then written to the live `<image>`'s
+`href` attribute by `updateSVGElement`, forcing the browser to re-decode the image every frame too.
+
+**Failure scenario (reproduced):** one `ImageElement` in a scene; `HTMLCanvasElement.prototype.toDataURL`
+is called once per `scene.render()` (1 call after 1 frame, 3 after 3). At 60fps with a 512×512 image
+that is ~60 PNG encodes/second per image. Canvas does a plain `ctx.drawImage`.
+
+The href is content-addressable and the `SVGImage` id is stable (`renderElement.id`), so the encode
+should be memoized per source+size and the attribute only rewritten when it changes.
+
+**Severity:** HIGH (perf) — a single image element makes an SVG scene unusable.
+
+**Test sketch:** spy on `HTMLCanvasElement.prototype.toDataURL`; render three frames with an unchanged
+image; expect exactly one call.
+
+---
+
+### S-8 · `packages/core/src/core/scene.ts:140` · MEDIUM
+**Defect:** the scene root inherits the host element's computed font only when
+`context.element instanceof HTMLElement`. `SVGSVGElement` is **not** an `HTMLElement`
+(it extends `SVGElement`), so an SVG scene never picks up the page font.
+
+**Failure scenario (reproduced):** host `<div style="font: italic bold 22px/1 Georgia">`.
+- canvas scene root `font` → `"italic bold 22px / 1 Georgia"`
+- SVG scene root `font` → `undefined` → every text element falls back to the context default
+  `10px sans-serif`.
+
+This changes both what is painted **and** the layout: `Text._getLocalBoundingBox` measures with
+`getComputedValue('font')`, so bounding boxes, label collision avoidance and axis tick spacing all shift
+between backends for the same chart.
+
+**Severity:** MEDIUM (visible on every text-bearing chart; trivially fixed by testing for `Element`
+rather than `HTMLElement`, or by reading the context's `root`).
+
+**Test sketch:** as above — construct both contexts on identically styled hosts and assert
+`scene.font` matches.
+
+---
+
+### S-9 · `packages/core/src/context/context.ts:502-513` + `packages/svg/src/context.ts:555-566` · MEDIUM
+**Defect:** a `clip: true` shape that is a **direct child of the scene** (not inside a group) leaves a
+dangling `save()` that nothing absorbs. `Shape2D.render` passes `skipRestore = this.clip`
+(`core/src/core/shape.ts:170`); inside a group `popGroup` unwinds to the recorded depth, but the scene
+root emits no `push`/`pop`, and `Context.batch` performs exactly one `save()`/`restore()` pair.
+
+**Failure scenario (reproduced):** scene with a root-level `clip: true` shape plus one leaf, rendered
+three times:
+
+| after frame | `saveDepth` | `states.length` | `_transformStack` | `_clipStack` |
+|---|---|---|---|---|
+| 1 | 1 | 1 | 1 | 1 |
+| 2 | 2 | 2 | 2 | 2 |
+| 3 | 3 | 3 | 3 | 3 |
+
++1 per frame, unbounded — ~216k retained state objects per hour at 60fps, across four arrays
+(two of them SVG-specific). Painted output stays correct (`_currentClipId` does return to `undefined`),
+so this is a pure leak, but `markRenderStart` deliberately does not reset these stacks, so nothing ever
+recovers.
+
+**Severity:** MEDIUM.
+
+**Test sketch:** render a scene containing a root-level `clip: true` shape ten times; assert
+`(ctx as any).saveDepth === 0` and `_transformStack.length === 0` afterwards.
+
+---
+
+### S-10 · `packages/svg/src/context.ts` (no `destroy()` override) · MEDIUM
+**Defect:** `SVGContext` never overrides `destroy()`. `DOMContext.destroy()` removes the `<svg>` and
+disposes retained subscriptions, but nothing cancels the pending `_requestFrame` commit, and none of
+`_domCache`, `_gradientCache`, `_patternCache`, `_textPathCache`, `_clipCache`, `_shadowCache`,
+`_vtree`, `_vnodeStack`, `_transformStack`, `_clipStack` are cleared. `createFrameBuffer`
+(`core/src/animation/utilities.ts:10-21`) returns only a scheduler — it exposes no cancel handle.
+
+**Failure scenario (reproduced):** create a standalone `SVGContext` (`buffer === true`), run one
+render pass, call `destroy()`, then wait two animation frames — `_commit()` still fires and reconciles
+the **detached** `<svg>` (which ends up with 2 children after destroy). Anything holding the context
+alive (a devtools panel, a `WeakRef`-free registry) also keeps every cached `<defs>` node and every
+cached DOM node alive.
+
+**Severity:** MEDIUM (post-destroy work + retention; not wrong pixels).
+
+**Test sketch:** spy on `_commit`; render, destroy, await two rAFs; expect zero calls and empty caches.
+
+---
+
+### S-11 · `packages/svg/src/text.ts:26-42` · MEDIUM
+**Defect:** `TextOptions.maxWidth` is carried by `ContextText` and honoured by canvas
+(`applyCanvasFill` → `ctx.fillText(content, x, y, element.maxWidth)`,
+`packages/canvas/src/utilities.ts:294`) but `SVGText.definition` never emits the SVG equivalent
+(`textLength` + `lengthAdjust="spacingAndGlyphs"`).
+
+**Failure scenario (reproduced):** `ctx.createText({ x:5, y:6, content:'hello', maxWidth:40 })` →
+`<text id="T1" … x="5" y="6">hello</text>` — no `textLength`. Canvas compresses the run to 40px;
+SVG lets it overflow. Any label that relies on `maxWidth` to fit a column/cell (heatmap cell labels,
+truncated axis ticks) overflows its cell in SVG only.
+
+**Severity:** MEDIUM.
+
+**Test sketch:** `createText({ …, maxWidth: 40 })`; expect `textLength === '40'` and
+`lengthAdjust === 'spacingAndGlyphs'` on the `<text>` node.
+
+---
+
+### S-12 · `packages/svg/src/context.ts:313-341` (`_setElementStyles`) · MEDIUM
+**Defect:** `globalCompositeOperation` is part of the shared drawing state (`CONTEXT_OPERATIONS`,
+`Element.globalCompositeOperation`) and honoured by canvas, but `_setElementStyles` never maps it to
+`mix-blend-mode` (nor sets `isolation: isolate` on the enclosing `<g>` to scope it).
+
+**Failure scenario:** an element with `globalCompositeOperation: 'multiply'` composites correctly on
+canvas and renders as plain `source-over` in SVG. Silent — no warning, no fallback.
+
+**Severity:** MEDIUM (silent divergence for a documented public state property).
+
+**Test sketch:** render an element with `globalCompositeOperation: 'multiply'`; expect
+`style.mixBlendMode === 'multiply'` on the node.
+
+---
+
+### S-13 · `packages/svg/src/context.ts:384-412` · LOW-MEDIUM
+**Defect:** an unbalanced `markRenderStart`/`markRenderEnd` wedges the surface **permanently**, in both
+directions:
+- depth drops below 0 (extra `markRenderEnd`) → `markRenderStart` bumps `-1 → 0` so the vtree reset
+  never runs and `markRenderEnd` never observes `0`, so `_commit()` never runs again;
+- depth stays above 0 (a throw between start and end) → same outcome.
+
+Verified: after one stray `markRenderEnd`, a full subsequent pass that creates and fills a path leaves
+the surface empty (`renderDepth` cycles `-1 → 0 → -1`, `_commit` never called).
+
+**Reachable trigger:** `Group.render` (`core/src/core/group.ts:194-207`) calls `markRenderStart`,
+`pushGroup`, renders children, then `popGroup`/`markRenderEnd` **with no `try/finally`** — unlike
+`Element.render` and `Context.batch`, both of which are protected. One exception from a child's render
+(a custom path renderer reading external data, a bad interpolator) permanently freezes the SVG surface;
+the canvas backend just drops that frame and recovers.
+
+**Severity:** LOW-MEDIUM (needs a throw, but the failure is unrecoverable and silent).
+
+**Test sketch:** make one child of a group throw during `render`; assert the next `scene.render()` still
+reconciles (i.e. `renderDepth` returns to 0).
+
+---
+
+### S-14 · `packages/svg/src/context.ts:562-566` (`restore`) · LOW
+**Defect:** `SVGContext.restore()` pops `_transformStack`/`_clipStack` **before** delegating, but
+`Context.restore()` (context.ts:443-450) returns early when `saveDepth === 0`. An unbalanced `restore()`
+therefore silently discards the current transform and clip while leaving `currentState` intact.
+
+**Failure scenario (reproduced):** with `saveDepth === 0`, `ctx.translate(10, 20)` then `ctx.restore()`
+→ `_currentTransforms` goes from `["translate(10,20)"]` to `[]` while `saveDepth` stays `0` and
+`currentState` is unchanged; subsequent elements render untransformed.
+
+**Severity:** LOW (latent — no in-tree caller over-restores today; `popGroup` is depth-guarded).
+
+**Test sketch:** `ctx.translate(1,2); ctx.restore();` expect `_currentTransforms` unchanged when
+`saveDepth === 0`.
+
+---
+
+### S-15 · `packages/svg/src/context.ts:631` (`applyFill`) · LOW
+**Defect:** `applyFill(element, fillRule)` accepts a `fillRule` (part of the abstract `Context`
+contract, honoured by canvas via `ctx.fill(path, fillRule)`) and drops it — the parameter is
+`eslint-disable`d as unused. `fill-rule` is never emitted, so an `evenodd` fill silently renders
+`nonzero`. (`applyClip` *does* honour it, ctx.ts:617-619 — so the two are inconsistent.)
+
+**Failure scenario:** a self-intersecting/donut path filled with `evenodd` shows the hole on canvas and
+is solid in SVG. No in-tree element passes a `fillRule` today, so this is latent.
+
+**Severity:** LOW (latent contract gap).
+
+**Test sketch:** `ctx.applyFill(path, 'evenodd')`; expect `fill-rule="evenodd"` on the node.
+
+---
+
+### S-16 · `packages/svg/src/context.ts:365-371` + `596-623` · LOW
+**Defect (two parts):**
+1. `_removeFromVTree` searches only `_currentParentVNode.children`. Every current caller
+   (`Shape2D.render` → `createPath` then `applyClip`, `core/src/core/shape.ts:157-160`) creates and
+   clips within the same parent, so it works — but nothing enforces that invariant, and the failure mode
+   is a silent no-op leaving a stray node.
+2. Reachable today: `applyClip` removes only `path.id`. A multi-path element removes only its
+   **primary** path. `Polyline` with `segments` mints extra paths via
+   `context.createPath(\`${this.id}:${index}\`)` (`core/src/elements/polyline.ts:336`) which are all
+   `_addToVTree`'d; if such an element is `clip: true`, the run paths stay in the vtree as stray
+   `<path>` nodes.
+
+They are invisible (`SVGPath` defaults to `stroke:none; fill:none` and `_setElementStyles` never runs
+on them), so this is DOM/`_domCache` bloat rather than wrong pixels. I could not get the segmented
+tracer to emit run paths in my repro, so part 2 is **CONFIRMED by code reading, not by execution**.
+
+**Severity:** LOW.
+
+**Test sketch:** `createPolyline({ segments: […], clip: true })` in a scene; assert
+`svg.querySelectorAll('path[id^="PL:"]').length === 0`.
+
+---
+
+### S-17 · `packages/svg/src/context.ts:415-430` (`export`) · LOW
+**Defect:** the serialized markup carries `viewBox` and the inline
+`style="display:block; width:100%; height:100%; user-select:none"` but **no `width`/`height`
+attributes**:
+```
+<svg xmlns="http://www.w3.org/2000/svg" style="display: block; width: 100%; height: 100%; …" viewBox="0 0 200 100">…</svg>
+```
+As a standalone document (which is exactly how `toURL()` and `svgMarkupToImageData` consume it) the
+`100%` percentages have no containing block, so the intrinsic size is browser-dependent. It also bakes
+`user-select: none` into every export.
+
+I could not rasterize in jsdom, so the *consequence* (blank/mis-scaled `toImage()`) is **SUSPECTED**;
+the missing attributes are confirmed.
+
+**Severity:** LOW.
+
+**Test sketch:** `expect(ctx.export().toString()).toContain('width="200" height="100"')`.
+
+---
+
+## SUSPECTED findings (code/spec reasoning; not executable in jsdom)
+
+### S-18 · shadow geometry lives in user space · LOW-MEDIUM
+`_resolveShadowFilter` (ctx.ts:245-280) writes `dx`/`dy`/`stdDeviation` onto `<feDropShadow>` in the
+filter's user space, which inherits every ancestor `<g>` transform. Canvas shadow offsets and blur are
+explicitly **not** affected by the CTM. So the same element with `shadowOffsetX: 4, shadowBlur: 8`
+inside `<g transform="scale(2)">` casts an 8px/16px shadow in SVG and a 4px/8px shadow on canvas.
+Verify in a browser (Playwright, alongside the existing `test/visual/` specs) by screenshot-diffing a
+shadowed rect inside a scaled group.
+
+### S-19 · `_isPointIn` coordinate space · MEDIUM-HIGH *(distinct from the out-of-scope `getElementById` concern)*
+`packages/svg/src/context.ts:343-354` builds an `SVGPoint` from the hit coordinates — which arrive in
+the **SVG root's** user space — and passes it to `SVGGeometryElement.isPointInFill/isPointInStroke`.
+Per SVG 2 those methods interpret the point in the **element's own local coordinate space**. Since
+`_setElementStyles` stamps a `transform` on the element itself and ancestors are transformed `<g>`s,
+the point is in the wrong space for any transformed element. Meanwhile
+`hitTestHonorsTransform = true` (ctx.ts:130) explicitly tells `Shape2D.intersectsWith`
+(`core/src/core/shape.ts:104-117`) *not* to map the point into local space — the opposite of what would
+be needed. jsdom implements neither method, so this needs a real browser to settle.
+Test sketch: Playwright — a rect inside `<g transform="translate(100,0)">`, click at its on-screen
+centre, assert the element's `click` handler fires.
+
+### S-20 · filter chain order · LOW
+`_resolveElementFilter` (ctx.ts:282-298) emits `filter="url(#shadow-…) <cssFilter>"`, so a CSS
+`blur(4px)` is applied to the shape **and its drop shadow**. Canvas applies `ctx.filter` to the shape
+and derives the shadow from the filtered result, so the shadow is not additionally blurred. Needs a
+browser screenshot diff.
+
+### S-21 · `alignment-baseline` is dead weight, and its `middle` mapping disagrees · LOW
+`_setElementStyles` writes both `alignment-baseline` and `dominant-baseline` on **every** element
+(including `<path>` and `<image>`). `SVG_STYLE_MAP` maps `middle → 'middle'` for `alignmentBaseline` but
+`middle → 'central'` for `dominantBaseline` (`packages/svg/src/constants.ts:20-30`). Browsers ignore
+`alignment-baseline` on `<text>` (the constants file says so), and `SVGTextPath.definition.styles` is
+`{}` so a `<textPath>` never receives it either — it inherits `dominant-baseline: central`. Net effect:
+`alignmentBaseline` is unreachable dead configuration, and the two mappings would disagree if it ever
+became reachable. Also worth noting canvas `textBaseline: 'middle'` (em-box middle) and SVG
+`dominant-baseline: 'central'` are close but not identical, so text sits a fraction of an em apart
+between backends.
+
+---
+
+## Ranked summary
+
+| Rank | ID | Severity | One-liner | Status |
+|---|---|---|---|---|
+| 1 | **S-1** | HIGH | `vdom.ts:147` skips reconciliation for zero-child vnodes → an emptied `<g>` keeps last frame's children forever | CONFIRMED |
+| 2 | **S-6** | HIGH | SVG box hit testing divides a CSS-pixel point by DPR → every `Text`/`Image`/`Group` mis-hits by 2× on Retina | CONFIRMED |
+| 3 | **S-4** | HIGH | Group gradient: canvas resolves once against the *previous leaf's* box (or the surface), SVG once per leaf against each leaf's box — neither uses the group's box | CONFIRMED |
+| 4 | **S-5** | HIGH | A leaf's own opacity overrides group alpha on canvas but multiplies with it in SVG (0.5 vs 0.125) | CONFIRMED |
+| 5 | **S-3** | HIGH | Clip stamped on the leaf resolves in the leaf's user space → displaced by every intervening `<g>` transform | CONFIRMED |
+| 6 | **S-2** | HIGH | `applyClip` replaces the active clip instead of intersecting it | CONFIRMED |
+| 7 | **S-7** | HIGH (perf) | `drawImage` re-encodes the image to a PNG data URL every frame | CONFIRMED |
+| 8 | **S-19** | MED-HIGH | `isPointInFill` is fed a root-space point but is specified in element-local space | SUSPECTED |
+| 9 | **S-8** | MEDIUM | SVG scene root never inherits the host font (`SVGSVGElement` is not an `HTMLElement`) | CONFIRMED |
+| 10 | **S-9** | MEDIUM | Root-level `clip: true` leaks one entry per frame across `states`/`_transformStack`/`_clipStack` | CONFIRMED |
+| 11 | **S-10** | MEDIUM | No `destroy()` override: buffered commit fires post-destroy, all caches retained | CONFIRMED |
+| 12 | **S-11** | MEDIUM | `maxWidth` honoured by canvas, silently dropped by SVG | CONFIRMED |
+| 13 | **S-12** | MEDIUM | `globalCompositeOperation` silently dropped (no `mix-blend-mode`) | CONFIRMED |
+| 14 | **S-18** | LOW-MED | Shadow `dx/dy/stdDeviation` scale with ancestor transforms; canvas shadows do not | SUSPECTED |
+| 15 | **S-13** | LOW-MED | One render exception permanently freezes the SVG surface (`Group.render` has no `try/finally`) | CONFIRMED |
+| 16 | **S-14** | LOW | `restore()` pops the SVG stacks even when the base `restore()` no-ops | CONFIRMED |
+| 17 | **S-16** | LOW | `applyClip` removes only the primary path; `_removeFromVTree`'s single-parent search is latent-fragile | CONFIRMED (code) |
+| 18 | **S-15** | LOW | `applyFill` drops `fillRule` (while `applyClip` honours it) | CONFIRMED |
+| 19 | **S-17** | LOW | Exported markup has no `width`/`height` | CONFIRMED |
+| 20 | **S-20** | LOW | `filter="url(#shadow) blur(…)"` blurs the shadow too | SUSPECTED |
+| 21 | **S-21** | LOW | `alignment-baseline` is unreachable dead config and disagrees with the `dominant-baseline` mapping | CONFIRMED |

--- a/docs/audits/terminal.md
+++ b/docs/audits/terminal.md
@@ -1,0 +1,650 @@
+# Audit — `@ripl/terminal` rendering context
+
+Scope: `packages/terminal/src/{context,path,rasterizer,algorithms,color,output}.ts`, read against the
+base contract in `packages/core/src/context/context.ts` and the pipeline in
+`packages/core/src/core/{element,group,scene,renderer,shape}.ts`, with `packages/canvas` as the
+parity reference.
+
+Read-only investigation. Every CONFIRMED item below was reproduced by executing the real code
+(vitest, jsdom env, `@ripl/core` + `@ripl/terminal` sources) in a scratch harness; the observed
+output is quoted inline. Scratch files were deleted afterwards.
+
+---
+
+## 1. save/restore symmetry and state-stack integrity — VERIFIED CLEAN
+
+`TerminalContext` does **not** override `save()`/`restore()`; there is no occurrence of either in
+`packages/terminal/src/context.ts`. It therefore uses the base `Context` stack verbatim
+(`packages/core/src/context/context.ts:79-84,436-450`): `states[]`, `currentState`, `saveDepth`,
+with `restore()` guarded at `saveDepth === 0`.
+
+Consequences verified:
+
+- The paint cascade works. A `Group` with `fill: '#00ff00'` and an unpainted `Rect` child produced
+  pixels coloured `\x1b[38;2;0;255;0m` — the group's paint reached the descendant through
+  `pushGroup` → `save()` → copied `currentState`.
+- `this.fill` / `this.stroke` in `applyFill`/`applyStroke` (`context.ts:393,404`) read
+  `currentState`, so nested scopes resolve correctly.
+- After a full `Scene.render()` containing a group and a `clip: true` shape (which renders with
+  `skipRestore`), `saveDepth === 0` and `states.length === 0`. Balance holds.
+
+No finding.
+
+## 2. markRenderStart / markRenderEnd depth handling — ONE LOW FINDING
+
+`markRenderStart` is not overridden. `markRenderEnd` (`context.ts:371-377`) calls `super` then
+flushes at depth 0. Under `Scene.render()` → `Context.batch()` (`core/.../context.ts:502-513`) the
+depth reaches 0 exactly once per frame, and exactly **two** writes are emitted per frame
+(`"\x1b[H"` from `clear()`, then the serialized grid). Correct.
+
+See **F17** for the missing floor on `renderDepth`.
+
+## 3. pushGroup / popGroup balance, group opacity, clip scoping — MIXED
+
+Balance verified (see §1). Group **opacity** is composited into `currentState.opacity` by the base
+`pushGroup` but is then read by nobody — see **F4**. Group-scoped **clip** is a documented no-op;
+`popGroup`'s depth unwind still correctly absorbs the dangling `save()` a clip shape leaves.
+
+## 4. Transform composition and ordering — NOT HONOURED AT ALL
+
+`rotate`/`scale`/`translate`/`setTransform`/`transform` are inherited as no-ops from `Context`
+(`core/.../context.ts:574-614`). `applyElementTransform` (`core/core/transform.ts:54-104`) drives
+exactly those five methods, so **every element and group transform is discarded**. See **F11**.
+
+## 5. Paint resolution — BROKEN FOR SEVERAL VALID CSS PAINTS
+
+`colorToAnsiFg` → `parseColor` only, with no `isGradientString`/`isPatternString` branch and no alpha
+handling. Compare `packages/canvas/src/utilities.ts:177-197` (`setCanvasFill`), which tries pattern,
+then gradient, then falls back to assigning the raw string to `fillStyle` (so the browser resolves
+named colours, `#rgb`, `color-mix()`, `currentColor`, …). See **F2**, **F3**.
+
+Gradients/patterns are **not** painted as literal text — they resolve to the empty string and the
+geometry is drawn uncoloured (which is a different, quieter failure).
+
+## 6. Text metrics and text rendering — see F5, F12, F22
+
+## 7. Hit testing — dead by design, with one latent inconsistency
+
+`isPointInPath`/`isPointInStroke` inherited → always `false` (verified). `hitTestHonorsTransform`
+is the base default `false` (verified). Because `Shape2D.hitPaths` is non-empty, `Shape2D.intersectsWith`
+(`core/core/shape.ts:96-137`) never falls back to the bounding-box test, so **no** hit testing works.
+Documented in the class JSDoc (`context.ts:286-287`) and the README. See **F21** for the latent
+`hitTestHonorsTransform` inconsistency.
+
+## 8. export() — one real defect
+
+Shape matches `ContextExport` (`core/context/types.ts:166-177`) and correctly snapshots eagerly
+(verified: mutating the grid after `export()` does not change `toString()`). Defect: **F9**.
+
+## 9. destroy() cleanup and leak surface — MOSTLY CLEAN
+
+`destroy()` is not overridden; the base calls `dispose()` then `EventBus.destroy()`. The
+`output.onResize` disposer is retained at `context.ts:330-332` and **was verified to be invoked**
+on `destroy()`. Remaining surface: **F20** (terminal state not restored), **F23** (Blob URL never
+revoked — same as `packages/dom/src/export.ts:51`, so a codebase convention rather than a terminal
+defect).
+
+## 10. Parity with canvas for an identical scene
+
+What works well: even-odd scanline fills are genuinely good. A full donut
+(`createArc({ innerRadius })`, 0→2π) rendered as a correct ring, and a half donut as a correct
+half ring — the annular hole is preserved. Uniform logical→raster letterboxing is correct
+(circle r=100 logical in a 400×300 space over an 80×48 grid → exact 16-px radius, centred).
+
+Silently dropped, categorised:
+
+| Feature | Status | Where |
+|---|---|---|
+| transforms (translate/rotate/scale) | not implemented, **documented** (`context.ts:288-290`, README) | F11 |
+| clipping (`applyClip`) | not implemented, documented (`context.ts:291`) | — |
+| images (`drawImage`) | not implemented, documented (`context.ts:291`) | — |
+| hit testing | not implemented, documented (`context.ts:286-287`) | §7 |
+| gradients / patterns | not implemented, README-documented | F2 |
+| **opacity / globalAlpha** | not implemented, **undocumented** | **F4** |
+| **alpha channel of `rgba()`/`#rrggbbaa`** | **implemented wrongly** (parsed then discarded) | **F3** |
+| **`transparent` / `none` fills** | **implemented wrongly** (geometry still painted) | **F3** |
+| **named CSS colours, `#rgb`** | **implemented wrongly** (drop to no-colour + bleed) | **F2** |
+| **stroked text** | **implemented wrongly** (renders nothing) | **F5** |
+| **partial / rotated ellipse** | **implemented wrongly** (full unrotated ellipse) | **F6** |
+| **text on a path (`pathData`)** | not implemented, undocumented | F12 |
+| lineWidth / lineDash / lineCap / lineJoin / miterLimit | not implemented, undocumented | F14 |
+| shadow* / filter / globalCompositeOperation | not implemented, undocumented | F15 |
+| `reset()` | not implemented, undocumented | F16 |
+
+---
+
+# Findings
+
+## CONFIRMED — implemented wrongly
+
+### F1 — ANSI colour bleeds indefinitely when a glyph has no resolved colour — HIGH
+
+`packages/terminal/src/rasterizer.ts:201-208` (and the guard at `:233`)
+
+**Defect.** In `_serializeRow`, a `_chars` entry whose colour is `''` sets `lastColor = ''` without
+emitting `ANSI_RESET`, so the glyph is painted in the previously active colour and the row's
+end-of-row reset (`return lastColor ? ... : output`, `:233`) is skipped — the stale SGR leaks to the
+rest of the row, the rest of the frame, and every following frame.
+
+The blank-cell branch (`:213-221`) *does* emit `ANSI_RESET`, which is exactly the missing behaviour
+in the char branch.
+
+**Failure scenario (reproduced).** 6-column grid. Fill `#ff0000`, `rect(0,0,2,3)`; then fill `#888`
+(the literal value used at `apps/website/src/.vitepress/components/example-terminal-interactive.vue:147,175`),
+`createText({ x: 4, y: 0, content: 'ab' })`, baseline `top`. Emitted frame:
+
+```
+"\x1b[1;1H\x1b[38;2;255;0;0m⣿⡇ab  "
+```
+
+The `ab` glyphs render **red**, and no reset is ever emitted, so every subsequent cell the terminal
+draws stays red until some other element happens to set a colour. Minimal form (test A): red pixel
+at (0,0) plus `setChar(1, 0, 'X', '')` → `"\x1b[1;1H\x1b[38;2;255;0;0m⠁X  "`.
+
+**Severity:** high — corrupts the whole screen, is trivially reachable from the shipped demo, and is
+self-perpetuating across frames.
+
+**Test sketch.**
+```ts
+const r = new BrailleRasterizer(4, 1);
+r.setPixel(0, 0, '\x1b[38;2;255;0;0m');
+r.setChar(1, 0, 'X', '');
+expect(r.serialize()).toBe('\x1b[1;1H\x1b[38;2;255;0;0m⠁\x1b[0mX  ');
+// and, invariant form: a serialized row must never leave an SGR open
+expect(r.serialize().endsWith(ANSI_RESET)).toBe(true);
+```
+
+### F2 — Valid CSS paints (named colours, `#rgb`, gradients, patterns) silently lose all colour — HIGH
+
+`packages/terminal/src/color.ts:9-23`, consumed at `packages/terminal/src/context.ts:393,404`
+
+**Defect.** `colorToAnsiFg` resolves colour exclusively through `parseColor`
+(`packages/core/src/color/index.ts:82`), whose `PATTERNS` (`packages/core/src/color/constants.ts:6-14`)
+are anchored and cover only `#rrggbb[aa]`, `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hsv()`, `hsva()`.
+Anything else returns `undefined` → `''` → the geometry is rasterized with **no** colour, and
+`BrailleRasterizer.setPixel`'s `if (color)` guard (`rasterizer.ts:169-171`) means the cell keeps
+whatever colour a *previous, unrelated* element left there. The canvas backend, by contrast, falls
+through to `ctx.fillStyle = value` (`packages/canvas/src/utilities.ts:196`) and handles
+gradients/patterns explicitly at `:178-194`.
+
+**Failure scenario (reproduced).** Same rect filled with each value; the set of ANSI codes handed to
+`setPixel`:
+
+| value | terminal | canvas |
+|---|---|---|
+| `red` | `[""]` | red |
+| `#f00` | `[""]` | red |
+| `#888` | `[""]` | grey |
+| `currentColor` | `[""]` | inherited |
+| `linear-gradient(...)` | `[""]` | gradient |
+| `#ff0000` | `["\x1b[38;2;255;0;0m"]` | red |
+
+Every one of these also triggers **F1** when it lands on a text glyph.
+
+**Severity:** high — `fill: 'white'` / `#888` / `#f00` are idiomatic and appear in this repo's own
+terminal demo; the failure is silent.
+
+**Test sketch.** Table-driven over `['red', '#f00', '#888', 'white', 'currentColor']`: assert the
+colour passed to a spy rasterizer's `setPixel` is a truecolor escape, not `''`. (Fix direction:
+expand `parseColor` coverage, or have `colorToAnsiFg` fall back to a DOM/`CSS.supports` resolution,
+or at minimum a named-colour table + `#rgb` expansion.)
+
+### F3 — `transparent` / `none` / zero-alpha paints still draw geometry at full strength — HIGH
+
+`packages/terminal/src/context.ts:392-400`; `packages/terminal/src/color.ts:11,20`
+
+**Defect (two parts).**
+1. `colorToAnsiFg` early-returns `''` for `'none'`/`'transparent'` (`color.ts:11`), but `applyFill`
+   proceeds to `_rasterizePath(element, '', true)` regardless — the shape is still rasterized, just
+   uncoloured. Nothing anywhere treats "no colour" as "do not paint".
+2. `parseColor` returns a 4-tuple, but `colorToAnsiFg` destructures `const [r, g, b] = parsed`
+   (`color.ts:20`) and throws the alpha away. `rgba(255,0,0,0)` becomes fully opaque red.
+
+**Failure scenario (reproduced).** `ctx.fill = 'transparent'; path.rect(0,0,6,6); ctx.applyFill(path)`
+→ **70 pixels plotted**. Same for `'none'` and `'rgba(0,0,0,0)'`. `rgba(255,0,0,0.25)` →
+70 pixels at full `\x1b[38;2;255;0;0m`. Canvas paints nothing for the first three and a
+25 %-alpha red for the fourth.
+
+Real-world: a chart element parked at `fill: 'transparent'` (or a legend swatch faded via
+`rgba(...,0)`) appears as a solid block of braille.
+
+**Severity:** high — draws things canvas would not draw at all.
+
+**Test sketch.**
+```ts
+ctx.fill = 'transparent';
+ctx.applyFill(rectPath);
+expect(spy.pixels).toHaveLength(0);
+
+ctx.fill = 'rgba(255,0,0,0)';
+ctx.applyFill(rectPath);
+expect(spy.pixels).toHaveLength(0);
+```
+
+### F4 — `opacity` is composited into the state and then ignored — HIGH
+
+`packages/terminal/src/context.ts` (no reader of `this.opacity` anywhere in the package);
+producers: `core/context/context.ts:526-538` (`pushGroup`), `core/core/element.ts:889-895`
+(`CONTEXT_OPERATIONS.opacity`)
+
+**Defect.** The base pipeline faithfully maintains `currentState.opacity` (element opacity via
+`CONTEXT_OPERATIONS`, group opacity multiplied at the boundary). `TerminalContext` never reads it,
+so **`opacity: 0` renders identically to `opacity: 1`**. This is *not* in the documented constraint
+list (`context.ts:279-291`) nor in the README.
+
+**Failure scenario (reproduced).**
+- `createRect({ x:0, y:0, width:8, height:8, fill:'#ff0000', opacity: 0 })` in a scene → **108
+  pixels plotted**, full red.
+- `createGroup({ opacity: 0, children: rect })` → **108 pixels plotted**.
+
+Concrete downstream breakage: `packages/charts/src/components/crosshair.ts:126,142` parks both
+crosshair lines at `opacity: 0` until hover — in the terminal they are **permanently visible**.
+`packages/charts/src/components/axis.ts:696-756` and `legend.ts:337-349` fade elements in from
+`opacity: 0`; in the terminal every "hidden" enter/exit element is drawn at full strength for the
+whole animation.
+
+**Severity:** high — it is the mechanism the charts package uses for show/hide, so charts render
+with permanently-visible chrome.
+
+**Test sketch.**
+```ts
+scene.add(createRect({ ..., fill: '#ff0000', opacity: 0 }));
+scene.render();
+expect(spy.pixels).toHaveLength(0);           // or: dithered/attenuated, but not full strength
+```
+(A character grid cannot do real alpha; the minimum correct behaviour is to skip drawing at
+`opacity === 0` and to blend the emitted colour toward the background otherwise.)
+
+### F5 — Text with a `stroke` renders nothing — HIGH
+
+`packages/terminal/src/context.ts:402-409` vs `packages/core/src/elements/text.ts:124-131`
+
+**Defect.** `applyStroke` handles only `TerminalPath`; the `ContextText` branch present in
+`applyFill` (`context.ts:397-399`) has no counterpart. `Text.render` prefers stroke over fill:
+
+```ts
+if (this.stroke) { return context.applyStroke(text); }
+if (this.fill)   { return context.applyFill(text); }
+```
+
+so any text with a stroke set takes the stroke branch and produces **no output at all** — the fill is
+never reached. The canvas backend handles both (`packages/canvas/src/utilities.ts:301-311`).
+
+**Failure scenario (reproduced).** A scene with two texts —
+`createText({ content: 'label', fill: '#ffffff', stroke: '#ff0000' })` and
+`createText({ content: 'plain', fill: '#ffffff' })` — produced glyphs `"plain"` only. The
+outlined label vanished entirely.
+
+**Severity:** high — an outlined label (fill + stroke, a common readability treatment over dense
+plots) disappears rather than degrading.
+
+**Test sketch.**
+```ts
+scene.add(createText({ x: 4, y: 20, content: 'label', fill: '#fff', stroke: '#f00' }));
+scene.render();
+expect(spy.chars.map(c => c[2]).join('')).toBe('label');
+```
+
+### F6 — `ellipse` drops rotation, start/end angle and direction; always draws a full unrotated ellipse — MEDIUM
+
+`packages/terminal/src/context.ts:214-222` (handler) — args recorded at
+`packages/terminal/src/path.ts:91-99`
+
+**Defect.** `TerminalPath.ellipse` records
+`[x, y, radiusX, radiusY, rotation, startAngle, endAngle, ccw]`, but both handler passes read only
+`args[0..3]`:
+
+```ts
+contours.push(flattenEllipse(sx(args[0]), sy(args[1]), args[2] * s, args[3] * s));
+// and
+rasterizeEllipse(sx(args[0]), sy(args[1]), args[2] * s, args[3] * s, plot);
+```
+
+`flattenEllipse`/`rasterizeEllipse` (`algorithms.ts:93,327`) have no angle or rotation parameters at
+all. Contrast the sibling `arc` handler (`context.ts:202-213`), which *does* forward
+`startAngle`/`endAngle`/`ccw`. This is not listed among the documented limitations.
+
+**Failure scenario (reproduced).** `createEllipse({ cx:40, cy:24, radiusX:20, radiusY:10,
+startAngle: 0, endAngle: Math.PI/2, stroke:'#ff0000' })` (the core element forwards the angles at
+`packages/core/src/elements/ellipse.ts:133-141`) plotted `x[20..60] y[14..34]` — the **complete**
+ellipse — where the quarter arc should occupy `x[40..60] y[24..34]`. A direct
+`path.ellipse(20,20,15,5, Math.PI/2, 0, Math.PI)` likewise drew a full, unrotated ellipse.
+
+**Severity:** medium — a whole documented element type (`Ellipse` with `startAngle`/`endAngle`, and
+`Polyline.ellipse`) renders wrong geometry, silently.
+
+**Test sketch.**
+```ts
+const path = ctx.createPath();
+path.ellipse(20, 20, 15, 5, 0, 0, Math.PI);   // lower half only
+ctx.applyStroke(path);
+expect(Math.min(...spy.pixels.map(p => p[1]))).toBeGreaterThanOrEqual(20);
+```
+
+### F7 — On resize, the repaint fires with a half-updated coordinate mapping — MEDIUM
+
+`packages/terminal/src/context.ts:352-361` (specifically `:356` then `:359`)
+
+**Defect.** `_applyScaling` sets `this._rasterScale = scale` (`:356`) and *then* calls
+`this.rescale(...)` (`:359`), which resets `scaleX`/`scaleY` to identity **and synchronously emits
+`resize`** (`core/context/context.ts:417-425`). `Scene`'s resize handler repaints immediately
+(`core/core/scene.ts:162-169`). Only after that emit returns do `:360-361` install the letterbox
+scales. So the repaint runs with the *new* `_rasterScale` but the *identity* `scaleX`/`scaleY` — the
+two halves of the mapping (`_buildContours`/`_executeCommands` use `sx`/`sy` for points and `s` for
+extents, `context.ts:511-518,531-536`) disagree.
+
+The in-code comment at `:358` anticipates the ordering but not the synchronous emit.
+
+**Failure scenario (reproduced).** Context with `logicalWidth: 400, logicalHeight: 300` over a 40×12
+grid; a `rect(0,0,400,300)` stroke. Grid resized to 80×24 (160×96 raster):
+
+```
+repaint fired during resize : x[0..128] y[0..96]     <- wrong origin, letterbox offset missing
+next explicit render        : x[16..144] y[0..96]    <- correct
+```
+
+Under a running `Renderer` the next tick corrects it (one bad frame). For a **static** scene rendered
+via `scene.render()` with no `Renderer`, the mis-placed frame is what stays on screen.
+
+**Severity:** medium.
+
+**Test sketch.** Install a spy rasterizer, trigger `onResize`, and assert the pixels captured *during*
+the resize match the pixels of an explicit `scene.render()` immediately afterwards.
+
+### F8 — Explicit `width`/`height` options are discarded on the first resize — MEDIUM
+
+`packages/terminal/src/context.ts:317-320` vs `:324-333`
+
+**Defect.** The constructor honours the caller's fixed grid (`width ?? output.columns`), but the
+resize handler unconditionally forwards the terminal's new dimensions:
+`this._rasterizer.resize(cols, rows)`. There is no memory of the explicit size.
+
+**Failure scenario (reproduced).** `createContext(output, { width: 20, height: 10 })` on a 100×40
+terminal → `ctx.width === 40` (20 cols × 2). After a `SIGWINCH` reporting 100×41 → `ctx.width === 200`.
+A deliberately fixed-size viewport silently becomes full-screen.
+
+**Severity:** medium (documented option does not hold).
+
+**Test sketch.**
+```ts
+const ctx = createContext(output, { width: 20, height: 10 });
+notifyResize(100, 41);
+expect(ctx.width).toBe(20 * BRAILLE_CELL_WIDTH);
+```
+
+### F9 — `toImageData()` drops every text glyph, so `export().toImage()` / `.toURL()` lose all text — MEDIUM
+
+`packages/terminal/src/rasterizer.ts:280-300` (loop at `:286-297`)
+
+**Defect.** The loop reads `this._dots` only; the `_chars` map — the sole home of every glyph placed
+by `setChar` — is never consulted. `serialize()` handles both (`:199-209`, `:241-246`); `toImageData`
+does not.
+
+**Failure scenario (reproduced).** `new BrailleRasterizer(4,1); r.setChar(0,0,'X','\x1b[38;2;255;0;0m');
+r.toImageData()` → **no pixel has non-zero alpha**. Every axis label, legend label and title is
+missing from `context.export().toImage()` and from the PNG produced by
+`terminalSnapshotToURL` (`context.ts:83-104`), while `export().toString()` shows them.
+
+**Severity:** medium — the PNG/ImageData export is a documented feature (README "Exporting") and is
+silently lossy.
+
+**Test sketch.**
+```ts
+r.setChar(0, 0, 'X', '\x1b[38;2;255;0;0m');
+const img = r.toImageData();
+expect(Array.from(img.data).some((v, i) => i % 4 === 3 && v > 0)).toBe(true);
+```
+(A minimal fix is a 5×7-ish glyph bitmap; even rendering the cell as a solid block would be closer
+than nothing.)
+
+### F10 — Shrinking the terminal leaves stale rows on screen — MEDIUM/LOW
+
+`packages/terminal/src/context.ts:365-368` (`clear`), `rasterizer.ts:257-278` (`serialize`)
+
+**Defect.** `clear()` writes only `\x1b[H` (cursor home) and clears the in-memory grid. `serialize()`
+emits exactly `_rows` rows of exactly `_cols` cells. Nothing ever erases the display, so rows that
+existed before a shrink are never overwritten.
+
+**Failure scenario (reproduced).** 6×3 grid, red rect → frame carries rows `1;1H`, `2;1H`, `3;1H`.
+Resize to 6×1 and re-render → frame carries only `\x1b[1;1H…`. Rows 2 and 3 of the physical terminal
+still show the previous braille. No `\x1b[2J`/`\x1b[J` is emitted anywhere in the package.
+
+**Severity:** medium/low — cosmetic but permanent until something else scrolls the terminal.
+
+**Test sketch.** Capture writes across a shrink and assert the frame contains an erase-below
+(`\x1b[J`) or that the grid is padded to the previous row count.
+
+### F11 — Element and group transforms are dropped entirely — MEDIUM (documented, but the largest parity gap)
+
+`packages/terminal/src/context.ts:288-290` (the documentation of the gap); mechanism:
+`core/context/context.ts:574-614` no-ops + `core/core/transform.ts:54-104`
+
+**Defect.** Documented as "No affine transforms", so *by design* — but it is worth stating plainly
+because the class JSDoc's claim that "elements are positioned through the context's own
+`scaleX`/`scaleY`/`rasterScale` mapping instead" is not a substitute: that mapping is a single global
+letterbox, it cannot express per-element placement.
+
+**Failure scenarios (reproduced).**
+- `createRect({ x:0, y:0, width:4, height:4, translateX:30, translateY:20 })` → drawn at
+  `x[0..4] y[0..4]`, i.e. at the origin.
+- `createGroup({ translateX: 20, children: rect })` → identical, `x[0..4]`.
+- `rotation: π/2, transformScaleX: 2` on a 20×2 rect → `x[10..30] y[10..12]`, i.e. unrotated and
+  unscaled.
+
+Downstream: `packages/charts/src/components/axis.ts:1189` rotates the y-axis title by ±π/2 — in the
+terminal it is drawn horizontally, overlapping the plot; `symbols.ts:116` rotates a diamond marker by
+π/4 — it renders as an unrotated square.
+
+**Severity:** medium as a *bug* (it is documented), high as a *parity* concern for charts.
+
+**Test sketch.** A "transforms are honoured" suite that asserts a translated rect's raster bbox is
+offset — currently expected to fail; if the intent is to keep it unimplemented, add an explicit
+negative test plus a note in the README that charts using transforms are unsupported.
+
+### F12 — Text on a path (`pathData` / `startOffset`) is silently ignored — MEDIUM/LOW
+
+`packages/terminal/src/context.ts:452-468`
+
+**Defect.** `_rasterizeText` reads only `content`, `maxWidth`, `x`, `y`. `ContextText.pathData` and
+`startOffset` (`core/context/text.ts:24-27`) are dropped. Canvas dispatches to
+`renderTextAlongPath` (`packages/canvas/src/utilities.ts:257-285`). Not in the documented limitation
+list.
+
+**Failure scenario (reproduced).** `createText({ x:0, y:20, content:'arc', pathData:'M 0 40 Q 40 0 80 40' })`
+→ glyphs placed at `(0,4) (1,4) (2,4)`, i.e. a straight run at the anchor, ignoring the curve.
+
+**Severity:** medium/low — degrades to straight text rather than vanishing.
+
+**Test sketch.** Assert the emitted `setChar` rows are not all equal when `pathData` describes a
+curve — or, if unimplementable, document it and keep the straight-line fallback deliberately.
+
+---
+
+## CONFIRMED — not implemented (undocumented silent drops)
+
+### F13 — A fill always also paints the path outline in the fill colour — LOW
+
+`packages/terminal/src/context.ts:477-482`
+
+```ts
+if (fill) { fillPolygon(this._buildContours(path), plot); }
+// Always draw the outline
+this._executeCommands(path, plot);
+```
+
+**Defect.** `applyFill` paints one extra pixel of outline beyond the even-odd interior, in the *fill*
+colour, and paints something even for degenerate (zero-area) fills.
+
+**Failure scenario (reproduced).** An **open** path `moveTo(0,0); lineTo(10,0)` with
+`fill = '#ff0000'` and no stroke → 11 pixels plotted. Canvas fills the implicitly-closed zero-area
+subpath, i.e. paints nothing.
+
+**Severity:** low (adjacent filled shapes bleed into each other by one raster pixel; harmless at
+braille resolution most of the time).
+
+**Test sketch.** Fill an open two-point path and assert no pixels; or fill a rect and assert the
+painted bbox does not exceed the geometric bbox.
+
+### F14 — Stroke geometry state (lineWidth, lineDash, lineCap/Join, miterLimit) ignored, undocumented — LOW
+
+`packages/terminal/src/context.ts:403-409`, `_executeCommands` `:529-541`
+
+Reproduced: `lineWidth = 10` → 21 pixels (a 1-px line); `lineDash = [2,2]` → 21 pixels (solid).
+Inherent to a 1-bit raster for `lineWidth`, but **dashes are implementable** (dashed grid lines and
+zero-lines are common in `@ripl/charts`), and none of these appear in the documented limitation
+list.
+
+**Test sketch.** `ctx.lineDash = [2,2]` over a 20-px line and assert gaps exist in the plotted x set.
+
+### F15 — Shadows, filters and composite operations ignored, undocumented — LOW
+
+`packages/terminal/src/context.ts:392-409`
+
+Reproduced: `shadowBlur:10, shadowOffsetX/Y:4, filter:'blur(4px)',
+globalCompositeOperation:'destination-out'` all produced the same 70-pixel plain rect.
+Unimplementable in a character grid (fine) but should be listed alongside the other documented
+constraints — `globalCompositeOperation: 'destination-out'` in particular means canvas would *erase*
+where the terminal *draws*.
+
+### F16 — `reset()` is a no-op — LOW
+
+Inherited from `core/context/context.ts:469-471`. Reproduced: after `ctx.reset()`, `export().toString()`
+is byte-identical (`"⠿⠿⠇ "`). Canvas implements it (`packages/canvas/src/mixins.ts:354-356`). At
+minimum it should clear the grid and reset `currentState`.
+
+### F17 — `renderDepth` has no floor; a throw inside `Group.render` permanently freezes terminal output — LOW/MEDIUM
+
+`packages/terminal/src/context.ts:370-377`; interacts with `core/core/group.ts:194-207`
+
+**Defect.** `Context.markRenderEnd` decrements without a floor, and `TerminalContext` gates its only
+flush on `renderDepth === 0`. `Group.render` is the one pipeline step with **no** `try/finally`
+around its `markRenderStart`/`markRenderEnd` pair, so an exception in a child permanently unbalances
+the depth — and on the terminal that means the display never updates again. On canvas the same
+exception merely leaks a `save()`.
+
+**Failure scenario (reproduced).** `group.render(ctx)` where one child's `render` throws →
+`renderDepth === 1`, `saveDepth === 1` afterwards; a subsequent successful `element.render(ctx)`
+produced **0 writes**. Symmetrically, a stray `ctx.markRenderEnd()` drives `renderDepth` to `-1`, after
+which the flush fires mid-frame (per element) instead of per frame.
+
+**Severity:** low/medium — needs an exception or misuse to trigger, but the failure mode (dead
+display, no error) is bad.
+
+**Test sketch.**
+```ts
+try { group.render(ctx); } catch {}
+expect((ctx as any).renderDepth).toBe(0);
+// then: a clean render still flushes
+```
+
+### F18 — `supportsPathCaching` is `false` although `TerminalPath` creation is side-effect free — LOW (perf)
+
+`packages/terminal/src/context.ts:379-382` (inherits `false` from `core/context/context.ts:627-629`)
+
+`createPath` is a plain `new TerminalPath(id)` with no per-frame registration (unlike SVG), so the
+canvas rationale for `true` (`packages/canvas/src/context.ts:28-31`) applies. Every shape re-traces
+its whole command list every frame. Not a correctness bug.
+
+### F19 — Path approximations: `arcTo`, `roundRect`, `addPath`, and `arc`'s subpath start — LOW
+
+- `packages/terminal/src/path.ts:60-66` — `arcTo` emits `lineTo(x1,y1); lineTo(x2,y2)`. Canvas
+  `arcTo` never passes through the corner `(x1,y1)`; this is the `radius === 0` degenerate case.
+  Documented as an approximation; visibly wrong for large radii.
+- `packages/terminal/src/path.ts:149-154` — `roundRect` → plain `rect`. Documented.
+- `packages/terminal/src/path.ts:156-161` — `addPath` silently drops a non-`TerminalPath`
+  (mixed-backend composition yields a silently empty path).
+- `packages/terminal/src/path.ts:45-53` — `arc`/`circle` update `_cursorX/_cursorY` but never
+  `_startX/_startY`, so a `closePath()` after a bare `circle()` closes back to the *previous*
+  subpath's start (or `(0,0)`) instead of the arc start.
+
+### F20 — `destroy()` leaves the terminal in whatever SGR/cursor state the last frame left — LOW
+
+`packages/terminal/src/context.ts` (no `destroy` override); `_flush` at `:447-450`
+
+The resize disposer is released correctly (verified), but nothing writes a final `ANSI_RESET`, shows
+the cursor, or clears the screen. Combined with **F1** this can leave the user's shell permanently
+coloured after the process exits.
+
+### F21 — `hitTestHonorsTransform = false` is semantically wrong for a transform-dropping backend — LOW (latent)
+
+`packages/terminal/src/context.ts` (inherits `false` from `core/context/context.ts:100`)
+
+`Shape2D.intersectsWith` (`core/core/shape.ts:104-117`) reads `false` as "I applied the transform at
+draw time, so map the point into local space". The terminal applies no transform, so the correct
+value for consistency is `true` ("the point is already in the space I drew in"). Currently latent —
+`isPointInPath` always returns `false` — but it becomes a live bug the moment hit testing is
+implemented.
+
+**Test sketch.** Once hit testing exists: a `translateX: 30` rect must be hit at its *drawn*
+(untranslated) position, not at the translated one.
+
+### F22 — `Text` bounding boxes disagree with what the terminal actually draws — LOW
+
+`packages/core/src/elements/text.ts:89-107` uses the **global** `measureText` (i.e.
+`factory.measureText`, which for `@ripl/node` is `value.length * 8`, `packages/node/src/index.ts:54-69`),
+whereas the terminal renders one glyph per braille cell and `TerminalContext.measureText`
+(`context.ts:412-431`) reports `2 / rasterScale` per character. So `element.getBoundingBox()` for a
+Text is ~4× too wide in the default (non-logical) mode. Charts are unaffected because they call
+`context.measureText` (`charts/src/components/axis.ts:480`, `legend.ts:161`), but the renderer's
+`boundingBoxes` debug overlay and any consumer of `Text.getBoundingBox()` will be wrong.
+
+### F23 — `export().toURL()` never revokes its Blob URL — INFORMATIONAL
+
+`packages/terminal/src/context.ts:98`. Identical to `packages/dom/src/export.ts:51`, so this is a
+codebase-wide convention rather than a terminal defect. In headless environments it correctly falls
+back to a `data:text/plain` URL (verified).
+
+---
+
+## Out of scope but found while tracing (core, affects every backend)
+
+### F24 — A top-level `clip: true` shape leaks one `save()` per frame — MEDIUM (core)
+
+`core/core/shape.ts:170` passes `skipRestore = this.clip`; the dangling `save()` is normally absorbed
+by `Context.popGroup` (`core/context/context.ts:565-571`). But the **scene root** is not bracketed by
+`push`/`pop` — `Scene._collectInstructions` (`core/core/scene.ts:209-234`) only emits them for child
+groups — so a clip shape that is a direct child of the scene has no `popGroup` to absorb it.
+
+**Reproduced.** Scene whose only child is `createRect({ clip: true })`; four consecutive
+`scene.render()` calls → `saveDepth` = `[1, 2, 3, 4]` and `states.length === 4`. Unbounded growth of
+the state stack (and, on canvas, of the native 2D state stack).
+
+**Test sketch.** Render such a scene twice and assert `saveDepth === 0` after each frame.
+
+---
+
+# Ranked summary
+
+| # | Finding | Severity | Kind |
+|---|---|---|---|
+| F1 | ANSI colour bleeds forever when a glyph resolves to no colour (`rasterizer.ts:201-208,233`) | **high** | implemented wrongly |
+| F2 | Named colours / `#rgb` / gradients / patterns silently lose all colour (`color.ts:9-23`) | **high** | implemented wrongly |
+| F3 | `transparent`/`none`/zero-alpha still painted at full strength; alpha discarded (`context.ts:392-400`, `color.ts:20`) | **high** | implemented wrongly |
+| F4 | `opacity` maintained by the pipeline and ignored by the backend (breaks chart crosshairs & fades) | **high** | not implemented, undocumented |
+| F5 | Text with a `stroke` renders nothing (`context.ts:402-409`) | **high** | implemented wrongly |
+| F6 | `ellipse` sweep/rotation args dropped → full unrotated ellipse (`context.ts:214-222`) | medium | implemented wrongly |
+| F7 | Resize repaint runs with a half-updated scale mapping (`context.ts:352-361`) | medium | implemented wrongly |
+| F8 | Explicit `width`/`height` clobbered on resize (`context.ts:324-333`) | medium | implemented wrongly |
+| F9 | `toImageData()` drops all text glyphs (`rasterizer.ts:280-300`) | medium | not implemented |
+| F10 | Shrinking the grid leaves stale rows (`context.ts:365-368`) | medium/low | not implemented |
+| F11 | Transforms dropped entirely (charts: rotated axis titles, rotated symbols) | medium | not implemented, **documented** |
+| F12 | Text-on-a-path ignored (`context.ts:452-468`) | medium/low | not implemented, undocumented |
+| F24 | (core) top-level `clip` shape leaks a `save()` per frame | medium | core defect |
+| F13 | Fill also paints the outline in the fill colour (`context.ts:481-482`) | low | implemented loosely |
+| F14 | lineWidth / lineDash / caps / joins ignored, undocumented | low | not implemented |
+| F15 | Shadows / filters / composite ops ignored, undocumented | low | not implemented |
+| F16 | `reset()` is a no-op | low | not implemented |
+| F17 | No floor on `renderDepth`; a throw in `Group.render` freezes the display | low/medium | robustness |
+| F18 | `supportsPathCaching` needlessly `false` | low | perf |
+| F19 | `arcTo` / `roundRect` / `addPath` / `arc` subpath-start approximations | low | approximation |
+| F20 | `destroy()` leaves the terminal SGR/cursor dirty | low | not implemented |
+| F21 | `hitTestHonorsTransform = false` inconsistent for a transform-dropping backend | low | latent |
+| F22 | `Text` bounding boxes use factory metrics, not cell metrics | low | inconsistency |
+| F23 | Blob URL never revoked (matches `@ripl/dom`) | info | convention |
+
+**Verified clean:** save/restore symmetry and state-stack integrity; `pushGroup`/`popGroup` balance
+(including the clip-absorb path inside a group); the group paint cascade; `markRenderStart`/
+`markRenderEnd` depth accounting under `Scene.render`/`Renderer` (exactly two writes per frame);
+even-odd scanline fills including annular sectors (donuts render as correct rings); uniform logical
+→ raster letterboxing; `textAlign`/`textBaseline` anchor shifting; `export()`'s eager-snapshot
+semantics; `destroy()`'s disposal of the resize listener; zero-size grids (no crash).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -142,6 +142,11 @@ export default tseslint.config(
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
     includeIgnoreFile(gitignorePath),
+
+    // Audit reports quote reproductions and test sketches verbatim; they are findings, not source.
+    {
+        ignores: ['docs/audits/**'],
+    },
     {
         name: 'ripl/main',
         plugins: {

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -1,0 +1,171 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    mockCanvasState,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createContext,
+} from '../src';
+
+import {
+    createCircle,
+    createScene,
+} from '@ripl/core';
+
+polyfillPath2D();
+
+/**
+ * Regression tests for the context audit (see `docs/audits/`). A skipped test pins a confirmed
+ * defect that is not fixed yet: un-skip it with the fix.
+ */
+describe('Canvas audit findings', () => {
+
+    let el: HTMLDivElement;
+
+    beforeEach(() => {
+        mockCanvasContext();
+        el = document.createElement('div');
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        el.remove();
+        vi.restoreAllMocks();
+    });
+
+    function sizeHost(width: number, height: number) {
+        vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+            left: 0,
+            top: 0,
+            right: width,
+            bottom: height,
+            width,
+            height,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        }) as DOMRect);
+    }
+
+    // CANVAS-1: `rescaleCanvas` compares against the backing store, which a fresh <canvas> already
+    // sets to 300x150, so the early return skips `super.rescale` and the context stays 0x0.
+    test.skip('Should scale a context whose host is exactly the default canvas size', () => {
+        sizeHost(300, 150);
+
+        const context = createContext(el);
+
+        expect(context.width).toBe(300);
+        expect(context.height).toBe(150);
+        expect(context.scaleX(150)).toBe(150);
+    });
+
+    test('Should scale a context whose host is any other size', () => {
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        expect(context.width).toBe(400);
+        expect(context.height).toBe(300);
+    });
+
+    // CANVAS-2: a clip shape skips its own restore so the clip persists to later siblings, and
+    // `popGroup` is what absorbs the dangling save. At scene root there is no group to absorb it.
+    test.skip('Should not accumulate save depth across frames for a scene-root clip', () => {
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        const scene = createScene(context, {
+            children: [
+                createCircle({
+                    clip: true,
+                    cx: 50,
+                    cy: 50,
+                    radius: 20,
+                }),
+                createCircle({
+                    fill: '#ff0000',
+                    cx: 50,
+                    cy: 50,
+                    radius: 10,
+                }),
+            ],
+        });
+
+        const depths: number[] = [];
+
+        for (let frame = 0; frame < 5; frame++) {
+            scene.render();
+            depths.push((context as unknown as { saveDepth: number }).saveDepth);
+        }
+
+        expect(depths).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    test('Should not accumulate save depth across frames without a clip', () => {
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        const scene = createScene(context, {
+            children: [
+                createCircle({
+                    fill: '#ff0000',
+                    cx: 50,
+                    cy: 50,
+                    radius: 10,
+                }),
+            ],
+        });
+
+        const depths: number[] = [];
+
+        for (let frame = 0; frame < 5; frame++) {
+            scene.render();
+            depths.push((context as unknown as { saveDepth: number }).saveDepth);
+        }
+
+        expect(depths).toEqual([0, 0, 0, 0, 0]);
+    });
+
+    // CANVAS-3: `_fillCSS`/`_strokeCSS` are plain fields outside the save/restore stack, so the
+    // public getters report a paint the underlying context is no longer using.
+    test.skip('Should report the restored paint from the fill and stroke getters', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.fill = '#ff0000';
+        context.stroke = '#00ff00';
+        context.save();
+        context.fill = '#0000ff';
+        context.stroke = '#ffff00';
+        context.restore();
+
+        expect(context.fill).toBe('#ff0000');
+        expect(context.stroke).toBe('#00ff00');
+    });
+
+    test('Should report the paint set in the current scope', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.fill = '#ff0000';
+
+        expect(context.fill).toBe('#ff0000');
+    });
+
+});

--- a/packages/test-utils/src/canvas.ts
+++ b/packages/test-utils/src/canvas.ts
@@ -172,3 +172,56 @@ export function mockCanvasContext() {
 
     return stub;
 }
+
+/** Drawing-state properties a real `CanvasRenderingContext2D` saves and restores. */
+const STATEFUL_CANVAS_PROPERTIES = [
+    'fillStyle',
+    'strokeStyle',
+    'filter',
+    'direction',
+    'font',
+    'fontKerning',
+    'globalAlpha',
+    'globalCompositeOperation',
+    'lineCap',
+    'lineDashOffset',
+    'lineJoin',
+    'lineWidth',
+    'miterLimit',
+    'shadowBlur',
+    'shadowColor',
+    'shadowOffsetX',
+    'shadowOffsetY',
+    'textAlign',
+    'textBaseline',
+] as const;
+
+/**
+ * Upgrades a {@link mockCanvasContext} stub so `save`/`restore` actually push and pop the drawing
+ * state, the way a real `CanvasRenderingContext2D` does.
+ *
+ * The default stub's `save`/`restore` are no-ops, which structurally hides every state-stack defect:
+ * a test cannot tell a context that correctly restores its paint from one that never restores
+ * anything. Use this whenever a test asserts what the drawing state is *after* a scope closes.
+ *
+ * @param stub - The context stub returned by {@link mockCanvasContext}.
+ * @returns The same stub, for chaining.
+ */
+export function mockCanvasState<TStub extends object>(stub: TStub): TStub {
+    const target = stub as Record<string, unknown>;
+    const stack: Record<string, unknown>[] = [];
+
+    target.save = vi.fn(() => {
+        stack.push(Object.fromEntries(STATEFUL_CANVAS_PROPERTIES.map(key => [key, target[key]])));
+    });
+
+    target.restore = vi.fn(() => {
+        const state = stack.pop();
+
+        if (state) {
+            Object.assign(target, state);
+        }
+    });
+
+    return stub;
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,5 +1,6 @@
 export {
     mockCanvasContext,
+    mockCanvasState,
     mockTextMetrics,
     polyfillPath2D,
 } from './canvas';


### PR DESCRIPTION
Investigation, not fixes. One audit per backend against the base contract in `packages/core/src/context/context.ts`, using a uniform checklist so findings are comparable: save/restore symmetry · render-depth handling · `pushGroup`/`popGroup` balance and clip scoping · transform composition · paint resolution and def lifecycle · text metrics · hit testing · `export()` · `destroy()` · **parity with canvas for an identical scene**.

Fixes are triaged into eight proposed branches in the README rather than attempted here, so each lands as its own small PR.

## What's in it

| Report | Scope | Confirmed | Highest |
|---|---|---|---|
| `canvas.md` | `CanvasContext`, `canvas2DStateMixin` | 18 / 21 | 4 high |
| `svg.md` | `SVGContext`, definitions, diff, text | 17 / 21 | 7 high |
| `dom-node.md` | `DOMContext`, reconciler, navigator, `@ripl/node` | 27 / 28 | 4 high |
| `terminal.md` | `TerminalContext`, rasterizer | 24 | 5 high |
| `3d-webgpu.md` | `Context3D`, `CanvasContext3D`, `WebGPUContext3D` | 28 | 4 high |

Each finding carries a `file:line`, a concrete failure scenario, a severity and a test sketch. **Confirmed** means a path was traced *and* executed; **suspected** means reasoning only (typically needing a real browser). Each report also lists what it checked and found correct, so the negative results are auditable.

## Worth knowing before you read them

**One seed lead was refuted.** `createFrameBuffer` was suspected of starving the hover hit test during a fast drag, by analogy with the slider bug in `0bc2fc4`. It doesn't: that was a `setTimeout` debounce with a *relative* deadline that every new event pushed forward, whereas `requestAnimationFrame` has an *absolute* one — cancel and reschedule N times still leaves exactly one callback registered. Measured at 20× a browser's delivery rate: one hover emission per frame.

**The test harness was hiding a whole class of defects.** `mockCanvasContext` uses no-op `save`/`restore`, so no test could distinguish a context that correctly restores its paint from one that never restores anything. `mockCanvasState` adds a real state stack — that's the durable asset here, and it's what made the fill-getter finding testable at all.

## What I re-verified myself

The reports are agent-produced. I independently re-verified three, and **those are the only ones encoded as tests** — everything else should be re-confirmed before a fix is written against it. The README says so explicitly.

1. **`rescaleCanvas` no-ops on a 300×150 host.** A fresh `<canvas>` backing store is exactly 300×150, so the early return skips `super.rescale`: `context.width`/`height` stay `0`, `scaleX(150)` returns `0`, and `clear()` becomes `clearRect(0, 0, 0, 0)` — the surface never clears. Total failure on a very common explicit chart size.
2. **A scene-root `clip: true` shape leaks one `save()` per frame** — measured depth `1, 2, 3, 4, 5`. `popGroup` normally absorbs the clip's dangling save; at scene root there's no group to do it. Found independently by the canvas and terminal audits.
3. **`context.fill` reports the inner scope's paint after a `restore()`** — `_fillCSS`/`_strokeCSS` are plain fields outside the stack. Blast radius is nil today (no product code reads those getters, only tests), so it's a lying public getter rather than a rendering bug.

Each is a `test.skip` in `packages/canvas/test/audit.test.ts` paired with a passing control. Un-skipped, all three fail; the controls pass.

## Overlap with the other branches

Four findings are already fixed in the sibling PRs and are marked as such rather than re-reported: the group-gradient box and the two gradient/pattern cache issues (#60), and the emptied-group reconcile (#62 — this audit is where that one came from).

The canvas/SVG group-gradient **parity** gap is characterized but deliberately not fixed, per the plan.

## Not done

The canvas↔SVG parity harness — same gallery through both backends, diffed against each other rather than a stored baseline — was scoped but not built. The README says where it goes and which two divergences it would catch first.

`docs/audits/**` is excluded from lint: the reports quote reproductions and test sketches verbatim, and they're findings, not source.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1KGv3Mu5uJguQqEQnCgTz)_