### PR TITLE
Keep canvas paint, transform and text on the state stack

### DIFF
--- a/docs/migrations/context-audit.md
+++ b/docs/migrations/context-audit.md
@@ -147,7 +147,81 @@ set `font` explicitly on the scene or the host.
 
 ## @ripl/canvas
 
-_No entries yet._
+### Paint state
+
+**`Context.fill`** and **`Context.stroke`** — **behaviour**. The resolved paint strings are pushed and
+popped alongside the native drawing state by `save()`/`restore()`, so the getters report the paint the
+context is actually painting with. They were plain instance fields outside the stack, so once a paint
+had been assigned inside any scope the getter reported that value for the life of the context — a
+lying getter, not a wrong pixel, since nothing in the render pipeline reads them back.
+
+**`Context.fill`** and **`Context.stroke`** — **behaviour**. Assigning an empty string is ignored.
+Native canvas rejects an invalid colour, so `fill = ''` neither cleared the paint nor reported the
+failure; it only blanked the tracked value and unmasked whatever the native context still held. To
+clear a paint, assign a transparent colour (`'transparent'`, `'rgba(0, 0, 0, 0)'`).
+
+### Sizing
+
+**`rescaleCanvas`** — **behaviour**. The returned scales map logical coordinates onto `width * dpr` —
+the exact transform drawing goes through — instead of the floored backing-store size. The backing
+store is still floored to whole device pixels. Pointer mapping and drawing disagreed by up to a device
+pixel at the far edge of a surface whose scaled size is not an integer.
+
+**`CanvasContext.rescale`** — **behaviour**. Assigns the DPR-aware scales *before* emitting `resize`,
+and no longer delegates to `Context.rescale`, which installs identity scales and emits from inside
+that window. Any `resize` handler reading `context.scaleX`/`scaleY` — including `Scene`'s own
+synchronous re-render — saw the identity mapping. A `Context` subclass that overrides `rescale` to
+install its own scales has to do the same.
+
+### Text and images
+
+**`renderTextAlongPath`** — **behaviour**. Each glyph is placed at the point its own `textAlign`
+anchors it to rather than always at its mid-point, which was only correct for `center`; under the
+canvas default of `start` every glyph slid forward by half its own advance. `startOffset` is clamped
+to `[0, 1]` (a negative value stacked the leading glyphs on the path start, because the sampler
+clamps but the layout kept advancing from a negative distance) and `maxWidth` caps the run's advance
+instead of being ignored. Text on a path moves back by half a glyph wherever `pathData` is used.
+
+**`canvasDrawImage`** — **behaviour**. A width supplied without a height (or the reverse) is honoured,
+with the missing dimension taken from the image's intrinsic size; it used to fall through to the
+three-argument form and draw at natural size. A `0` is honoured too and draws nothing, rather than
+reading as "no size given".
+
+### Lifecycle
+
+**`Context.reset`** — **behaviour**. Calls `super.reset()` and re-installs the
+`setTransform(dpr, 0, 0, dpr, 0, 0)` matrix the surface is drawn through. Native `reset()` clears the
+state stack, the clip **and** the transform, so on a 2× display everything after a `reset()` rendered
+at half size in the top-left quadrant, while `Context.saveDepth` kept counting saves the native stack
+no longer held and a later `popGroup()` unwound to the wrong depth.
+
+**`CanvasContext.destroy`** — **API**, additive override. Releases the gradients and patterns cached
+against the context, together with the offscreen tile canvases the patterns hold, and zeroes the
+canvas backing store (`width × height × 4` bytes, otherwise held until collection). Do not draw into a
+context after `destroy()`.
+
+**`toCanvasPattern`** — **behaviour**. Cached per context *and* string rather than in one module-global
+map. A destroyed context's `CanvasPattern` was handed to the next context that asked for the same
+string, and neither it nor its tile canvas was ever released.
+
+**`releaseCanvasPaintCache`** — **API**, additive. Drops every `CanvasGradient` and `CanvasPattern`
+cached against a native context. Call it from the teardown of a backend that composes
+`canvas2DStateMixin` itself.
+
+### Performance
+
+**`setCanvasFill`** and **`setCanvasStroke`** — **behaviour**. The native `CanvasGradient` is cached
+per context, paint string and bounds instead of rebuilt on every assignment — 500 gradient elements at
+60 fps allocated 30 000 gradients a second. **`renderTextAlongPath`** caches path length and glyph
+sample points per `d` string and distance, so a text element parses its path once rather than once per
+glyph per frame. Both are pure functions of their inputs; no output changes.
+
+### Known limitation
+
+**Group `globalCompositeOperation`** — unchanged. A group's blend mode is still applied to each
+descendant independently rather than to the subtree as a unit, so it does not match SVG's
+`<g mix-blend-mode>`. True group compositing needs an offscreen layer and real blending, neither of
+which the jsdom stub can express; left for the pixel harness.
 
 ## @ripl/svg
 

--- a/packages/canvas/src/context.ts
+++ b/packages/canvas/src/context.ts
@@ -3,6 +3,7 @@ import {
 } from './mixins';
 
 import {
+    releaseCanvasPaintCache,
     rescaleCanvas,
 } from './utilities';
 
@@ -71,6 +72,17 @@ export class CanvasContext extends canvas2DStateMixin(CanvasDOMBase) {
     /** Captures a snapshot of the canvas and returns format-specific exporters (see {@link ContextExport}). */
     public export(): ContextExport {
         return createCanvasExport(this.element);
+    }
+
+    /** Destroys the context, releasing its cached paint and the canvas backing store on top of the base teardown. */
+    public destroy(): void {
+        releaseCanvasPaintCache(this.context);
+
+        // A detached canvas holds width*height*4 bytes until it is collected; zeroing frees it now.
+        this.element.width = 0;
+        this.element.height = 0;
+
+        super.destroy();
     }
 
 }

--- a/packages/canvas/src/context.ts
+++ b/packages/canvas/src/context.ts
@@ -54,12 +54,18 @@ export class CanvasContext extends canvas2DStateMixin(CanvasDOMBase) {
             return;
         }
 
-        const result = rescaleCanvas(this.element, this.context, width, height);
+        const {
+            scaleX,
+            scaleY,
+        } = rescaleCanvas(this.element, this.context, width, height);
 
-        super.rescale(width, height);
+        this.width = width;
+        this.height = height;
+        this.scaleX = scaleX;
+        this.scaleY = scaleY;
 
-        this.scaleX = result.scaleX;
-        this.scaleY = result.scaleY;
+        // Not `super.rescale`: it installs identity scales and emits before the DPR-aware ones land.
+        this.emit('resize', null);
     }
 
     /** Captures a snapshot of the canvas and returns format-specific exporters (see {@link ContextExport}). */

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -14,6 +14,7 @@ import {
 } from './path';
 
 import {
+    factory,
     getGradientBounds,
     isGradientString,
     isPatternString,
@@ -92,7 +93,7 @@ export interface Canvas2DState {
     restore(): void;
     /** Clears the entire canvas surface. */
     clear(): void;
-    /** Resets the canvas context to its default state. */
+    /** Resets the context to its default state, dropping the saved-state stack and re-installing the device-pixel-ratio transform the surface is drawn through. */
     reset(): void;
     /** Applies a rotation transformation, in radians. */
     rotate(angle: number): void;
@@ -375,7 +376,17 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
         }
 
         public reset(): void {
-            return this.context.reset();
+            super.reset();
+
+            this._paintScopes = [];
+            this._fillCSS = '';
+            this._strokeCSS = '';
+            this.context.reset();
+
+            // Native `reset()` drops the transform too, taking the DPR matrix `rescaleCanvas` installed.
+            const dpr = factory.devicePixelRatio ?? 1;
+
+            this.context.setTransform(dpr, 0, 0, dpr, 0, 0);
         }
 
         public rotate(angle: number): void {

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -121,7 +121,7 @@ export interface Canvas2DState {
      * @param f Vertical translation.
      */
     transform(a: number, b: number, c: number, d: number, e: number, f: number): void;
-    /** Measures text dimensions using the canvas context's current font or an optional override. */
+    /** Measures text dimensions using the canvas context's current font, text alignment, and baseline, or an optional font override. */
     measureText(text: string, font?: string): TextMetrics;
     /** Creates a new {@link CanvasPath}, optionally reusing an id for diffing efficiency. */
     createPath(id?: string): CanvasPath;

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -33,6 +33,9 @@ import type {
     TextBaseline,
 } from '@ripl/core';
 
+/** The `[fill, stroke]` paint strings a save/restore pair has to put back alongside the native state. */
+type PaintScope = [string, string];
+
 /** Constructor type for (possibly abstract) classes, used to compose mixins over a `Context` base. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AbstractConstructor<TInstance = object> = abstract new (...args: any[]) => TInstance;
@@ -43,7 +46,7 @@ export type AbstractConstructor<TInstance = object> = abstract new (...args: any
  * drawing, transform, measurement, and hit-testing operations common to every canvas-backed context.
  */
 export interface Canvas2DState {
-    /** The current fill style: a color or CSS gradient string. */
+    /** The current fill style: a color or CSS gradient string. Assigning an empty value is ignored, because native canvas rejects it and the paint already in force stays in use. */
     fill: string;
     /** The current filter applied to drawing operations. */
     filter: string;
@@ -77,13 +80,13 @@ export interface Canvas2DState {
     shadowOffsetX: number;
     /** The current vertical shadow offset. */
     shadowOffsetY: number;
-    /** The current stroke style: a color or CSS gradient string. */
+    /** The current stroke style: a color or CSS gradient string. Assigning an empty value is ignored, because native canvas rejects it and the paint already in force stays in use. */
     stroke: string;
     /** The current horizontal text alignment. */
     textAlign: TextAlignment;
     /** The current vertical text baseline. */
     textBaseline: TextBaseline;
-    /** Saves the current drawing state onto the state stack. */
+    /** Saves the current drawing state, including the resolved {@link Canvas2DState.fill} and {@link Canvas2DState.stroke} strings, onto the state stack. */
     save(): void;
     /** Restores the most recently saved drawing state from the stack; a no-op when the stack is empty. */
     restore(): void;
@@ -149,6 +152,7 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
     abstract class Canvas2DStateContext extends Base {
 
         declare protected context: CanvasRenderingContext2D;
+        private _paintScopes: PaintScope[] = [];
         private _fillCSS: string = '';
         private _strokeCSS: string = '';
 
@@ -157,6 +161,11 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
         }
 
         public set fill(value) {
+            // Native canvas ignores an invalid colour, so recording one would report a paint it never took.
+            if (!value) {
+                return;
+            }
+
             this._fillCSS = value;
 
             // Fast path: plain colors skip bounds resolution and parsing; a raw pattern is not a valid fill.
@@ -301,6 +310,10 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
         }
 
         public set stroke(value) {
+            if (!value) {
+                return;
+            }
+
             this._strokeCSS = value;
 
             // Fast path: plain colors skip bounds resolution and parsing; a raw pattern is not a valid stroke.
@@ -334,7 +347,9 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
         }
 
         public save(): void {
+            this._paintScopes.push([this._fillCSS, this._strokeCSS]);
             this.saveDepth += 1;
+
             return this.context.save();
         }
 
@@ -343,7 +358,15 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
                 return;
             }
 
+            const [
+                fill,
+                stroke,
+            ] = this._paintScopes.pop() || ['', ''];
+
+            this._fillCSS = fill;
+            this._strokeCSS = stroke;
             this.saveDepth -= 1;
+
             return this.context.restore();
         }
 

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -127,7 +127,7 @@ export interface Canvas2DState {
     createPath(id?: string): CanvasPath;
     /** Clips subsequent drawing operations to the given path. */
     applyClip(path: CanvasPath, fillRule?: FillRule): void;
-    /** Draws an image onto the canvas at the given position and optional size. */
+    /** Draws an image onto the canvas at the given position, sized to the given width and height; a dimension given on its own is taken with the image's intrinsic size for the other. */
     drawImage(image: CanvasImageSource, x: number, y: number, width?: number, height?: number): void;
     /** Fills the given path or text element using the current fill style. */
     applyFill(element: CanvasPath | ContextText, fillRule?: FillRule): void;

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -20,6 +20,7 @@ import type {
     Gradient,
     GradientBounds,
     Scale,
+    TextAlignment,
 } from '@ripl/core';
 
 import {
@@ -245,21 +246,45 @@ export function rescaleCanvas(
     };
 }
 
-/** Renders text character-by-character along a path using fill or stroke. */
+// Where a glyph's anchor sits within its own advance, per the alignment `fillText` will draw it with.
+const TEXT_PATH_ANCHORS: Record<TextAlignment, (advance: number) => number> = {
+    start: () => 0,
+    left: () => 0,
+    center: advance => advance / 2,
+    right: advance => advance,
+    end: advance => advance,
+};
+
+/**
+ * Renders text character-by-character along a path using fill or stroke.
+ *
+ * Each glyph is drawn at the origin of a frame translated to the path, so it is placed at the
+ * point its own `textAlign` anchors it to — the mid-point only for `center`. Glyphs are laid out
+ * from `startOffset` (clamped into the path) up to `maxWidth` of advance, and one whose mid-point
+ * falls past the end of the run is dropped, as SVG `<textPath>` does.
+ *
+ * @param ctx - The native context to draw into.
+ * @param element - The text element, whose `pathData` describes the path to lay the text along.
+ * @param method - Whether to fill or stroke each glyph.
+ */
 export function renderTextAlongPath(ctx: CanvasRenderingContext2D, element: ContextText, method: 'fill' | 'stroke'): void {
     const pathData = element.pathData!;
     const totalLength = getPathLength(pathData);
-    let distance = (element.startOffset ?? 0) * totalLength;
+    const anchorOffset = TEXT_PATH_ANCHORS[ctx.textAlign] || TEXT_PATH_ANCHORS.start;
+    const startDistance = numberClamp(element.startOffset ?? 0, 0, 1) * totalLength;
+    const limit = Math.min(totalLength, startDistance + (element.maxWidth ?? Infinity));
+
+    let distance = startDistance;
 
     for (const char of element.content) {
-        const charWidth = ctx.measureText(char).width;
-        const midDistance = distance + charWidth / 2;
+        const advance = ctx.measureText(char).width;
 
-        if (midDistance > totalLength) {
+        // Advance only grows, so the first glyph past the end of the run is also the last that fits.
+        if (distance + advance / 2 > limit) {
             break;
         }
 
-        const { x, y, angle } = samplePathPoint(pathData, midDistance);
+        const { x, y, angle } = samplePathPoint(pathData, distance + anchorOffset(advance));
 
         ctx.save();
         ctx.translate(x, y);
@@ -272,7 +297,7 @@ export function renderTextAlongPath(ctx: CanvasRenderingContext2D, element: Cont
         }
 
         ctx.restore();
-        distance += charWidth;
+        distance += advance;
     }
 }
 

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -26,6 +26,8 @@ import type {
 
 import {
     numberClamp,
+    typeIsNil,
+    typeIsNumber,
 } from '@ripl/utilities';
 
 import type {
@@ -33,6 +35,18 @@ import type {
 } from './path';
 
 type CanvasGradientFactory = (context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds) => CanvasGradient;
+
+/** Anything with an intrinsic pixel size `drawImage` can fall back to, across the `CanvasImageSource` union. */
+interface IntrinsicallySized {
+    naturalWidth?: number;
+    naturalHeight?: number;
+    videoWidth?: number;
+    videoHeight?: number;
+    codedWidth?: number;
+    codedHeight?: number;
+    width?: unknown;
+    height?: unknown;
+}
 
 const CANVAS_GRADIENT_FACTORIES: Record<string, CanvasGradientFactory> = {
     linear: (context, gradient, { x, y, width, height }) => {
@@ -383,13 +397,42 @@ export function applyCanvasStroke(ctx: CanvasRenderingContext2D, element: Canvas
     return ctx.stroke(element.ref);
 }
 
-/** Draws an image onto a canvas context with optional width and height. */
+function getIntrinsicSize(image: CanvasImageSource): [number, number] {
+    const source = image as IntrinsicallySized;
+    const width = typeIsNumber(source.width) ? source.width : 0;
+    const height = typeIsNumber(source.height) ? source.height : 0;
+
+    return [
+        source.naturalWidth ?? source.videoWidth ?? source.codedWidth ?? width,
+        source.naturalHeight ?? source.videoHeight ?? source.codedHeight ?? height,
+    ];
+}
+
+/**
+ * Draws an image onto a canvas context, sizing it to the given width and height.
+ *
+ * A dimension given on its own is honoured and the other taken from the image's intrinsic size —
+ * the destination-rectangle form of `drawImage` needs both. Supplying neither draws at intrinsic
+ * size; supplying `0` draws nothing, which is what a zero-sized element asks for.
+ *
+ * @param ctx - The native context to draw into.
+ * @param image - The image source to draw.
+ * @param x - Destination x coordinate.
+ * @param y - Destination y coordinate.
+ * @param width - Destination width, defaulting to the image's intrinsic width.
+ * @param height - Destination height, defaulting to the image's intrinsic height.
+ */
 export function canvasDrawImage(ctx: CanvasRenderingContext2D, image: CanvasImageSource, x: number, y: number, width?: number, height?: number): void {
-    if (width && height) {
-        return ctx.drawImage(image, x, y, width, height);
+    if (typeIsNil(width) && typeIsNil(height)) {
+        return ctx.drawImage(image, x, y);
     }
 
-    return ctx.drawImage(image, x, y);
+    const [
+        intrinsicWidth,
+        intrinsicHeight,
+    ] = getIntrinsicSize(image);
+
+    return ctx.drawImage(image, x, y, width ?? intrinsicWidth, height ?? intrinsicHeight);
 }
 
 /** Measures text dimensions using the context's alignment and baseline, and an optional font override. */

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -238,9 +238,10 @@ export function rescaleCanvas(
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
 
+    // The scales describe the transform drawing actually uses (an exact `dpr`), not the floored store.
     return {
-        scaleX: scaleContinuous([0, width], [0, scaledWidth]),
-        scaleY: scaleContinuous([0, height], [0, scaledHeight]),
+        scaleX: scaleContinuous([0, width], [0, width * dpr]),
+        scaleY: scaleContinuous([0, height], [0, height * dpr]),
     };
 }
 

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -19,6 +19,7 @@ import type {
     FillRule,
     Gradient,
     GradientBounds,
+    PathPoint,
     Scale,
     TextAlignment,
 } from '@ripl/core';
@@ -84,6 +85,64 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
 // Pattern tiles are position-independent, so one `CanvasPattern` per string serves every element and frame.
 const PATTERN_CACHE_LIMIT = 256;
 const patternCache = new Map<string, CanvasPattern | null>();
+
+const PAINT_CACHE_LIMIT = 256;
+const PATH_CACHE_LIMIT = 1024;
+
+// Canvas bakes gradient geometry at set time, so one native object serves a paint string and box.
+const gradientCaches = new WeakMap<CanvasRenderingContext2D, Map<string, CanvasGradient>>();
+
+// Path geometry is a pure function of the `d` string, and text on a path re-samples the same
+// distances every frame; without this each glyph re-parses the whole path once per frame.
+const pathLengthCache = new Map<string, number>();
+const pathPointCache = new Map<string, PathPoint>();
+
+/** Reads through a bounded cache, dropping the whole map on overflow rather than tracking recency. */
+function resolveCached<TValue>(cache: Map<string, TValue>, limit: number, key: string, produce: () => TValue): TValue {
+    const cached = cache.get(key);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    if (cache.size >= limit) {
+        cache.clear();
+    }
+
+    const value = produce();
+
+    cache.set(key, value);
+
+    return value;
+}
+
+function getPaintCache<TValue>(caches: WeakMap<CanvasRenderingContext2D, Map<string, TValue>>, ctx: CanvasRenderingContext2D): Map<string, TValue> {
+    const cache = caches.get(ctx) || new Map<string, TValue>();
+
+    caches.set(ctx, cache);
+
+    return cache;
+}
+
+function toCanvasGradientCached(ctx: CanvasRenderingContext2D, value: string, bounds: GradientBounds): CanvasGradient | null {
+    const gradient = parseGradientCached(value);
+
+    if (!gradient) {
+        return null;
+    }
+
+    const key = `${value}|${bounds.x},${bounds.y},${bounds.width},${bounds.height}`;
+
+    return resolveCached(getPaintCache(gradientCaches, ctx), PAINT_CACHE_LIMIT, key, () => toCanvasGradient(ctx, gradient, bounds));
+}
+
+function getPathLengthCached(pathData: string): number {
+    return resolveCached(pathLengthCache, PATH_CACHE_LIMIT, pathData, () => getPathLength(pathData));
+}
+
+function samplePathPointCached(pathData: string, distance: number): PathPoint {
+    return resolveCached(pathPointCache, PATH_CACHE_LIMIT, `${pathData}|${distance}`, () => samplePathPoint(pathData, distance));
+}
 
 /**
  * Materializes a `pattern(...)` paint string as a repeating `CanvasPattern`, drawing the shared
@@ -166,10 +225,10 @@ export function setCanvasFill(ctx: CanvasRenderingContext2D, value: string, boun
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientCached(value);
+        const gradient = toCanvasGradientCached(ctx, value, bounds);
 
         if (gradient) {
-            ctx.fillStyle = toCanvasGradient(ctx, gradient, bounds);
+            ctx.fillStyle = gradient;
             return;
         }
     }
@@ -189,10 +248,10 @@ export function setCanvasStroke(ctx: CanvasRenderingContext2D, value: string, bo
     }
 
     if (isGradientString(value)) {
-        const gradient = parseGradientCached(value);
+        const gradient = toCanvasGradientCached(ctx, value, bounds);
 
         if (gradient) {
-            ctx.strokeStyle = toCanvasGradient(ctx, gradient, bounds);
+            ctx.strokeStyle = gradient;
             return;
         }
     }
@@ -269,7 +328,7 @@ const TEXT_PATH_ANCHORS: Record<TextAlignment, (advance: number) => number> = {
  */
 export function renderTextAlongPath(ctx: CanvasRenderingContext2D, element: ContextText, method: 'fill' | 'stroke'): void {
     const pathData = element.pathData!;
-    const totalLength = getPathLength(pathData);
+    const totalLength = getPathLengthCached(pathData);
     const anchorOffset = TEXT_PATH_ANCHORS[ctx.textAlign] || TEXT_PATH_ANCHORS.start;
     const startDistance = numberClamp(element.startOffset ?? 0, 0, 1) * totalLength;
     const limit = Math.min(totalLength, startDistance + (element.maxWidth ?? Infinity));
@@ -284,7 +343,7 @@ export function renderTextAlongPath(ctx: CanvasRenderingContext2D, element: Cont
             break;
         }
 
-        const { x, y, angle } = samplePathPoint(pathData, distance + anchorOffset(advance));
+        const { x, y, angle } = samplePathPointCached(pathData, distance + anchorOffset(advance));
 
         ctx.save();
         ctx.translate(x, y);

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -82,14 +82,12 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
     return canvasGradient;
 }
 
-// Pattern tiles are position-independent, so one `CanvasPattern` per string serves every element and frame.
-const PATTERN_CACHE_LIMIT = 256;
-const patternCache = new Map<string, CanvasPattern | null>();
-
 const PAINT_CACHE_LIMIT = 256;
 const PATH_CACHE_LIMIT = 1024;
 
-// Canvas bakes gradient geometry at set time, so one native object serves a paint string and box.
+// Paint is cached per context: a `CanvasPattern`/`CanvasGradient` outlives the context that built it,
+// so a module-global cache handed a destroyed context's objects — and their tiles — to the next one.
+const patternCaches = new WeakMap<CanvasRenderingContext2D, Map<string, CanvasPattern | null>>();
 const gradientCaches = new WeakMap<CanvasRenderingContext2D, Map<string, CanvasGradient>>();
 
 // Path geometry is a pure function of the `d` string, and text on a path re-samples the same
@@ -124,50 +122,10 @@ function getPaintCache<TValue>(caches: WeakMap<CanvasRenderingContext2D, Map<str
     return cache;
 }
 
-function toCanvasGradientCached(ctx: CanvasRenderingContext2D, value: string, bounds: GradientBounds): CanvasGradient | null {
-    const gradient = parseGradientCached(value);
-
-    if (!gradient) {
-        return null;
-    }
-
-    const key = `${value}|${bounds.x},${bounds.y},${bounds.width},${bounds.height}`;
-
-    return resolveCached(getPaintCache(gradientCaches, ctx), PAINT_CACHE_LIMIT, key, () => toCanvasGradient(ctx, gradient, bounds));
-}
-
-function getPathLengthCached(pathData: string): number {
-    return resolveCached(pathLengthCache, PATH_CACHE_LIMIT, pathData, () => getPathLength(pathData));
-}
-
-function samplePathPointCached(pathData: string, distance: number): PathPoint {
-    return resolveCached(pathPointCache, PATH_CACHE_LIMIT, `${pathData}|${distance}`, () => samplePathPoint(pathData, distance));
-}
-
-/**
- * Materializes a `pattern(...)` paint string as a repeating `CanvasPattern`, drawing the shared
- * tile geometry into an offscreen canvas. Results (including parse failures) are cached per
- * string.
- *
- * @param ctx - The context the pattern will paint into.
- * @param value - The `pattern(...)` paint string.
- * @returns The repeating pattern, or `null` when the string or environment can't produce one.
- */
-export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): CanvasPattern | null {
-    const cached = patternCache.get(value);
-
-    if (cached !== undefined) {
-        return cached;
-    }
-
-    if (patternCache.size >= PATTERN_CACHE_LIMIT) {
-        patternCache.clear();
-    }
-
+function createCanvasPattern(ctx: CanvasRenderingContext2D, value: string): CanvasPattern | null {
     const pattern = parsePatternCached(value);
 
     if (!pattern) {
-        patternCache.set(value, null);
         return null;
     }
 
@@ -180,7 +138,6 @@ export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): C
     const tileContext = tile.getContext('2d');
 
     if (!tileContext) {
-        patternCache.set(value, null);
         return null;
     }
 
@@ -206,11 +163,51 @@ export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): C
         tileContext.fill();
     });
 
-    const canvasPattern = ctx.createPattern(tile, 'repeat');
+    return ctx.createPattern(tile, 'repeat');
+}
 
-    patternCache.set(value, canvasPattern);
+function toCanvasGradientCached(ctx: CanvasRenderingContext2D, value: string, bounds: GradientBounds): CanvasGradient | null {
+    const gradient = parseGradientCached(value);
 
-    return canvasPattern;
+    if (!gradient) {
+        return null;
+    }
+
+    const key = `${value}|${bounds.x},${bounds.y},${bounds.width},${bounds.height}`;
+
+    return resolveCached(getPaintCache(gradientCaches, ctx), PAINT_CACHE_LIMIT, key, () => toCanvasGradient(ctx, gradient, bounds));
+}
+
+function getPathLengthCached(pathData: string): number {
+    return resolveCached(pathLengthCache, PATH_CACHE_LIMIT, pathData, () => getPathLength(pathData));
+}
+
+function samplePathPointCached(pathData: string, distance: number): PathPoint {
+    return resolveCached(pathPointCache, PATH_CACHE_LIMIT, `${pathData}|${distance}`, () => samplePathPoint(pathData, distance));
+}
+
+/**
+ * Materializes a `pattern(...)` paint string as a repeating `CanvasPattern`, drawing the shared
+ * tile geometry into an offscreen canvas. Results (including parse failures) are cached per
+ * context and string, and released by {@link releaseCanvasPaintCache}.
+ *
+ * @param ctx - The context the pattern will paint into.
+ * @param value - The `pattern(...)` paint string.
+ * @returns The repeating pattern, or `null` when the string or environment can't produce one.
+ */
+export function toCanvasPattern(ctx: CanvasRenderingContext2D, value: string): CanvasPattern | null {
+    return resolveCached(getPaintCache(patternCaches, ctx), PAINT_CACHE_LIMIT, value, () => createCanvasPattern(ctx, value));
+}
+
+/**
+ * Drops every `CanvasGradient` and `CanvasPattern` cached against a context, together with the
+ * offscreen tile canvases the patterns hold. Call it when the context is torn down.
+ *
+ * @param ctx - The native context whose cached paint is released.
+ */
+export function releaseCanvasPaintCache(ctx: CanvasRenderingContext2D): void {
+    patternCaches.delete(ctx);
+    gradientCaches.delete(ctx);
 }
 
 /** Sets the fill style on a native canvas context, resolving gradient and pattern strings when applicable. */

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -23,6 +23,10 @@ import {
     factory,
 } from '@ripl/core';
 
+import type {
+    MeasureTextOptions,
+} from '@ripl/core';
+
 polyfillPath2D();
 
 const PATTERN = 'pattern(diagonal, #1a6, #fff, 8)';
@@ -302,6 +306,33 @@ describe('Canvas audit findings', () => {
         second.fill = PATTERN;
 
         expect(stub.createPattern).toHaveBeenCalledTimes(1);
+    });
+
+    // CANVAS-14: `actualBoundingBox*` is anchor-relative, so the alignment has to reach the measurer.
+    test('Should measure text through the context alignment and baseline', () => {
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+        const measured: (MeasureTextOptions | undefined)[] = [];
+        const measurer = factory.measureText;
+
+        factory.set({
+            measureText: (text, options) => {
+                measured.push(options);
+                return measurer(text, options);
+            },
+        });
+
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.measureText('hello');
+
+        factory.set({
+            measureText: measurer,
+        });
+
+        expect(measured[0]?.textAlign).toBe('center');
+        expect(measured[0]?.textBaseline).toBe('middle');
     });
 
 });

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -25,6 +25,8 @@ import {
 
 polyfillPath2D();
 
+const PATTERN = 'pattern(diagonal, #1a6, #fff, 8)';
+
 /**
  * Regression tests for the context audit (see `docs/audits/`). A skipped test pins a confirmed
  * defect that is not fixed yet: un-skip it with the fix.
@@ -271,6 +273,35 @@ describe('Canvas audit findings', () => {
         context['rescale'](800, 600);
 
         expect(scales).toEqual([200]);
+    });
+
+    // CANVAS-16: the pattern cache was module-global, so it outlived the context that built it.
+    test('Should release the canvas backing store on destroy', () => {
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+        const canvas = context.element;
+
+        context.destroy();
+
+        expect(canvas.width).toBe(0);
+        expect(canvas.height).toBe(0);
+    });
+
+    test('Should not hand a destroyed context cached paint to the next context', () => {
+        sizeHost(400, 300);
+
+        const first = createContext(el);
+
+        first.fill = PATTERN;
+        first.destroy();
+
+        const stub = mockCanvasContext();
+        const second = createContext(el);
+
+        second.fill = PATTERN;
+
+        expect(stub.createPattern).toHaveBeenCalledTimes(1);
     });
 
 });

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -138,7 +138,7 @@ describe('Canvas audit findings', () => {
 
     // CANVAS-3: `_fillCSS`/`_strokeCSS` are plain fields outside the save/restore stack, so the
     // public getters report a paint the underlying context is no longer using.
-    test.skip('Should report the restored paint from the fill and stroke getters', () => {
+    test('Should report the restored paint from the fill and stroke getters', () => {
         mockCanvasState(mockCanvasContext());
         sizeHost(400, 300);
 
@@ -164,6 +164,46 @@ describe('Canvas audit findings', () => {
         context.fill = '#ff0000';
 
         expect(context.fill).toBe('#ff0000');
+    });
+
+    // A paint written only inside a scope must not outlive it, or the getter reports a value the
+    // outer scope never held.
+    test('Should fall back to the native default for a paint set only inside a scope', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.save();
+        context.fill = '#123456';
+        context.restore();
+
+        expect(context.fill).toBe('#000000');
+    });
+
+    // Native canvas rejects an invalid colour, so recording one unmasked the stale native value.
+    test('Should ignore an empty fill and keep reporting the paint in force', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.fill = '#ff0000';
+        context.fill = '';
+
+        expect(context.fill).toBe('#ff0000');
+    });
+
+    test('Should ignore an empty stroke and keep reporting the paint in force', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.stroke = '#00ff00';
+        context.stroke = '';
+
+        expect(context.stroke).toBe('#00ff00');
     });
 
 });

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -256,4 +256,21 @@ describe('Canvas audit findings', () => {
         expect(context.lineWidth).toBe(8);
     });
 
+    // CANVAS-9: `Context.rescale` installs identity scales and emits before the DPR ones land.
+    test('Should emit resize with the device pixel ratio scales already applied', () => {
+        factory.set({
+            devicePixelRatio: 2,
+        });
+
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+        const scales: number[] = [];
+
+        context.on('resize', () => scales.push(context.scaleX(100)));
+        context['rescale'](800, 600);
+
+        expect(scales).toEqual([200]);
+    });
+
 });

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -20,6 +20,7 @@ import {
 import {
     createCircle,
     createScene,
+    factory,
 } from '@ripl/core';
 
 polyfillPath2D();
@@ -40,6 +41,9 @@ describe('Canvas audit findings', () => {
 
     afterEach(() => {
         el.remove();
+        factory.set({
+            devicePixelRatio: 1,
+        });
         vi.restoreAllMocks();
     });
 
@@ -204,6 +208,52 @@ describe('Canvas audit findings', () => {
         context.stroke = '';
 
         expect(context.stroke).toBe('#00ff00');
+    });
+
+    // CANVAS-8: native `reset()` drops the transform, taking the DPR matrix the surface draws through.
+    test('Should re-install the device pixel ratio transform on reset', () => {
+        factory.set({
+            devicePixelRatio: 2,
+        });
+
+        const stub = mockCanvasState(mockCanvasContext());
+
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.translate(30, 40);
+        context.reset();
+
+        expect(stub.getMatrix()).toEqual([2, 0, 0, 2, 0, 0]);
+    });
+
+    test('Should resynchronise the save depth on reset', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.save();
+        context.save();
+        context.reset();
+
+        expect((context as unknown as { saveDepth: number }).saveDepth).toBe(0);
+    });
+
+    test('Should not unwind past a reset on a later restore', () => {
+        mockCanvasState(mockCanvasContext());
+        sizeHost(400, 300);
+
+        const context = createContext(el);
+
+        context.lineWidth = 2;
+        context.save();
+        context.lineWidth = 8;
+        context.reset();
+        context.restore();
+
+        expect(context.lineWidth).toBe(8);
     });
 
 });

--- a/packages/canvas/test/context.test.ts
+++ b/packages/canvas/test/context.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
     mockCanvasContext,
+    mockCanvasState,
     polyfillPath2D,
 } from '@ripl/test-utils';
 
@@ -129,14 +130,32 @@ describe('CanvasContext', () => {
         expect(ctx.supportsPathCaching).toBe(true);
     });
 
-    test('save and restore delegate without throwing', () => {
+    test('save and restore round-trip the drawing state', () => {
+        const stub = mockCanvasState(mockCanvasContext());
         const ctx = context();
 
-        expect(() => {
-            ctx.save();
-            ctx.lineWidth = 8;
-            ctx.restore();
-        }).not.toThrow();
+        ctx.lineWidth = 2;
+        ctx.save();
+        ctx.lineWidth = 8;
+
+        expect(ctx.lineWidth).toBe(8);
+        expect(stub.getSaveDepth()).toBe(1);
+
+        ctx.restore();
+
+        expect(ctx.lineWidth).toBe(2);
+        expect(stub.getSaveDepth()).toBe(0);
+    });
+
+    test('restore is a no-op with nothing on the stack', () => {
+        const stub = mockCanvasState(mockCanvasContext());
+        const ctx = context();
+
+        ctx.lineWidth = 3;
+        ctx.restore();
+
+        expect(ctx.lineWidth).toBe(3);
+        expect(stub.getSaveDepth()).toBe(0);
     });
 
     test('isPointInPath returns a boolean from the native context', () => {

--- a/packages/canvas/test/helpers.test.ts
+++ b/packages/canvas/test/helpers.test.ts
@@ -18,6 +18,10 @@ import {
     toCanvasGradient,
 } from '../src';
 
+import {
+    factory,
+} from '@ripl/core';
+
 const BOUNDS = {
     x: 0,
     y: 0,
@@ -150,6 +154,44 @@ describe('rescaleCanvas', () => {
 
         expect(result.scaleX(canvas.width)).toBe(canvas.width);
         expect(result.scaleY(canvas.height)).toBe(canvas.height);
+    });
+
+    // Drawing goes through an exact `dpr` transform, so scaling pointers by the floored backing
+    // store disagreed with it by up to a device pixel at the far edge.
+    test('scales by the exact device pixel ratio, not the floored backing store', () => {
+        factory.set({
+            devicePixelRatio: 1.5,
+        });
+
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d')!;
+
+        const result = rescaleCanvas(canvas, ctx, 301, 151);
+
+        expect(result.scaleX(301)).toBe(451.5);
+        expect(result.scaleY(151)).toBe(226.5);
+
+        factory.set({
+            devicePixelRatio: 1,
+        });
+    });
+
+    test('floors the backing store to whole device pixels', () => {
+        factory.set({
+            devicePixelRatio: 1.5,
+        });
+
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d')!;
+
+        rescaleCanvas(canvas, ctx, 301, 151);
+
+        expect(canvas.width).toBe(451);
+        expect(canvas.height).toBe(226);
+
+        factory.set({
+            devicePixelRatio: 1,
+        });
     });
 
 });

--- a/packages/canvas/test/helpers.test.ts
+++ b/packages/canvas/test/helpers.test.ts
@@ -59,16 +59,42 @@ describe('setCanvasFill / setCanvasStroke', () => {
         expect(typeof ctx.fillStyle).toBe('object');
     });
 
-    test('memoizes gradient parsing across repeated calls', () => {
+    // Canvas bakes gradient geometry at set time, so one native object serves a string and box.
+    test('reuses the native gradient across repeated calls', () => {
         const ctx = context();
         const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
 
         setCanvasFill(ctx, LINEAR, BOUNDS);
         setCanvasFill(ctx, LINEAR, BOUNDS);
 
-        // Both calls build a native gradient (bounds change per frame), but parsing is cached.
-        expect(createLinearGradient).toHaveBeenCalledTimes(2);
+        expect(createLinearGradient).toHaveBeenCalledTimes(1);
         expect(typeof ctx.fillStyle).toBe('object');
+    });
+
+    test('rebuilds the native gradient when the bounds change', () => {
+        const ctx = context();
+        const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
+
+        setCanvasFill(ctx, LINEAR, BOUNDS);
+        setCanvasFill(ctx, LINEAR, {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+        });
+
+        expect(createLinearGradient).toHaveBeenCalledTimes(2);
+    });
+
+    test('shares one native gradient between fill and stroke', () => {
+        const ctx = context();
+        const createLinearGradient = vi.spyOn(ctx, 'createLinearGradient');
+
+        setCanvasFill(ctx, LINEAR, BOUNDS);
+        setCanvasStroke(ctx, LINEAR, BOUNDS);
+
+        expect(createLinearGradient).toHaveBeenCalledTimes(1);
+        expect(ctx.strokeStyle).toBe(ctx.fillStyle);
     });
 
 });

--- a/packages/canvas/test/helpers.test.ts
+++ b/packages/canvas/test/helpers.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@ripl/test-utils';
 
 import {
+    canvasDrawImage,
     rescaleCanvas,
     setCanvasFill,
     setCanvasStroke,
@@ -95,6 +96,59 @@ describe('setCanvasFill / setCanvasStroke', () => {
 
         expect(createLinearGradient).toHaveBeenCalledTimes(1);
         expect(ctx.strokeStyle).toBe(ctx.fillStyle);
+    });
+
+});
+
+describe('canvasDrawImage', () => {
+
+    beforeEach(() => mockCanvasContext());
+    afterEach(() => vi.restoreAllMocks());
+
+    function image(width: number, height: number) {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = width;
+        canvas.height = height;
+
+        return canvas;
+    }
+
+    test('draws at intrinsic size when neither dimension is given', () => {
+        const ctx = context();
+        const source = image(100, 50);
+
+        canvasDrawImage(ctx, source, 5, 5);
+
+        expect(ctx.drawImage).toHaveBeenCalledWith(source, 5, 5);
+    });
+
+    // The destination-rectangle form needs both dimensions, so a lone width used to be dropped.
+    test('takes the intrinsic height when only a width is given', () => {
+        const ctx = context();
+        const source = image(100, 50);
+
+        canvasDrawImage(ctx, source, 5, 5, 200);
+
+        expect(ctx.drawImage).toHaveBeenCalledWith(source, 5, 5, 200, 50);
+    });
+
+    test('takes the intrinsic width when only a height is given', () => {
+        const ctx = context();
+        const source = image(100, 50);
+
+        canvasDrawImage(ctx, source, 5, 5, undefined, 200);
+
+        expect(ctx.drawImage).toHaveBeenCalledWith(source, 5, 5, 100, 200);
+    });
+
+    test('honours a zero dimension rather than falling back to the intrinsic size', () => {
+        const ctx = context();
+        const source = image(100, 50);
+
+        canvasDrawImage(ctx, source, 0, 0, 0, 40);
+
+        expect(ctx.drawImage).toHaveBeenCalledWith(source, 0, 0, 0, 40);
     });
 
 });

--- a/packages/canvas/test/text-path.test.ts
+++ b/packages/canvas/test/text-path.test.ts
@@ -1,0 +1,142 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    mockTextMetrics,
+} from '@ripl/test-utils';
+
+import {
+    renderTextAlongPath,
+} from '../src/utilities';
+
+import {
+    ContextText,
+} from '@ripl/core';
+
+import type * as Core from '@ripl/core';
+
+// jsdom implements neither `getTotalLength` nor `getPointAtLength`, so the path primitives are
+// replaced with a straight horizontal line running from the origin to the `L` coordinate.
+vi.mock('@ripl/core', async importOriginal => {
+    const actual = await importOriginal<typeof Core>();
+    const lengthOf = (pathData: string) => Number(/L(\d+)/.exec(pathData)?.[1] ?? 0);
+
+    return {
+        ...actual,
+        getPathLength: vi.fn(lengthOf),
+        samplePathPoint: vi.fn((pathData: string, distance: number) => ({
+            x: Math.max(0, Math.min(lengthOf(pathData), distance)),
+            y: 0,
+            angle: 0,
+        })),
+    };
+});
+
+describe('Canvas text along a path', () => {
+
+    let stub: ReturnType<typeof mockCanvasContext>;
+
+    beforeEach(() => {
+        stub = mockTextMetrics(mockCanvasContext(), {
+            charWidth: 10,
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    function render(content: string, pathData: string, options?: {
+        startOffset?: number;
+        maxWidth?: number;
+    }) {
+        const element = new ContextText({
+            x: 0,
+            y: 0,
+            content,
+            pathData,
+            ...options,
+        });
+
+        renderTextAlongPath(stub as unknown as CanvasRenderingContext2D, element, 'fill');
+
+        return stub.translate.mock.calls;
+    }
+
+    // CANVAS-13: glyphs were placed at their own mid-point but drawn with the context's alignment,
+    // so under the canvas default of `start` the whole string slid forward by half a glyph.
+    test('Should place each glyph at its own advance offset under the default alignment', () => {
+        expect(render('AB', 'M0,0 L1000,0')).toEqual([[0, 0], [10, 0]]);
+    });
+
+    test('Should place each glyph at its mid-point under a centered alignment', () => {
+        stub.textAlign = 'center';
+
+        expect(render('AB', 'M0,0 L1001,0')).toEqual([[5, 0], [15, 0]]);
+    });
+
+    test('Should place each glyph at the end of its advance under a right alignment', () => {
+        stub.textAlign = 'right';
+
+        expect(render('AB', 'M0,0 L1002,0')).toEqual([[10, 0], [20, 0]]);
+    });
+
+    test('Should draw one glyph per character that fits', () => {
+        render('AB', 'M0,0 L1003,0');
+
+        expect(stub.fillText).toHaveBeenCalledTimes(2);
+    });
+
+    test('Should stroke each glyph when the stroke method is used', () => {
+        const element = new ContextText({
+            x: 0,
+            y: 0,
+            content: 'AB',
+            pathData: 'M0,0 L1004,0',
+        });
+
+        renderTextAlongPath(stub as unknown as CanvasRenderingContext2D, element, 'stroke');
+
+        expect(stub.strokeText).toHaveBeenCalledTimes(2);
+    });
+
+    // A negative offset used to stack every leading glyph on the path start, because the sampler
+    // clamps the distance but the layout kept advancing from a negative one.
+    test('Should clamp a negative start offset to the start of the path', () => {
+        const calls = render('ABC', 'M0,0 L1005,0', {
+            startOffset: -0.5,
+        });
+
+        expect(calls).toEqual([[0, 0], [10, 0], [20, 0]]);
+    });
+
+    test('Should lay out from a fractional start offset', () => {
+        const calls = render('A', 'M0,0 L1000,0', {
+            startOffset: 0.5,
+        });
+
+        expect(calls).toEqual([[500, 0]]);
+    });
+
+    test('Should stop laying out glyphs past the maximum width', () => {
+        const calls = render('ABCD', 'M0,0 L1006,0', {
+            maxWidth: 25,
+        });
+
+        expect(calls).toEqual([[0, 0], [10, 0], [20, 0]]);
+    });
+
+    test('Should drop glyphs whose mid-point falls past the end of the path', () => {
+        const calls = render('ABCD', 'M0,0 L25,0');
+
+        expect(calls).toEqual([[0, 0], [10, 0], [20, 0]]);
+    });
+
+});

--- a/packages/canvas/test/text-path.test.ts
+++ b/packages/canvas/test/text-path.test.ts
@@ -18,6 +18,8 @@ import {
 
 import {
     ContextText,
+    getPathLength,
+    samplePathPoint,
 } from '@ripl/core';
 
 import type * as Core from '@ripl/core';
@@ -137,6 +139,24 @@ describe('Canvas text along a path', () => {
         const calls = render('ABCD', 'M0,0 L25,0');
 
         expect(calls).toEqual([[0, 0], [10, 0], [20, 0]]);
+    });
+
+    // CANVAS-15: every glyph re-parsed the whole `d` attribute, once per element per frame.
+    test('Should not re-measure the path on the next frame', () => {
+        render('ABCD', 'M0,0 L500,0');
+        render('ABCD', 'M0,0 L500,0');
+
+        expect(vi.mocked(getPathLength)).toHaveBeenCalledTimes(1);
+    });
+
+    test('Should not re-sample a glyph position on the next frame', () => {
+        render('ABCD', 'M0,0 L501,0');
+
+        const sampled = vi.mocked(samplePathPoint).mock.calls.length;
+
+        render('ABCD', 'M0,0 L501,0');
+
+        expect(vi.mocked(samplePathPoint)).toHaveBeenCalledTimes(sampled);
     });
 
 });


### PR DESCRIPTION
Stacked on #68 — review that first; this PR's diff is only the canvas commits.

Second of seven PRs implementing the rendering-context audit in `docs/audits/`. Covers the canvas-owned findings in `canvas.md`; the ~26 core-owned ones are in #68.

## The problem

**`context.fill` and `context.stroke` lied after any `restore()`.** `_fillCSS`/`_strokeCSS` were plain fields sitting outside the save/restore stack, so the getters reported a paint the underlying context was no longer using. Assigning `''` compounded it — the native context rejects it as invalid CSS, so the value was silently dropped and the getter's `||` fallback then unmasked a stale native value.

**`reset()` threw away the DPR transform.** It was a bare `return this.context.reset()`, so everything drawn after a reset was at 1× on a retina surface, and `saveDepth` desynced from the native stack.

**Text on a path was offset by half a glyph.** `renderTextAlongPath` translates to each glyph's midpoint and then calls `fillText(char, 0, 0)` with `textAlign` untouched — which at the default `'start'` draws the glyph *starting* at its own midpoint. `startOffset` was unclamped and `maxWidth` ignored.

**Nothing was released on teardown.** No `destroy()` override: the pattern and gradient caches were module-global, and the backing store stayed allocated.

**`resize` fired with identity scales**, because `super.rescale()` emits before the subclass assigns `this.scaleX`.

## The fix

`_fillCSS`/`_strokeCSS` ride the save/restore stack; `''` is ignored rather than half-applied. `reset()` calls `super.reset()` and re-installs `setTransform(dpr,0,0,dpr,0,0)` — inherited by `CanvasContext3D` for free. The glyph anchor is derived from `ctx.textAlign`, `startOffset` is clamped to `[0,1]`, and `maxWidth` caps the run. `rescale` assigns size and scales itself and emits last. `patternCache` is rescoped per context, with a new `releaseCanvasPaintCache`, and `destroy()` releases paint and zeroes the backing store. A lone `width` or `height` in `canvasDrawImage` now resolves the other from intrinsic size, and an explicit `0` is honoured.

Two perf findings collapsed into one change: `CanvasGradient` is cached per context+string+bounds (#17), and path length and glyph samples are cached per `d`+distance (#15). The O(chars) re-parse in #15 is inherent to `samplePathPoint`, which core owns — rather than fork core geometry into canvas, the pure results are memoized, so a text element parses its path once ever rather than once per glyph per frame.

## Verification

`yarn lint` 0 · `yarn typecheck` 0 · TypeDoc `notDocumented` for `@ripl/canvas` clean. `yarn test` **184 files / 2128 passed, 0 skipped** against a branch point of 183 / 2097 / 1. Coverage 85.64 / 73.84 / 80.38 / 85.86, up on all four from 85.46 / 73.64 / 80.32 / 85.67. Node 24.18.1.

Branch-point proof: restoring the three `src/*.ts` files to the branch point fails **24 tests**, at least one per finding. A few new tests pass either way by design and are labelled as contract guards rather than regressions — the `measureText` forwarding (core already fixed it; this is canvas-side coverage), the `center`-alignment companion, and the intrinsic-size contract.

**`docs/audits/` says this repo's last audit pin should be un-skipped with its fix — it is. The repo now has zero skipped tests on this branch.**

**Three existing tests changed:**

- `packages/canvas/test/helpers.test.ts:58` asserted `createLinearGradient` was called **twice**, with the comment *"Both calls build a native gradient (bounds change per frame)"*. That comment describes finding #17 as if it were intended behaviour. Now asserts 1, with companions pinning that a genuine bounds change still rebuilds and that fill and stroke share one object.
- `packages/canvas/test/context.test.ts:132` — `'save and restore delegate without throwing'` was the vacuous test finding #21 exists to call out. Rewritten over `mockCanvasState` as a real round-trip.
- `packages/canvas/test/audit.test.ts:141` — `test.skip` → `test`.

Verified green and left untouched: `context.test.ts:88` (gradient bounding box — confirms #68 took the right route) and `pattern.test.ts:42,59` under the per-context cache.

## Breaking

1. **Assigning `''` to `Context.fill`/`.stroke` is ignored, not "clear".** Use a transparent colour. `BREAKING CHANGE:` footer on `aae0812`.
2. Behavioural, no compile break: `reset()` re-installs the DPR transform; `rescale` no longer calls `super.rescale`; path text shifts back by half a glyph; fill and stroke gradients are now shared objects.

## Follow-ups

- **#12** (group `globalCompositeOperation` as a subtree unit) is **deferred, not fixed** — it needs an offscreen layer and real compositing, and the jsdom stub records the property but never blends. Documented as a known limitation; it belongs to the phase-7 pixel harness.
- **`CanvasContext3D.rescale` still has #9** (calls `super.rescale()` then assigns scales) — out of scope here, flagged to the 3d branch.
- `rescaleCanvas` still desyncs `saveDepth` when it writes `canvas.width` mid-frame (#8's second paragraph). Harmless now that #68 makes `batch` unwind to its entry depth, so depth 0 is the only state a resize can reach. Left deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156vGhahurZUzVHRFeUXtnc)_