### PR TITLE
Give the pointer state machine one teardown path

### DIFF
--- a/docs/migrations/context-audit.md
+++ b/docs/migrations/context-audit.md
@@ -155,11 +155,124 @@ _No entries yet._
 
 ## @ripl/dom
 
-_No entries yet._
+### Pointer payloads
+
+**Element `click`, `dragstart`, `drag` and `dragend` payloads** — **behaviour**. `x`/`y` (and
+`startX`/`startY`) carry **CSS pixels**, not device pixels. Element `mousemove` already reported CSS
+pixels, so the same pointer position produced payloads differing by the device pixel ratio depending
+on which event you read — `packages/charts/src/core/interaction.ts` documents `InteractionPoint` as
+"chart pixels" and feeds `onEnter`/`onLeave` from `mousemove` while `onClick` reads `click`. On a
+non-retina display nothing moves. Elsewhere, multiply by `devicePixelRatio` — or better, map through
+`Context.toSurfacePoint` — to recover the old values. Hit testing is unchanged: it still runs in
+surface space.
+
+### Pointer lifecycle
+
+**`DOMContext.disableInteraction`** — **behaviour**. Emits `mouseleave` on every element that was
+hovered before dropping the set, and cancels the pending hover frame. It used to clear
+`_activeElements` silently, so a bar stayed enlarged and its tooltip stayed painted with nothing left
+that could ever produce the leave. `destroy()` delegates here, so teardown is complete when it
+returns rather than a frame later. Any `mouseleave` handler must therefore tolerate running during
+teardown.
+
+**Surface `mouseleave`** — **behaviour**. Also unwinds the hovered element. The element-level
+`mouseleave` was only ever emitted from the hover hit test, which only runs on `mousemove`, so
+leaving the canvas left the last-hovered element hovered forever — the reason chart tooltips stayed
+on screen after the pointer left.
+
+**`mouseup`** — **behaviour**. Also bound at the window, so a release outside the surface ends the
+drag. A gesture released off-canvas previously never emitted `dragend` and resumed on re-entry with
+no button held. A `dragend` may now arrive with coordinates outside the surface bounds (including
+negatives); clamp if your handler assumes otherwise.
+
+**`mousedown`** — **behaviour**. Assigns drag state unconditionally instead of only when something
+is hit, so a press on empty canvas clears the previous gesture's `dragElement` and origin rather than
+making it the next gesture's delta baseline.
+
+**`click`** — **behaviour**. Suppressed once for the gesture that ended a drag. The DOM fires `click`
+after `mouseup`, so a drill-down or selection handler fired at the end of every drag. A click below
+the drag threshold is unaffected.
+
+### Reconciliation
+
+**`reconcileNode`** — **behaviour**. Sibling vnodes sharing an id each get their own DOM node.
+Duplicates previously collapsed onto one node — the second overwrote the first's attributes and
+subtree, and the reorder step desynchronised — so a duplicate key in chart data silently dropped a
+mark and reordered the rest. Node identity is stable across passes.
+
+**`reconcileNode`** — **behaviour**. Nodes matched by `excludeSelectors` keep their position instead
+of drifting to the end of the parent. The reorder step indexed the parent's children directly, which
+counts excluded nodes, so managed children were inserted before them and pushed them rightward.
+Harmless for a `<defs>`; not for a positioned overlay.
+
+### Resize
+
+**`onDOMElementResize`** — **behaviour**. The `window.resize` fallback reports the **content box**,
+matching what the `ResizeObserver` branch reports via `entry.contentRect`. It reported the border box
+before, so on a padded host the two branches of one function disagreed and the backing store was
+sized to a box the surface was never stretched over. Only reachable on engines without
+`ResizeObserver`.
+
+**`onDOMElementResize`** — **behaviour**. Returns an inert disposable outside a browser rather than
+throwing `ReferenceError: window is not defined`. `@ripl/dom` ships `sideEffects: false`, so an SSR
+consumer can import this helper directly.
+
+### Export
+
+**`createCanvasExport`** — **API**, additive. The returned `ContextExport` implements `release()`,
+revoking every object URL `toURL()` handed out. Without it each URL pinned its blob for the
+document's lifetime. Call `release()` when you are done with an export; it is safe to call
+repeatedly.
+
+### Navigator
+
+**`DOMNavigator`** — **behaviour**. Lifting one finger of a pinch hands the survivor back to panning.
+It previously cleared every gesture flag, leaving a finger still on the surface matching no branch at
+all until it was lifted and re-pressed.
+
+**`DOMNavigator`** — **behaviour**. Every tracked pointer is captured on `pointerdown`, not just the
+ones that pan or brush. A secondary-button gesture or the second finger of a pinch released off the
+element never reached the cleanup, and the leaked pointer id made the next single-touch gesture read
+as a pinch — a one-finger pan that zoomed.
+
+**`DOMNavigator`** — **behaviour**. The element origin is cached and invalidated on resize and
+scroll, instead of `getBoundingClientRect` being called on every `pointermove`. If you move the
+element by means that fire neither (a transform on an ancestor, say), invalidate by resizing or
+recreating the navigator.
+
+**`DOMNavigatorOptions.interactions`** — **behaviour**. `touchAction` is left alone when every
+interaction resolves to disabled. `{}` and `{ zoom: false, pan: false, brush: false }` are both
+truthy, so they used to suppress native scrolling over the chart with no gesture wired up.
 
 ## @ripl/node
 
-_No entries yet._
+**`factory.measureText`** — **behaviour**. Measures in braille cells — 2 logical units per character
+and ascent 4 at the default `10px monospace`, descent 0 — scaled by the requested font size, and
+anchors `actualBoundingBox*` on `textAlign`. It reported 8px per character with ascent 8 and descent
+2 regardless of the options passed, so text boxes were roughly 4x too wide and 2.5x too tall against
+what the terminal paints, and centred or right-aligned text was anchored at the wrong corner. Core
+falls back to this only before an element's first paint; anything rendered measures through
+`TerminalContext`. `textBaseline` is deliberately not modelled — the terminal paints one cell per
+glyph with no baseline variation.
+
+**`factory.requestAnimationFrame`** — **behaviour**. Returns an **unref'd** timer and invokes its
+callback with a `DOMHighResTimeStamp`. The render loop re-arms every frame with `autoStart` on, so a
+ref'd timer meant a process that drew one static chart never exited. A script that relied on the
+render loop to keep the event loop alive must now hold it open itself.
+
+**`factory.createElement`** and **`factory.createElementNS`** — **behaviour**. Return a duck-typed
+stub (`getContext()` → `null`, `getTotalLength()` → `0`, attribute accessors) instead of `{}`. Core's
+graceful-degradation guards are written against exactly those probes and could never run — the first
+property access threw a raw `TypeError`. `getPathLength` now returns `0` off-platform rather than
+throwing.
+
+**`factory.createContext`** — **behaviour**. Builds one `TerminalOutput` per process rather than one
+per context, and that output multiplexes its resize subscribers behind a single `SIGWINCH` handler;
+ten scenes used to trip Node's `MaxListenersExceededWarning`. A `TerminalOutput` passed as the target
+is honoured; any other target warns that it cannot be, instead of being discarded in silence.
+
+**`createTerminalOutput`** — **behaviour**. `onResize` registers its `SIGWINCH` handler on the first
+subscription and removes it with the last, rather than one handler per subscriber.
 
 ## @ripl/terminal
 

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -36,6 +36,7 @@ interface InteractionState {
     dragPrevX: number;
     dragPrevY: number;
     dragStarted: boolean;
+    suppressClick: boolean;
     scheduleHitTest: ReturnType<typeof createFrameBuffer>;
 }
 
@@ -125,12 +126,27 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this._originDirty = false;
     }
 
+    /**
+     * Unwinds every hovered element, emitting the `mouseleave` each one is owed.
+     *
+     * The pending hover frame is dropped first: it re-enters whatever the pointer was last over,
+     * so flushing before cancelling would hand a `mouseenter` back to an element a frame later —
+     * on a context that may by then be torn down.
+     */
+    private _flushActiveElements(): void {
+        this._interactionState?.scheduleHitTest.cancel();
+
+        this._activeElements.forEach(element => element.emit('mouseleave', null));
+        this._activeElements.clear();
+    }
+
     private _handleMouseEnter(): void {
         this._refreshOrigin(true);
         this.emit('mouseenter', null);
     }
 
     private _handleMouseLeave(): void {
+        this._flushActiveElements();
         this.emit('mouseleave', null);
     }
 
@@ -145,12 +161,12 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         const hitElements = this.hitTest(['dragstart', 'drag', 'dragend'], x, y);
 
-        if (hitElements.length > 0) {
-            state.dragElement = hitElements[0];
-            state.dragStartX = rx;
-            state.dragStartY = ry;
-            state.dragStarted = false;
-        }
+        // Assigned unconditionally: a press that hits nothing must not inherit the last gesture's origin.
+        state.dragElement = hitElements[0];
+        state.dragStartX = rx;
+        state.dragStartY = ry;
+        state.dragStarted = false;
+        state.suppressClick = false;
     }
 
     private _handleMouseMove(event: MouseEvent): void {
@@ -184,8 +200,8 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
                 state.dragPrevY = state.dragStartY;
 
                 const payload = {
-                    x: this.scaleX(state.dragStartX),
-                    y: this.scaleY(state.dragStartY),
+                    x: state.dragStartX,
+                    y: state.dragStartY,
                 };
 
                 this.emit('dragstart', payload);
@@ -202,10 +218,10 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         state.dragPrevY = ry;
 
         const payload = {
-            x: this.scaleX(rx),
-            y: this.scaleY(ry),
-            startX: this.scaleX(state.dragStartX),
-            startY: this.scaleY(state.dragStartY),
+            x: rx,
+            y: ry,
+            startX: state.dragStartX,
+            startY: state.dragStartY,
             deltaX,
             deltaY,
         };
@@ -245,28 +261,39 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         }));
     }
 
-    private _handleMouseUp(event: MouseEvent): void {
-        this._refreshOrigin();
+    /**
+     * Closes out the gesture in flight, wherever the button was released.
+     *
+     * Bound at the window as well as the surface, so this can arrive against a state that
+     * {@link DOMContext.disableInteraction} has already dropped — hence the null check rather than
+     * the non-null assertion the surface-bound handlers use.
+     */
+    private _endDrag(event: MouseEvent): void {
+        const state = this._interactionState;
 
-        const state = this._interactionState!;
+        if (!state?.dragElement) {
+            return;
+        }
 
-        if (state.dragElement && state.dragStarted) {
+        if (state.dragStarted) {
+            this._refreshOrigin();
+
             const rx = event.clientX - state.left;
             const ry = event.clientY - state.top;
-            const deltaX = rx - state.dragPrevX;
-            const deltaY = ry - state.dragPrevY;
 
             const payload = {
-                x: this.scaleX(rx),
-                y: this.scaleY(ry),
-                startX: this.scaleX(state.dragStartX),
-                startY: this.scaleY(state.dragStartY),
-                deltaX,
-                deltaY,
+                x: rx,
+                y: ry,
+                startX: state.dragStartX,
+                startY: state.dragStartY,
+                deltaX: rx - state.dragPrevX,
+                deltaY: ry - state.dragPrevY,
             };
 
             this.emit('dragend', payload);
             state.dragElement.emit('dragend', payload);
+
+            state.suppressClick = true;
         }
 
         state.dragElement = undefined;
@@ -274,18 +301,25 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     }
 
     private _handleClick(event: MouseEvent): void {
+        const state = this._interactionState!;
+
+        // The DOM fires `click` after the `mouseup` that ended the drag; the gesture was not a click.
+        if (state.suppressClick) {
+            state.suppressClick = false;
+            return;
+        }
+
         this._refreshOrigin();
 
-        const state = this._interactionState!;
-        const x = this.scaleX(event.clientX - state.left);
-        const y = this.scaleY(event.clientY - state.top);
+        const rx = event.clientX - state.left;
+        const ry = event.clientY - state.top;
 
-        const hitElements = this.hitTest(['click'], x, y);
+        const hitElements = this.hitTest(['click'], this.scaleX(rx), this.scaleY(ry));
 
         if (hitElements.length > 0) {
             hitElements[0].emit('click', {
-                x,
-                y,
+                x: rx,
+                y: ry,
             });
         }
     }
@@ -307,6 +341,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             dragPrevX: 0,
             dragPrevY: 0,
             dragStarted: false,
+            suppressClick: false,
             scheduleHitTest: createFrameBuffer(),
         };
 
@@ -314,7 +349,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this._attachInteractionEvent('mouseleave', () => this._handleMouseLeave());
         this._attachInteractionEvent('mousedown', event => this._handleMouseDown(event));
         this._attachInteractionEvent('mousemove', event => this._handleMouseMove(event));
-        this._attachInteractionEvent('mouseup', event => this._handleMouseUp(event));
+        this._attachInteractionEvent('mouseup', event => this._endDrag(event));
         this._attachInteractionEvent('click', event => this._handleClick(event));
 
         if (hasWindow) {
@@ -325,22 +360,28 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             }), INTERACTION_KEY);
 
             this.retain(onDOMEvent(window, 'resize', () => this._originDirty = true), INTERACTION_KEY);
+
+            // A release outside the surface never reaches the element, stranding the drag with no `dragend`.
+            this.retain(onDOMEvent(window, 'mouseup', event => this._endDrag(event)), INTERACTION_KEY);
         }
 
         // Seeded now rather than on the first `mouseenter`, which never fires for a surface mounted under the pointer.
         this._refreshOrigin(true);
     }
 
-    /** Disables DOM interaction events and clears the active element set. */
+    /** Disables DOM interaction events, unwinding any hover with a final `mouseleave` per element. */
     public disableInteraction(): void {
         if (!this._interactionEnabled) {
             return;
         }
 
         this._interactionEnabled = false;
+
+        // Ahead of dropping the state, which holds the frame buffer the flush has to cancel.
+        this._flushActiveElements();
+
         this._interactionState = undefined;
         this.dispose(INTERACTION_KEY);
-        this._activeElements.clear();
     }
 
     /** Destroys the context, removing the DOM element and disposing all resources. */

--- a/packages/dom/src/dom.ts
+++ b/packages/dom/src/dom.ts
@@ -43,8 +43,54 @@ export function onDOMEvent<TElement extends EventTarget, TEvent extends string &
     };
 }
 
-/** Observes an element for size changes using `ResizeObserver` (with a `window.resize` fallback) and returns a disposable. */
+const HORIZONTAL_EDGES = [
+    'left',
+    'right',
+];
+
+const VERTICAL_EDGES = [
+    'top',
+    'bottom',
+];
+
+function getEdgeSize(style: CSSStyleDeclaration, edges: string[]): number {
+    return edges.reduce((total, edge) => {
+        // A `none` border still resolves `medium` in some engines; CSS says it contributes nothing.
+        const border = style.getPropertyValue(`border-${edge}-style`) === 'none'
+            ? 0
+            : parseFloat(style.getPropertyValue(`border-${edge}-width`)) || 0;
+
+        return total + border + (parseFloat(style.getPropertyValue(`padding-${edge}`)) || 0);
+    }, 0);
+}
+
+/** Measures an element's content box, which is what `ResizeObserver` reports and `getBoundingClientRect` does not. */
+function getContentBoxSize(element: HTMLElement): DOMElementResizeEvent {
+    const {
+        width,
+        height,
+    } = element.getBoundingClientRect();
+
+    const style = window.getComputedStyle(element);
+
+    return {
+        width: width - getEdgeSize(style, HORIZONTAL_EDGES),
+        height: height - getEdgeSize(style, VERTICAL_EDGES),
+    };
+}
+
+/**
+ * Observes an element for size changes using `ResizeObserver` (with a `window.resize` fallback) and
+ * returns a disposable. Degrades to an inert disposable outside a browser, so an SSR or Node
+ * consumer of this module gets a no-op rather than a `ReferenceError`.
+ */
 export function onDOMElementResize(element: HTMLElement, handler: DOMElementResizeHandler): Disposable {
+    if (!hasWindow) {
+        return {
+            dispose: () => undefined,
+        };
+    }
+
     let disposer: Disposable;
 
     if ('ResizeObserver' in window) {
@@ -67,17 +113,7 @@ export function onDOMElementResize(element: HTMLElement, handler: DOMElementResi
             dispose: () => observer.disconnect(),
         };
     } else {
-        disposer = onDOMEvent(window, 'resize', () => {
-            const {
-                width,
-                height,
-            } = element.getBoundingClientRect();
-
-            handler({
-                width,
-                height,
-            });
-        });
+        disposer = onDOMEvent(window, 'resize', () => handler(getContentBoxSize(element)));
     }
 
     return disposer;

--- a/packages/dom/src/export.ts
+++ b/packages/dom/src/export.ts
@@ -26,6 +26,9 @@ function dataURLToBlob(dataURL: string): Blob {
  * for any canvas regardless of the API used to draw it, because the source canvas is a valid
  * `drawImage` source even when backed by WebGL/WebGPU, so callers should ensure a frame has been
  * rendered before exporting (WebGPU present textures are transient).
+ *
+ * Every object URL handed out by `toURL()` is tracked and revoked by `release()`; without that call
+ * each one pins its blob for the document's lifetime.
  */
 export function createCanvasExport(canvas: HTMLCanvasElement): ContextExport {
     const width = Math.max(1, canvas.width);
@@ -46,9 +49,21 @@ export function createCanvasExport(canvas: HTMLCanvasElement): ContextExport {
         context.drawImage(canvas, 0, 0);
     }
 
+    const urls = new Set<string>();
+
     return {
         toString: () => snapshot.toDataURL('image/png'),
-        toURL: () => URL.createObjectURL(dataURLToBlob(snapshot.toDataURL('image/png'))),
+        toURL: () => {
+            const url = URL.createObjectURL(dataURLToBlob(snapshot.toDataURL('image/png')));
+
+            urls.add(url);
+
+            return url;
+        },
         toImage: () => Promise.resolve(context.getImageData(0, 0, width, height)),
+        release: () => {
+            urls.forEach(url => URL.revokeObjectURL(url));
+            urls.clear();
+        },
     };
 }

--- a/packages/dom/src/navigator.ts
+++ b/packages/dom/src/navigator.ts
@@ -16,6 +16,7 @@ import {
 } from '@ripl/utilities';
 
 import {
+    hasWindow,
     onDOMElementResize,
     onDOMEvent,
 } from './dom';
@@ -94,6 +95,9 @@ export class DOMNavigator extends Navigator {
     private _brushing = false;
     private _panning = false;
     private _pinchDistance = 0;
+    private _originDirty = true;
+    private _originLeft = 0;
+    private _originTop = 0;
 
     constructor(context: Context, options?: DOMNavigatorOptions) {
         super(options);
@@ -108,7 +112,20 @@ export class DOMNavigator extends Navigator {
 
         this._syncViewport();
 
-        this.retain(onDOMElementResize(this._element, () => this._syncViewport()), VIEWPORT_KEY);
+        this.retain(onDOMElementResize(this._element, () => {
+            this._originDirty = true;
+            this._syncViewport();
+        }), VIEWPORT_KEY);
+
+        if (hasWindow) {
+            // Capture phase: a scroll event doesn't bubble, so an ancestor scroll container is only visible here.
+            this.retain(onDOMEvent(window, 'scroll', () => this._originDirty = true, {
+                capture: true,
+                passive: true,
+            }), VIEWPORT_KEY);
+
+            this.retain(onDOMEvent(window, 'resize', () => this._originDirty = true), VIEWPORT_KEY);
+        }
 
         if (options?.interactions) {
             this._attachInteractions(options.interactions);
@@ -124,15 +141,30 @@ export class DOMNavigator extends Navigator {
         };
     }
 
+    /** Re-reads where the element sits in the viewport, at most once per invalidation. */
+    private _refreshOrigin(): void {
+        if (!this._originDirty) {
+            return;
+        }
+
+        ({
+            left: this._originLeft,
+            top: this._originTop,
+        } = this._element.getBoundingClientRect());
+
+        this._originDirty = false;
+    }
+
     private _localPoint(event: {
         clientX: number;
         clientY: number;
     }): Point {
-        const rect = this._element.getBoundingClientRect();
+        // A rect read per `pointermove` flushes layout mid-gesture, which is the frame budget gone.
+        this._refreshOrigin();
 
         return [
-            event.clientX - rect.left,
-            event.clientY - rect.top,
+            event.clientX - this._originLeft,
+            event.clientY - this._originTop,
         ];
     }
 
@@ -150,6 +182,11 @@ export class DOMNavigator extends Navigator {
         const zoom = resolveInteraction(config.zoom, fallback);
         const pan = resolveInteraction(config.pan, fallback);
         const brush = resolveInteraction(config.brush, fallback);
+
+        // `{}` and `{ zoom: false }` are both truthy; suppressing native scroll for no gesture is not a trade.
+        if (!zoom.enabled && !pan.enabled && !brush.enabled) {
+            return;
+        }
 
         this._previousTouchAction = this._element.style.touchAction;
         this._element.style.touchAction = 'none';
@@ -189,6 +226,9 @@ export class DOMNavigator extends Navigator {
         this.retain(onDOMEvent(this._element, 'pointerdown', event => {
             this._pointers.set(event.pointerId, this._localPoint(event));
 
+            // Every tracked pointer, not just the gesturing ones: an uncaptured release off the element leaks its entry.
+            this._element.setPointerCapture?.(event.pointerId);
+
             if (this._pointers.size === 2) {
                 this._pinchDistance = this._pointerDistance();
                 this._panning = false;
@@ -211,8 +251,6 @@ export class DOMNavigator extends Navigator {
             if (this._panning) {
                 this._setCursor('grabbing');
             }
-
-            this._element.setPointerCapture?.(event.pointerId);
         }), INTERACTION_KEY);
 
         this.retain(onDOMEvent(this._element, 'pointermove', event => {
@@ -254,6 +292,17 @@ export class DOMNavigator extends Navigator {
             this._brushing = false;
             this._panning = false;
             this._dragStart = null;
+            this._pinchDistance = 0;
+
+            // A pinch that loses a finger has to hand the survivor back to panning, not strand it mid-gesture.
+            if (this._pointers.size === 1 && pan.enabled) {
+                this._panning = true;
+                this._dragStart = [...this._pointers.values()][0];
+                this._setCursor('grabbing');
+
+                return;
+            }
+
             this._setCursor('grab');
         };
 

--- a/packages/dom/src/vdom.ts
+++ b/packages/dom/src/vdom.ts
@@ -100,6 +100,17 @@ function isExcluded(element: Element, selectors: string[]): boolean {
     return false;
 }
 
+function countChildIds<TElement>(children: VNode<TElement>[]): Map<string, number> {
+    const counts = new Map<string, number>();
+
+    for (let i = 0; i < children.length; i++) {
+        const id = children[i].id;
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+
+    return counts;
+}
+
 function reconcileChildren<TElement = unknown>(
     domParent: Element,
     vnode: VNode<TElement>,
@@ -115,8 +126,9 @@ function reconcileChildren<TElement = unknown>(
         getChildId = defaultGetChildId,
     } = options;
 
-    const desiredIds = new Set(vnode.children.map(c => c.id));
-    const existingChildren = new Map<string, Element>();
+    // Counted, not a set: siblings may share an id, and each occurrence still needs its own node.
+    const wantedIds = countChildIds(vnode.children);
+    const existingChildren = new Map<string, Element[]>();
 
     for (let i = domParent.children.length - 1; i >= 0; i--) {
         const child = domParent.children[i];
@@ -126,9 +138,18 @@ function reconcileChildren<TElement = unknown>(
         }
 
         const childId = getChildId(child);
+        const wanted = childId ? wantedIds.get(childId) ?? 0 : 0;
 
-        if (childId && desiredIds.has(childId)) {
-            existingChildren.set(childId, child);
+        if (childId && wanted > 0) {
+            wantedIds.set(childId, wanted - 1);
+
+            const matches = existingChildren.get(childId);
+
+            if (matches) {
+                matches.unshift(child);
+            } else {
+                existingChildren.set(childId, [child]);
+            }
         } else {
             child.remove();
             state.removed = true;
@@ -139,9 +160,19 @@ function reconcileChildren<TElement = unknown>(
         }
     }
 
+    const claimed = new Set<Element>();
+
+    let domIndex = 0;
+
     for (let i = 0; i < vnode.children.length; i++) {
         const childVNode = vnode.children[i];
-        let domChild = existingChildren.get(childVNode.id) || domCache.get(childVNode.id);
+        const cached = domCache.get(childVNode.id);
+
+        let domChild = existingChildren.get(childVNode.id)?.shift();
+
+        if (!domChild && cached && !claimed.has(cached)) {
+            domChild = cached;
+        }
 
         if (!domChild) {
             const tag = childVNode.element
@@ -151,11 +182,18 @@ function reconcileChildren<TElement = unknown>(
             domCache.set(childVNode.id, domChild);
         }
 
+        claimed.add(domChild);
+
         if (childVNode.element) {
             updateElement(domChild, childVNode.element);
         }
 
-        const currentAtIndex = domParent.children[i] as Element | undefined;
+        // Excluded nodes hold an index without being managed, so step over them rather than displace them.
+        while (excludeSelectors.length > 0 && domIndex < domParent.children.length && isExcluded(domParent.children[domIndex], excludeSelectors)) {
+            domIndex++;
+        }
+
+        const currentAtIndex = domParent.children[domIndex] as Element | undefined;
 
         if (currentAtIndex !== domChild) {
             if (currentAtIndex) {
@@ -164,6 +202,8 @@ function reconcileChildren<TElement = unknown>(
                 domParent.appendChild(domChild);
             }
         }
+
+        domIndex++;
 
         // Also when the vnode has no children but the node does: that pass is what empties it.
         if (childVNode.children.length > 0 || domChild.children.length > 0) {

--- a/packages/dom/test/context.test.ts
+++ b/packages/dom/test/context.test.ts
@@ -16,58 +16,66 @@ import {
     createContext,
 } from '@ripl/canvas';
 
+import {
+    factory,
+} from '@ripl/core';
+
+import type {
+    RenderElement,
+} from '@ripl/core';
+
 polyfillPath2D();
 
 const SURFACE_WIDTH = 400;
 const SURFACE_HEIGHT = 300;
 
+let el: HTMLDivElement;
+let rect: DOMRect;
+let contexts: ReturnType<typeof createContext>[];
+
+// jsdom reports a zero rect for everything, so the surface's position has to be stubbed.
+function setOrigin(left: number, top: number) {
+    rect = {
+        left,
+        top,
+        right: left + SURFACE_WIDTH,
+        bottom: top + SURFACE_HEIGHT,
+        width: SURFACE_WIDTH,
+        height: SURFACE_HEIGHT,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+    } as DOMRect;
+}
+
+function create() {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => rect);
+
+    const context = createContext(el);
+
+    contexts.push(context);
+
+    return context;
+}
+
+beforeEach(() => {
+    mockCanvasContext();
+
+    contexts = [];
+    el = document.createElement('div');
+    document.body.appendChild(el);
+
+    setOrigin(0, 0);
+});
+
+afterEach(() => {
+    // A surviving context keeps its window listeners, which would fire during later tests.
+    contexts.forEach(context => context.destroy());
+    el.remove();
+    vi.restoreAllMocks();
+});
+
 describe('DOMContext interaction origin', () => {
-
-    let el: HTMLDivElement;
-    let rect: DOMRect;
-    let contexts: ReturnType<typeof createContext>[];
-
-    beforeEach(() => {
-        mockCanvasContext();
-
-        contexts = [];
-        el = document.createElement('div');
-        document.body.appendChild(el);
-
-        setOrigin(0, 0);
-    });
-
-    afterEach(() => {
-        // A surviving context keeps its window listeners, which would fire during later tests.
-        contexts.forEach(context => context.destroy());
-        el.remove();
-        vi.restoreAllMocks();
-    });
-
-    // jsdom reports a zero rect for everything, so the surface's position has to be stubbed.
-    function setOrigin(left: number, top: number) {
-        rect = {
-            left,
-            top,
-            right: left + SURFACE_WIDTH,
-            bottom: top + SURFACE_HEIGHT,
-            width: SURFACE_WIDTH,
-            height: SURFACE_HEIGHT,
-            x: left,
-            y: top,
-            toJSON: () => ({}),
-        } as DOMRect;
-    }
-
-    function create() {
-        vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => rect);
-
-        const context = createContext(el);
-
-        contexts.push(context);
-
-        return context;
-    }
 
     function mouseMove(context: ReturnType<typeof create>, clientX: number, clientY: number) {
         const positions: {
@@ -194,6 +202,321 @@ describe('DOMContext interaction origin', () => {
         }));
 
         expect(getBoundingClientRect).not.toHaveBeenCalled();
+    });
+
+});
+
+describe('DOMContext pointer state machine', () => {
+
+    const HOVER_EVENTS = [
+        'mouseenter',
+        'mouseleave',
+        'mousemove',
+    ];
+
+    const DRAG_EVENTS = [
+        'dragstart',
+        'drag',
+        'dragend',
+    ];
+
+    interface MockElement extends RenderElement {
+        hits: boolean;
+        events: {
+            type: string;
+            data: unknown;
+        }[];
+    }
+
+    let frames: FrameRequestCallback[];
+
+    const nativeRequestAnimationFrame = factory.requestAnimationFrame;
+    const nativeCancelAnimationFrame = factory.cancelAnimationFrame;
+    const nativeDevicePixelRatio = factory.devicePixelRatio;
+
+    beforeEach(() => {
+        frames = [];
+
+        factory.set({
+            requestAnimationFrame: callback => frames.push(callback),
+            cancelAnimationFrame: handle => frames[handle - 1] = () => undefined,
+        });
+    });
+
+    afterEach(() => {
+        factory.set({
+            requestAnimationFrame: nativeRequestAnimationFrame,
+            cancelAnimationFrame: nativeCancelAnimationFrame,
+            devicePixelRatio: nativeDevicePixelRatio,
+        });
+    });
+
+    function flushFrames(): void {
+        const pending = frames;
+
+        frames = [];
+        pending.forEach(callback => callback(0));
+    }
+
+    function createMockElement(id: string, events: string[]): MockElement {
+        const eventSet = new Set(events);
+
+        const element: MockElement = {
+            id,
+            hits: true,
+            events: [],
+            abstract: false,
+            pointerEvents: 'all',
+            zIndex: 0,
+            has: event => eventSet.has(event),
+            intersectsWith: () => element.hits,
+            emit: (type, data) => element.events.push({
+                type,
+                data,
+            }),
+        };
+
+        return element;
+    }
+
+    function register(context: ReturnType<typeof create>, elements: MockElement[]): void {
+        context.markRenderStart();
+
+        elements.forEach(element => context.currentRenderElement = element);
+
+        context.markRenderEnd();
+        context.invalidateTrackedElements();
+    }
+
+    function typesOf(element: MockElement): string[] {
+        return element.events.map(({ type }) => type);
+    }
+
+    function mouse(context: ReturnType<typeof create>, type: string, clientX: number, clientY: number): void {
+        context.element.dispatchEvent(new MouseEvent(type, {
+            clientX,
+            clientY,
+            bubbles: true,
+        }));
+    }
+
+    function hover(context: ReturnType<typeof create>, clientX: number, clientY: number): void {
+        mouse(context, 'mousemove', clientX, clientY);
+        flushFrames();
+    }
+
+    test('Should emit mouseleave on the hovered element when the pointer leaves the surface', () => {
+        const context = create();
+        const element = createMockElement('a', HOVER_EVENTS);
+
+        register(context, [element]);
+        hover(context, 50, 50);
+
+        expect(typesOf(element)).toEqual(['mouseenter']);
+
+        context.element.dispatchEvent(new MouseEvent('mouseleave'));
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
+    });
+
+    test('Should re-enter an element hovered again after the pointer left the surface', () => {
+        const context = create();
+        const element = createMockElement('a', HOVER_EVENTS);
+
+        register(context, [element]);
+        hover(context, 50, 50);
+
+        context.element.dispatchEvent(new MouseEvent('mouseleave'));
+        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+
+        hover(context, 50, 50);
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave', 'mouseenter']);
+    });
+
+    test('Should emit mouseleave on the hovered element when interaction is disabled', () => {
+        const context = create();
+        const element = createMockElement('a', HOVER_EVENTS);
+
+        register(context, [element]);
+        hover(context, 50, 50);
+
+        context.disableInteraction();
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
+    });
+
+    // Teardown has to be complete when `destroy()` returns, not a frame later.
+    test('Should unwind a hover synchronously on destroy', () => {
+        const context = create();
+        const element = createMockElement('a', HOVER_EVENTS);
+
+        register(context, [element]);
+        hover(context, 50, 50);
+
+        mouse(context, 'mousemove', 60, 60);
+        context.destroy();
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
+
+        flushFrames();
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
+    });
+
+    test('Should not re-enter a flushed element on the frame after interaction is disabled', () => {
+        const context = create();
+        const element = createMockElement('a', HOVER_EVENTS);
+
+        register(context, [element]);
+        hover(context, 50, 50);
+
+        mouse(context, 'mousemove', 60, 60);
+        context.disableInteraction();
+        flushFrames();
+
+        expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
+    });
+
+    test('Should end a drag released outside the surface', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mousemove', 140, 140);
+
+        window.dispatchEvent(new MouseEvent('mouseup', {
+            clientX: 900,
+            clientY: 900,
+        }));
+
+        expect(typesOf(element)).toEqual(['dragstart', 'drag', 'dragend']);
+    });
+
+    test('Should not resume a stranded drag once the button is released', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+
+        window.dispatchEvent(new MouseEvent('mouseup', {
+            clientX: 900,
+            clientY: 900,
+        }));
+
+        element.events.length = 0;
+
+        mouse(context, 'mousemove', 140, 140);
+
+        expect(typesOf(element)).toEqual([]);
+    });
+
+    test('Should not resume the previous drag after a press that hits nothing', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+
+        element.hits = false;
+        element.events.length = 0;
+
+        mouse(context, 'mousedown', 300, 300);
+        mouse(context, 'mousemove', 340, 340);
+
+        expect(typesOf(element)).toEqual([]);
+    });
+
+    test('Should not emit click on the gesture that ended a drag', () => {
+        const context = create();
+        const element = createMockElement('a', [...DRAG_EVENTS, 'click']);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mouseup', 100, 100);
+        mouse(context, 'click', 100, 100);
+
+        expect(typesOf(element)).not.toContain('click');
+    });
+
+    test('Should emit click for a press and release under the drag threshold', () => {
+        const context = create();
+        const element = createMockElement('a', [...DRAG_EVENTS, 'click']);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 11, 11);
+        mouse(context, 'mouseup', 11, 11);
+        mouse(context, 'click', 11, 11);
+
+        expect(typesOf(element)).toEqual(['click']);
+    });
+
+    test('Should emit click on the gesture after a drag', () => {
+        const context = create();
+        const element = createMockElement('a', [...DRAG_EVENTS, 'click']);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mouseup', 100, 100);
+        mouse(context, 'click', 100, 100);
+
+        element.events.length = 0;
+
+        mouse(context, 'mousedown', 100, 100);
+        mouse(context, 'mouseup', 100, 100);
+        mouse(context, 'click', 100, 100);
+
+        expect(typesOf(element)).toEqual(['click']);
+    });
+
+    // `InteractionPoint` is documented as chart pixels, but click/drag used to report device pixels.
+    test('Should report click and drag payloads in the same space as mousemove', () => {
+        factory.set({
+            devicePixelRatio: 2,
+        });
+
+        const context = create();
+        const element = createMockElement('a', [...HOVER_EVENTS, ...DRAG_EVENTS, 'click']);
+
+        register(context, [element]);
+
+        expect(context.scaleX(50)).toBe(100);
+
+        hover(context, 50, 50);
+        hover(context, 50, 50);
+
+        mouse(context, 'click', 50, 50);
+        mouse(context, 'mousedown', 50, 50);
+        mouse(context, 'mousemove', 100, 100);
+
+        const payloads = new Map(element.events.map(({ type, data }) => [type, data]));
+
+        expect(payloads.get('mousemove')).toEqual({
+            x: 50,
+            y: 50,
+        });
+        expect(payloads.get('click')).toEqual({
+            x: 50,
+            y: 50,
+        });
+        expect(payloads.get('dragstart')).toEqual({
+            x: 50,
+            y: 50,
+        });
     });
 
 });

--- a/packages/dom/test/dom.node.test.ts
+++ b/packages/dom/test/dom.node.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+
+import {
+    describe,
+    expect,
+    test,
+} from 'vitest';
+
+import {
+    hasWindow,
+    onDOMElementResize,
+} from '../src/dom';
+
+describe('onDOMElementResize outside a browser', () => {
+
+    test('Should report no window', () => {
+        expect(hasWindow).toBe(false);
+    });
+
+    // `@ripl/dom` is published with `sideEffects: false`, so an SSR consumer can reach this helper.
+    test('Should degrade to an inert disposable rather than throwing', () => {
+        const disposable = onDOMElementResize({} as HTMLElement, () => undefined);
+
+        expect(() => disposable.dispose()).not.toThrow();
+    });
+
+});

--- a/packages/dom/test/dom.test.ts
+++ b/packages/dom/test/dom.test.ts
@@ -90,6 +90,33 @@ describe('onDOMElementResize', () => {
         vi.unstubAllGlobals();
     });
 
+    // jsdom has no `ResizeObserver`, so leaving it unstubbed is what reaches the fallback branch.
+    test('Should report the content box when falling back to window resize', () => {
+        const el = document.createElement('div');
+        const handler = vi.fn();
+
+        el.style.padding = '10px';
+        el.style.border = '2px solid black';
+        document.body.appendChild(el);
+
+        vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+            width: 420,
+            height: 320,
+        } as DOMRect);
+
+        const disposable = onDOMElementResize(el, handler);
+
+        window.dispatchEvent(new Event('resize'));
+
+        expect(handler).toHaveBeenCalledWith({
+            width: 396,
+            height: 296,
+        });
+
+        disposable.dispose();
+        el.remove();
+    });
+
     test('Should return a disposable that disconnects the observer', () => {
         const el = document.createElement('div');
         const handler = vi.fn();

--- a/packages/dom/test/export.test.ts
+++ b/packages/dom/test/export.test.ts
@@ -52,6 +52,42 @@ describe('createCanvasExport', () => {
         expect(url.startsWith('blob:')).toBe(true);
     });
 
+    // An unrevoked object URL pins its blob for the document's lifetime.
+    test('Should revoke every object URL it handed out on release', () => {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 16;
+        canvas.height = 16;
+
+        const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+        const contextExport = createCanvasExport(canvas);
+
+        const first = contextExport.toURL();
+        const second = contextExport.toURL();
+
+        contextExport.release?.();
+
+        expect(revokeObjectURL).toHaveBeenCalledWith(first);
+        expect(revokeObjectURL).toHaveBeenCalledWith(second);
+        expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+    });
+
+    test('Should be safe to release repeatedly', () => {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 16;
+        canvas.height = 16;
+
+        const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+        const contextExport = createCanvasExport(canvas);
+
+        contextExport.toURL();
+        contextExport.release?.();
+        contextExport.release?.();
+
+        expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+
     test('Should export the canvas as ImageData at the backing resolution', async () => {
         const canvas = document.createElement('canvas');
 

--- a/packages/dom/test/navigator.test.ts
+++ b/packages/dom/test/navigator.test.ts
@@ -257,6 +257,171 @@ describe('DOMNavigator interactions', () => {
         sharp.destroy();
     });
 
+    test('Should pan with the finger that survives a pinch', () => {
+        const navigator = createNavigator(fakeContext(), {
+            interactions: {
+                pan: true,
+                zoom: true,
+            },
+        });
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 100,
+            clientY: 100,
+        });
+        fire('pointerdown', {
+            pointerId: 2,
+            clientX: 200,
+            clientY: 100,
+        });
+        fire('pointermove', {
+            pointerId: 2,
+            clientX: 240,
+            clientY: 100,
+        });
+        fire('pointerup', {
+            pointerId: 2,
+            clientX: 240,
+            clientY: 100,
+        });
+
+        const panned = navigator.transform.x;
+
+        fire('pointermove', {
+            pointerId: 1,
+            clientX: 130,
+            clientY: 100,
+        });
+
+        expect(navigator.transform.x).toBe(panned + 30);
+
+        navigator.destroy();
+    });
+
+    // An uncaptured pointer never reaches `endPointer`, so the next gesture reads as a pinch.
+    test('Should not misread a gesture that follows an uncaptured release as a pinch', () => {
+        const navigator = createNavigator(fakeContext(), {
+            interactions: {
+                pan: true,
+                zoom: true,
+            },
+        });
+
+        const setPointerCapture = vi.fn();
+        const onZoom = vi.fn();
+
+        element.setPointerCapture = setPointerCapture;
+        navigator.on('zoom', onZoom);
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 10,
+            clientY: 10,
+            button: 2,
+        });
+
+        expect(setPointerCapture).toHaveBeenCalledWith(1);
+
+        fire('pointerup', {
+            pointerId: 1,
+            clientX: 10,
+            clientY: 10,
+        });
+
+        fire('pointerdown', {
+            pointerId: 2,
+            clientX: 100,
+            clientY: 100,
+        });
+        fire('pointermove', {
+            pointerId: 2,
+            clientX: 130,
+            clientY: 100,
+        });
+
+        expect(navigator.transform.x).toBe(30);
+        expect(onZoom).not.toHaveBeenCalled();
+
+        navigator.destroy();
+    });
+
+    test('Should measure the element once per gesture, not once per pointer move', () => {
+        const navigator = createNavigator(fakeContext(), {
+            interactions: {
+                pan: true,
+            },
+        });
+
+        const getBoundingClientRect = vi.spyOn(element, 'getBoundingClientRect');
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 100,
+            clientY: 100,
+        });
+
+        getBoundingClientRect.mockClear();
+
+        for (let i = 0; i < 10; i++) {
+            fire('pointermove', {
+                pointerId: 1,
+                clientX: 100 + i,
+                clientY: 100,
+            });
+        }
+
+        expect(getBoundingClientRect).not.toHaveBeenCalled();
+
+        navigator.destroy();
+    });
+
+    test('Should re-measure the element after a scroll', () => {
+        const navigator = createNavigator(fakeContext(), {
+            interactions: {
+                pan: true,
+            },
+        });
+
+        const getBoundingClientRect = vi.spyOn(element, 'getBoundingClientRect');
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 100,
+            clientY: 100,
+        });
+
+        getBoundingClientRect.mockClear();
+
+        window.dispatchEvent(new Event('scroll'));
+
+        fire('pointermove', {
+            pointerId: 1,
+            clientX: 130,
+            clientY: 100,
+        });
+
+        expect(getBoundingClientRect).toHaveBeenCalledOnce();
+
+        navigator.destroy();
+    });
+
+    test('Should leave touchAction alone when every interaction is disabled', () => {
+        element.style.touchAction = 'pan-y';
+
+        const navigator = createNavigator(fakeContext(), {
+            interactions: {
+                zoom: false,
+                pan: false,
+                brush: false,
+            },
+        });
+
+        expect(element.style.touchAction).toBe('pan-y');
+
+        navigator.destroy();
+    });
+
     test('Should warn and stay inert on a non-DOM context', () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 

--- a/packages/dom/test/reconcile.test.ts
+++ b/packages/dom/test/reconcile.test.ts
@@ -496,6 +496,76 @@ describe('VDOM', () => {
             expect(childIds).toContain('defs');
             expect(parent.querySelector('.protected')).not.toBeNull();
             expect(parent.querySelector('#child-1')).not.toBeNull();
+
+            // Managed children used to be inserted at an index the excluded nodes still counted towards.
+            expect(Array.from(parent.children).indexOf(defsEl)).toBe(0);
+            expect(Array.from(parent.children).indexOf(protectedEl)).toBe(1);
+        });
+
+        test('Should render every sibling that shares an id, in order', () => {
+            const parent = createDOMElement('div');
+            const domCache = new Map<string, Element>();
+            const options = createTestOptions();
+
+            const vnode: VNode<TestElement> = {
+                id: 'root',
+                tag: 'div',
+                children: [
+                    {
+                        id: 'dup',
+                        tag: 'span',
+                        children: [],
+                    },
+                    {
+                        id: 'other',
+                        tag: 'span',
+                        children: [],
+                    },
+                    {
+                        id: 'dup',
+                        tag: 'span',
+                        children: [],
+                    },
+                ],
+            };
+
+            reconcileNode(parent, vnode, domCache, options);
+
+            expect(parent.children).toHaveLength(3);
+            expect(Array.from(parent.children).map(c => c.getAttribute('id'))).toEqual(['dup', 'other', 'dup']);
+        });
+
+        test('Should keep siblings that share an id stable across passes', () => {
+            const parent = createDOMElement('div');
+            const domCache = new Map<string, Element>();
+            const options = createTestOptions();
+
+            const vnode: VNode<TestElement> = {
+                id: 'root',
+                tag: 'div',
+                children: [
+                    {
+                        id: 'dup',
+                        tag: 'span',
+                        children: [],
+                    },
+                    {
+                        id: 'dup',
+                        tag: 'span',
+                        children: [],
+                    },
+                ],
+            };
+
+            reconcileNode(parent, vnode, domCache, options);
+
+            const nodes = Array.from(parent.children);
+
+            expect(nodes).toHaveLength(2);
+
+            reconcileNode(parent, vnode, domCache, options);
+
+            expect(Array.from(parent.children)).toEqual(nodes);
         });
 
         test('should handle mixed add, remove, and reorder in one pass', () => {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,19 +4,43 @@ import {
 
 import type {
     BaseState,
+    MeasureTextOptions,
 } from '@ripl/core';
 
 import {
+    BRAILLE_CELL_HEIGHT,
+    BRAILLE_CELL_WIDTH,
     createContext,
 } from '@ripl/terminal';
 
 import type {
     TerminalContextOptions,
+    TerminalOutput,
 } from '@ripl/terminal';
+
+import {
+    functionCache,
+    typeIsFunction,
+} from '@ripl/utilities';
 
 import {
     createTerminalOutput,
 } from './output';
+
+const DEFAULT_FONT_SIZE = 10;
+const FRAME_INTERVAL = 16;
+const FONT_SIZE_PATTERN = /(\d*\.?\d+)px/;
+
+const TEXT_ALIGN_ANCHORS: Record<string, number> = {
+    start: 0,
+    left: 0,
+    center: 0.5,
+    end: 1,
+    right: 1,
+};
+
+// One per process, not one per context: each `createTerminalOutput` registers its own `SIGWINCH` handler.
+const getDefaultOutput = functionCache(createTerminalOutput);
 
 function getDefaultState(): BaseState {
     return {
@@ -51,38 +75,101 @@ function getDefaultState(): BaseState {
     };
 }
 
-function nodeMeasureText(value: string): TextMetrics {
+function getFontSize(font: string | undefined): number {
+    const match = font ? FONT_SIZE_PATTERN.exec(font) : null;
+
+    return match ? parseFloat(match[1]) : DEFAULT_FONT_SIZE;
+}
+
+/**
+ * Measures text as the terminal paints it — one braille cell per character — scaled by the
+ * requested font size.
+ *
+ * `TerminalContext.measureText` is the authority for anything already rendered; this is the
+ * fallback core falls back to before an element's first paint, so the two have to agree at the
+ * default font or every box jumps on the first frame. `textBaseline` is deliberately not modelled:
+ * the terminal paints one cell per glyph with no baseline variation, so honouring it here would
+ * manufacture a disagreement.
+ */
+function nodeMeasureText(value: string, options?: MeasureTextOptions): TextMetrics {
+    const scale = getFontSize(options?.font) / DEFAULT_FONT_SIZE;
+    const width = value.length * BRAILLE_CELL_WIDTH * scale;
+    const height = BRAILLE_CELL_HEIGHT * scale;
+
+    // `actualBoundingBox*` is measured from the alignment point, not from the start of the run.
+    const anchor = TEXT_ALIGN_ANCHORS[options?.textAlign ?? 'start'] ?? 0;
+
     return {
-        width: value.length * 8,
-        actualBoundingBoxAscent: 8,
-        actualBoundingBoxDescent: 2,
-        actualBoundingBoxLeft: 0,
-        actualBoundingBoxRight: value.length * 8,
-        fontBoundingBoxAscent: 10,
-        fontBoundingBoxDescent: 2,
+        width,
+        actualBoundingBoxAscent: height,
+        actualBoundingBoxDescent: 0,
+        actualBoundingBoxLeft: width * anchor,
+        actualBoundingBoxRight: width * (1 - anchor),
+        fontBoundingBoxAscent: height,
+        fontBoundingBoxDescent: 0,
         alphabeticBaseline: 0,
-        emHeightAscent: 8,
-        emHeightDescent: 2,
-        hangingBaseline: 8,
-        ideographicBaseline: -2,
+        emHeightAscent: height,
+        emHeightDescent: 0,
+        hangingBaseline: height,
+        ideographicBaseline: 0,
     } as TextMetrics;
 }
 
+function isTerminalOutput(target: unknown): target is TerminalOutput {
+    return !!target && typeIsFunction((target as TerminalOutput).write);
+}
+
+function resolveOutput(target: unknown): TerminalOutput {
+    if (isTerminalOutput(target)) {
+        return target;
+    }
+
+    if (target) {
+        console.warn('createContext: @ripl/node renders to the terminal, so the provided target is ignored. Pass a TerminalOutput to choose one.');
+    }
+
+    return getDefaultOutput();
+}
+
+/**
+ * Minimal duck-typed element for the DOM helpers core reaches for off-platform. Core is written to
+ * degrade — `interpolateImage` checks `getContext()` and the path helpers read a length — so the
+ * stub answers those probes rather than throwing a raw `TypeError` at the first property access.
+ */
+function createNodeElement(tagName: string) {
+    const attributes = new Map<string, string>();
+
+    return {
+        tagName,
+        style: {},
+        setAttribute: (name: string, value: string) => void attributes.set(name, value),
+        getAttribute: (name: string) => attributes.get(name) ?? null,
+        removeAttribute: (name: string) => void attributes.delete(name),
+        getContext: () => null,
+        getTotalLength: () => 0,
+        getPointAtLength: () => ({
+            x: 0,
+            y: 0,
+        }),
+    };
+}
+
 factory.set({
-    requestAnimationFrame: (cb) => setTimeout(cb, 16) as unknown as number,
+    // Unref'd: the render loop re-arms every frame, so a ref'd timer keeps a static chart's process alive forever.
+    requestAnimationFrame: (callback) => setTimeout(() => callback(performance.now()), FRAME_INTERVAL).unref() as unknown as number,
     cancelAnimationFrame: (handle) => clearTimeout(handle),
     now: () => performance.now(),
     devicePixelRatio: 1,
     getDefaultState,
     measureText: nodeMeasureText,
     createContext: (target, options) => createContext(
-        createTerminalOutput(),
+        resolveOutput(target),
         options as TerminalContextOptions
     ),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getComputedStyle: () => ({ font: '10px monospace' } as any),
-    createElement: () => ({}) as HTMLElement,
-    createElementNS: () => ({}) as Element,
+    createElement: (tagName) => createNodeElement(tagName) as unknown as HTMLElement,
+    createElementNS: (_namespace, tagName) => createNodeElement(tagName) as unknown as Element,
 });
 
 export { createTerminalOutput };

--- a/packages/node/src/output.ts
+++ b/packages/node/src/output.ts
@@ -2,8 +2,18 @@ import type {
     TerminalOutput,
 } from '@ripl/terminal';
 
-/** Creates a `TerminalOutput` adapter backed by Node.js `process.stdout`. */
+/**
+ * Creates a `TerminalOutput` adapter backed by Node.js `process.stdout`.
+ *
+ * Resize subscribers are multiplexed behind a single `SIGWINCH` handler, registered on the first
+ * subscription and removed with the last. One handler per subscriber tripped Node's
+ * `MaxListenersExceededWarning` at ten scenes, and fired every handler on every resize.
+ */
 export function createTerminalOutput(): TerminalOutput {
+    const listeners = new Set<(cols: number, rows: number) => void>();
+
+    let handler: (() => void) | undefined;
+
     return {
         write(data: string) {
             process.stdout.write(data);
@@ -18,15 +28,24 @@ export function createTerminalOutput(): TerminalOutput {
         },
 
         onResize(callback: (cols: number, rows: number) => void) {
-            const handler = () => callback(
-                process.stdout.columns || 80,
-                process.stdout.rows || 24
-            );
+            listeners.add(callback);
 
-            process.on('SIGWINCH', handler);
+            if (!handler) {
+                handler = () => listeners.forEach(listener => listener(
+                    process.stdout.columns || 80,
+                    process.stdout.rows || 24
+                ));
+
+                process.on('SIGWINCH', handler);
+            }
 
             return () => {
-                process.off('SIGWINCH', handler);
+                listeners.delete(callback);
+
+                if (listeners.size === 0 && handler) {
+                    process.off('SIGWINCH', handler);
+                    handler = undefined;
+                }
             };
         },
     };

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -9,7 +9,25 @@ import '../src/index';
 
 import {
     factory,
+    getPathLength,
+    samplePathPoint,
 } from '@ripl/core';
+
+import {
+    createContext,
+} from '@ripl/terminal';
+
+import type {
+    TerminalOutput,
+} from '@ripl/terminal';
+
+function terminalContext() {
+    return createContext({
+        write: () => undefined,
+        columns: 80,
+        rows: 24,
+    } as TerminalOutput);
+}
 
 describe('Node factory bindings', () => {
 
@@ -64,6 +82,70 @@ describe('Node factory bindings', () => {
         const long = factory.measureText('abcd');
 
         expect(long.width).toBe(short.width * 2);
+    });
+
+    // Core falls back to this before an element's first paint, so a disagreement makes boxes jump.
+    test('measureText should agree with the terminal context it feeds', () => {
+        const context = terminalContext();
+        const metrics = factory.measureText('hello');
+        const painted = context.measureText('hello');
+
+        expect(metrics.width).toBe(painted.width);
+        expect(metrics.actualBoundingBoxAscent).toBe(painted.actualBoundingBoxAscent);
+        expect(metrics.actualBoundingBoxDescent).toBe(painted.actualBoundingBoxDescent);
+
+        context.destroy();
+    });
+
+    test('measureText should scale with the requested font size', () => {
+        const small = factory.measureText('hello', {
+            font: '10px monospace',
+        });
+
+        const large = factory.measureText('hello', {
+            font: '40px monospace',
+        });
+
+        expect(large.width).toBe(small.width * 4);
+        expect(large.actualBoundingBoxAscent).toBe(small.actualBoundingBoxAscent * 4);
+    });
+
+    test('measureText should anchor the box on the requested text alignment', () => {
+        const start = factory.measureText('hello', {
+            textAlign: 'start',
+        });
+
+        const centre = factory.measureText('hello', {
+            textAlign: 'center',
+        });
+
+        const end = factory.measureText('hello', {
+            textAlign: 'right',
+        });
+
+        expect(start.actualBoundingBoxLeft).toBe(0);
+        expect(start.actualBoundingBoxRight).toBe(start.width);
+        expect(centre.actualBoundingBoxLeft).toBe(centre.width / 2);
+        expect(centre.actualBoundingBoxRight).toBe(centre.width / 2);
+        expect(end.actualBoundingBoxLeft).toBe(end.width);
+        expect(end.actualBoundingBoxRight).toBe(0);
+    });
+
+    // `{}` threw a raw TypeError on the first property access, so core's guards never ran.
+    test('createElementNS should return a path stub the geometry helpers can degrade against', () => {
+        expect(getPathLength('M0,0 L10,10')).toBe(0);
+        expect(samplePathPoint('M0,0 L10,10', 5)).toEqual({
+            x: 0,
+            y: 0,
+            angle: 0,
+        });
+    });
+
+    // `image.ts` guards on a null 2D context; the old `{}` threw before the guard could run.
+    test('createElement should return a canvas stub whose getContext degrades to null', () => {
+        const canvas = factory.createElement('canvas') as HTMLCanvasElement;
+
+        expect(canvas.getContext('2d')).toBeNull();
     });
 
     test('requestAnimationFrame should be defined', () => {

--- a/packages/node/test/runtime.node.test.ts
+++ b/packages/node/test/runtime.node.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import {
+    afterEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+// Side-effect import: registers node factory bindings (overrides vitest.setup.ts)
+import '../src/index';
+
+import {
+    factory,
+} from '@ripl/core';
+
+describe('Node runtime bindings', () => {
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    // jsdom's numeric timer handle cannot express this, hence the node environment.
+    test('Should schedule frames on a timer that does not hold the process open', () => {
+        const handle = factory.requestAnimationFrame(() => undefined) as unknown as NodeJS.Timeout;
+
+        expect(handle.hasRef()).toBe(false);
+
+        factory.cancelAnimationFrame(handle as unknown as number);
+    });
+
+    test('Should pass a timestamp to the frame callback', async () => {
+        const timestamp = await new Promise<number>(resolve => factory.requestAnimationFrame(resolve));
+
+        expect(typeof timestamp).toBe('number');
+        expect(timestamp).toBeGreaterThan(0);
+    });
+
+    test('Should share one terminal output across contexts rather than one SIGWINCH handler each', () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const before = process.listenerCount('SIGWINCH');
+
+        const first = factory.createContext('#one');
+        const second = factory.createContext('#two');
+
+        expect(process.listenerCount('SIGWINCH') - before).toBeLessThanOrEqual(1);
+
+        first.destroy();
+        second.destroy();
+    });
+
+    test('Should warn that a DOM target cannot be honoured', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        factory.createContext('#chart').destroy();
+
+        expect(warn).toHaveBeenCalledOnce();
+    });
+
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -6,8 +6,9 @@ factory.set({
     requestAnimationFrame: (cb: FrameRequestCallback) => window.requestAnimationFrame(cb),
     cancelAnimationFrame: (handle: number) => window.cancelAnimationFrame(handle),
     now: () => performance.now(),
+    // Read eagerly by the spread in `factory.set`, so it has to survive a `// @vitest-environment node` file.
     get devicePixelRatio() {
-        return window.devicePixelRatio ?? 1;
+        return typeof window === 'undefined' ? 1 : window.devicePixelRatio ?? 1;
     },
     getComputedStyle: (el: unknown) => window.getComputedStyle(el as Element),
     createElement: (tagName: string) => document.createElement(tagName),


### PR DESCRIPTION
Stacked on #68 — review that first; this PR's diff is only the dom and node commits.

Fourth of seven PRs implementing the rendering-context audit in `docs/audits/`. Covers the dom- and node-owned findings in `dom-node.md`.

## The problem

`DOMContext` owns all pointer state, split across two lifetimes: `_activeElements` is an instance field surviving the whole object, while everything else lives in `InteractionState`, which `disableInteraction()` nulls. That asymmetry causes most of the cluster, and the pieces interlock — which is why they are fixed as one unit rather than seven patches.

**A `mouseup` outside the surface stranded the drag permanently.** `mouseup` was bound to the element only, so releasing off-surface emitted no `dragend` and left the drag live — it resumed on the next move with no button held. `_handleMouseDown` assigned only inside `if (hitElements.length > 0)` with no `else`, so the stale `dragElement` *and* `dragStartX/Y` survived, making the next gesture's delta baseline the previous gesture's origin.

**Leaving the surface never emitted element `mouseleave`.** `_activeElements` was reconciled only inside `_handleHoverHitTest`, which runs only from `_handleMouseMove`. Every other exit dropped the set without unwinding — so a chart tooltip stayed painted after the pointer left the chart.

**A pending hit test fired after teardown.** `_handleHoverHitTest` reads `_activeElements` and never touches `_interactionState`, so a scheduled frame callback ran happily against a destroyed context and re-populated the set that had just been flushed.

**`click` fired after every drag**, because `_handleMouseUp` cleared `dragStarted` before the synthesised `click` reached `_handleClick`.

Plus a duplicate sibling id deleting an element and reordering the rest, and payloads that were CSS pixels for `mousemove` but device pixels for `click`/`drag`.

## The fix

Two helpers, in the order the interlocks demand:

- **`_endDrag()`** — null-safe, bound at both element and window, setting a consume-once "this gesture was a drag" flag that the click path reads. That covers the off-surface release, the stale target, and the spurious click in one place.
- **`_flushActiveElements()`** — cancel-then-flush, called from surface `mouseleave` and from `disableInteraction`. Cancel has to come first: flush-then-cancel would let the pending frame re-populate the set and emit `mouseenter` on a dead context.

`destroy()` delegates to `disableInteraction()`, so **there is now a single teardown path**. Every exit from a hover goes through one helper, every exit from a drag through the other, and the frame buffer is cancelled before the state holding it is dropped. The remaining asymmetry — `_activeElements` on the instance, everything else on `InteractionState` — is now harmless; folding the set into `InteractionState` is the natural next step.

Element payloads normalise to **CSS pixels**, matching the direction the existing `context.test.ts` cases already pin.

## Verification

`yarn lint` 0 · `yarn typecheck` 0 · build clean across all 12 packages with `attw` and `publint` · `yarn typecheck:dist` 0. `yarn test` **185 files / 2130 passed, 1 skipped** against a branch point of 183 / 2097 / 1. Coverage 86.29 / 74.12 / 81.02 / 86.51, up on all four from 85.46 / 73.64 / 80.32 / 85.67. Node 24.18.1.

Branch-point proof, per area: 10/12 pointer-state tests fail at the branch point, 2/3 reconciler, 2/2 `dom.ts`, 2/2 export, 4/5 navigator, 9/9 node. The ones that pass either way are deliberate over-correction guards — a click *under* the drag threshold still fires, the gesture *after* a drag still clicks, and the navigator still re-measures after a scroll.

**No existing test body was altered.** `packages/dom/test/context.test.ts` had its `setOrigin`/`create`/`beforeEach` hoisted to module scope so a second `describe` could share them, and `reconcile.test.ts:467` gained two index assertions (extended, not replaced, as the audit's triage recommended). `packages/node/test/index.test.ts:62` is **unchanged** — the new metric model is still linear in character count, so its ratio assertion still holds.

One file outside the branch's scope: `vitest.setup.ts`, one line. The `devicePixelRatio` getter is read eagerly during factory setup, so without a `typeof window` guard **no `// @vitest-environment node` file can load at all** — and both F15 and F27 need one. Flagging it because it is shared with the sibling branches.

## Breaking

1. **Element `click`/`dragstart`/`drag`/`dragend` payloads are CSS pixels**, not device pixels. `deltaX`/`deltaY` were already CSS px, so the payload was internally inconsistent. The website's drag examples use only the deltas and are unaffected. `!` + footer on `db904cc`.
2. **`@ripl/node` `factory.measureText` reports braille-cell metrics** (2 units/char at 10px, ascent 4, descent 0) instead of 8px/char. `!` + footer on `1bb3d0e`.
3. Behavioural, untyped: `disableInteraction()`/`destroy()` now emit `mouseleave` during teardown, and a `dragend` may carry coordinates outside the surface.

## Follow-ups

Three deferrals, each with a reason rather than silence:

- **F18's image half.** `factory.createElement` now returns a stub whose `getContext()` returns `null`, which makes core's guard reachable — but `interpolateImage` threw before it. That turned out to be a **new core defect**: `getSourceSize` dereferenced `HTMLImageElement`, `SVGImageElement`, `HTMLVideoElement` and `ImageBitmap` unguarded, so it threw a `ReferenceError` on any runtime without the DOM globals. Reported rather than patched here; **it is fixed in #68**.
- **F16's `textBaseline`.** Deliberately not modelled. `TerminalContext.measureText` — the authority for anything actually rendered — paints one braille cell per glyph with no baseline variation, so honouring baseline in the factory would manufacture a disagreement on the very axis F16 exists to close.
- **F17's `target` rejection.** `FactoryOptions.createContext` types `target` as `string | HTMLElement`, so throwing on a DOM target would break `new Scene('#chart')` outright. It warns instead, matching how `DOMNavigator` handles a non-DOM context. The substantive half — one `SIGWINCH` handler per process rather than per context — is fully fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156vGhahurZUzVHRFeUXtnc)_