### PR TITLE
Honour lineWidth when stroking in the terminal

### DIFF
--- a/docs/migrations/context-audit.md
+++ b/docs/migrations/context-audit.md
@@ -245,11 +245,21 @@ ellipse renders different geometry than before — the geometry that was asked f
 
 **`dashPixels`** — **API**, additive. Gates a plot callback on a dash pattern.
 
+**`thickenPixels`** — **API**, additive. Widens a plot callback by stamping a round brush at every
+pixel it plots.
+
 **`TerminalContext.applyStroke`** — **behaviour**. Honors `lineDash`/`lineDashOffset`. Dashed grid
 lines and zero-lines were indistinguishable from solid data lines. Arc length is approximated by
 counting plotted pixels, which is exact for axis-aligned runs and up to √2 short on a diagonal.
-`lineWidth`, `lineCap`, `lineJoin` and `miterLimit` remain ignored — a 1-bit raster has no form for
-them.
+
+**`TerminalContext.applyStroke`** — **behaviour**. Honors `lineWidth`. Every stroke was one dot
+wide regardless of width, which erased the encoding of any chart carrying its data in stroke
+thickness — a Sankey's links (`lineWidth` *is* the flow magnitude, 20–200px) all collapsed to
+identical hairline curves, and a radial bar's rings to concentric hairlines. Thickness quantises to
+an odd number of dots because the brush centres on one: widths of 1, 2, 3, 4 and 5 give strokes 1,
+3, 3, 5 and 5 dots across. **A scene that strokes anything wider than 1 now emits different bytes.**
+`lineCap`, `lineJoin` and `miterLimit` are still ignored — the round brush shapes every cap and
+join — so a gap narrower than the stroke is wide gets bridged by its caps, as it is on canvas.
 
 **`TerminalPath.arcTo`** — **behaviour**. Constructs the real tangent arc instead of two straight
 lines through the corner. Canvas `arcTo` never passes through `(x1, y1)`; the old approximation was

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -28,7 +28,7 @@ The terminal context is a rasterizer onto a character grid, so parts of the canv
 | **Fill rule** | Even-odd only; a `nonzero` fill rule is ignored. |
 | **Gradients and patterns** | Resolved to a single color — the gradient's first stop, or the pattern's foreground. |
 | **Opacity and alpha** | A cell is lit or unlit, so `opacity` and a paint's own alpha darken the color toward an assumed dark background. Zero alpha draws nothing. |
-| **Stroke geometry** | `lineWidth`, `lineCap`, `lineJoin` and `miterLimit` are ignored — strokes are always one raster pixel wide. `lineDash`/`lineDashOffset` **are** honored, with arc length approximated by plotted-pixel count. |
+| **Stroke geometry** | `lineWidth` **is** honored, by stamping a round brush along the path. The brush centres on a dot, so thickness quantises to an odd number of dots — widths of 1, 2, 3, 4 and 5 give strokes 1, 3, 3, 5 and 5 dots across. `lineCap`, `lineJoin` and `miterLimit` are ignored: the brush makes every cap and join round. `lineDash`/`lineDashOffset` **are** honored, with arc length measured along the centreline and approximated by plotted-pixel count. |
 | **Shadows, filters, compositing** | Ignored. `globalCompositeOperation: 'destination-out'` warns: canvas *erases* where the terminal *draws*, so that geometry renders inverted rather than merely degraded. |
 
 Charts that rely on transforms (rotated axis titles, rotated symbols) render legibly but not identically to canvas.

--- a/packages/terminal/src/algorithms.ts
+++ b/packages/terminal/src/algorithms.ts
@@ -458,6 +458,47 @@ export function dashPixels(pattern: number[], offset: number, plot: PixelCallbac
     };
 }
 
+/**
+ * Widens a rasterization pass by stamping a round brush at every pixel it plots, so a stroke can be
+ * more than one dot thick. Thickness is geometry, not color depth: a braille cell is 2×4 dots, so a
+ * width is perfectly expressible even though each dot is only lit or unlit.
+ *
+ * The brush centres on a dot, so thickness quantises to an **odd** number of dots — widths of 1, 2,
+ * 3, 4 and 5 produce strokes 1, 3, 3, 5 and 5 dots across. Because the brush is round, caps and
+ * joins are always round; `lineCap`, `lineJoin` and `miterLimit` have no effect.
+ *
+ * Compose this *inside* {@link dashPixels}, never outside it: dash measures arc length by counting
+ * the pixels it receives, so thickening first would advance the pattern once per stamped dot rather
+ * than once per centreline dot.
+ *
+ * @param width - Stroke width in raster pixels.
+ * @param plot - The callback to widen.
+ * @returns A callback that stamps a brush per pixel, or `plot` itself for a hairline stroke.
+ */
+export function thickenPixels(width: number, plot: PixelCallback): PixelCallback {
+    if (!(width > 1)) {
+        return plot;
+    }
+
+    const radius = width / 2;
+    const extent = Math.floor(radius);
+    const offsets: number[] = [];
+
+    for (let dy = -extent; dy <= extent; dy++) {
+        for (let dx = -extent; dx <= extent; dx++) {
+            if (dx * dx + dy * dy <= radius * radius) {
+                offsets.push(dx, dy);
+            }
+        }
+    }
+
+    return (x, y) => {
+        for (let i = 0; i < offsets.length; i += 2) {
+            plot(x + offsets[i], y + offsets[i + 1]);
+        }
+    };
+}
+
 /** Computes the x-coordinates where a horizontal scanline crosses the edges of the given contours. */
 function scanlineCrossings(contours: Vertex[][], scanY: number): number[] {
     const crossings: number[] = [];

--- a/packages/terminal/src/context.ts
+++ b/packages/terminal/src/context.ts
@@ -40,6 +40,7 @@ import {
     rasterizeLine,
     rasterizeQuadBezier,
     rasterizeRect,
+    thickenPixels,
 } from './algorithms';
 
 import type {
@@ -645,7 +646,20 @@ export class TerminalContext extends Context<Element> {
             return;
         }
 
-        this._executeCommands(path, this._dashPlot(plot));
+        this._executeCommands(path, this._dashPlot(this._thickPlot(plot)));
+    }
+
+    /**
+     * Widens a plot callback to the current stroke width, mapped from logical units into raster
+     * pixels. Nested inside {@link TerminalContext._dashPlot} so the dash pattern still measures
+     * arc length along the centreline rather than across the brush.
+     */
+    private _thickPlot(plot: PixelCallback): PixelCallback {
+        // A brush wider than the grid is stamped entirely out of bounds, so cap the wasted work.
+        const limit = Math.max(this._rasterizer.pixelWidth, this._rasterizer.pixelHeight);
+        const width = Math.min(this.lineWidth * this._rasterScale, limit);
+
+        return thickenPixels(width, plot);
     }
 
     /** Gates a plot callback on the current dash pattern, mapped from logical units into raster pixels. */

--- a/packages/terminal/test/algorithms.test.ts
+++ b/packages/terminal/test/algorithms.test.ts
@@ -19,6 +19,7 @@ import {
     rasterizeLine,
     rasterizeQuadBezier,
     rasterizeRect,
+    thickenPixels,
 } from '../src/algorithms';
 
 import type {
@@ -258,6 +259,71 @@ describe('dashPixels', () => {
         const pixels = collectPixels(plot => rasterizeLine(0, 0, 4, 0, dashPixels([2, -2], 0, plot)));
 
         expect(pixels).toHaveLength(5);
+    });
+
+});
+
+describe('thickenPixels', () => {
+
+    /** Strokes a horizontal line of the given width and measures its depth clear of the round caps. */
+    function strokeThickness(width: number): number {
+        const pixels = collectPixels(plot => rasterizeLine(0, 20, 9, 20, thickenPixels(width, plot)));
+        const middle = pixels.filter(([x]) => x === 5).map(([, y]) => y);
+
+        return new Set(middle).size;
+    }
+
+    test('Should return the original callback for a hairline stroke', () => {
+        const plot: PixelCallback = () => {};
+
+        expect(thickenPixels(1, plot)).toBe(plot);
+        expect(thickenPixels(0, plot)).toBe(plot);
+    });
+
+    // The brush centres on a dot, so an even width rounds up to the next odd dot count.
+    test('Should widen a stroke to an odd number of dots', () => {
+        expect(strokeThickness(1)).toBe(1);
+        expect(strokeThickness(2)).toBe(3);
+        expect(strokeThickness(3)).toBe(3);
+        expect(strokeThickness(4)).toBe(5);
+        expect(strokeThickness(5)).toBe(5);
+    });
+
+    test('Should round the ends of a thick stroke', () => {
+        const pixels = collectPixels(plot => rasterizeLine(0, 20, 9, 20, thickenPixels(5, plot)));
+        const depthAt = (x: number) => new Set(pixels.filter(p => p[0] === x).map(([, y]) => y)).size;
+
+        expect(depthAt(5)).toBe(5);
+        expect(depthAt(-2)).toBeLessThan(depthAt(5));
+        expect(depthAt(-2)).toBeGreaterThan(0);
+    });
+
+    test('Should centre the brush on the plotted pixel', () => {
+        const pixels = collectPixels(plot => thickenPixels(3, plot)(10, 10));
+        const set = pixelSet(pixels);
+
+        expect(set.has('10,10')).toBe(true);
+        expect(set.has('9,10')).toBe(true);
+        expect(set.has('11,10')).toBe(true);
+        expect(set.has('10,9')).toBe(true);
+        expect(set.has('10,11')).toBe(true);
+    });
+
+    test('Should keep a diagonal stroke the same thickness as an axis-aligned one', () => {
+        const diagonal = collectPixels(plot => rasterizeLine(0, 0, 9, 9, thickenPixels(5, plot)));
+        const set = pixelSet(diagonal);
+
+        // A round brush measures the same across any heading; a square one would inflate by √2.
+        expect(set.has('5,3')).toBe(true);
+        expect(set.has('5,7')).toBe(true);
+        expect(set.has('5,1')).toBe(false);
+    });
+
+    test('Should widen a curve as well as a line', () => {
+        const thin = collectPixels(plot => rasterizeCircle(20, 20, 8, plot));
+        const thick = collectPixels(plot => rasterizeCircle(20, 20, 8, thickenPixels(3, plot)));
+
+        expect(pixelSet(thick).size).toBeGreaterThan(pixelSet(thin).size);
     });
 
 });

--- a/packages/terminal/test/context.test.ts
+++ b/packages/terminal/test/context.test.ts
@@ -11,6 +11,10 @@ import {
 } from '@ripl/core';
 
 import {
+    comparitorNumeric,
+} from '@ripl/utilities';
+
+import {
     mockCanvasContext,
     polyfillPath2D,
 } from '@ripl/test-utils';
@@ -744,6 +748,113 @@ describe('TerminalContext line dash', () => {
         const row = rasterizer.pixels.filter(([, y]) => y === 3).map(([x]) => x);
 
         expect(row).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    });
+
+});
+
+describe('TerminalContext line width', () => {
+
+    beforeEach(() => {
+        mockCanvasContext();
+    });
+
+    /** Strokes a horizontal line through a spy rasterizer and returns its de-duplicated dots. */
+    function strokeLine(configure: (ctx: TerminalContext) => void): [number, number][] {
+        const rasterizer = createSpyRasterizer(20, 5);
+        const ctx = createContext(createMockOutput(20, 5), {
+            rasterizer,
+        });
+
+        ctx.stroke = '#ffffff';
+        configure(ctx);
+
+        const path = ctx.createPath();
+
+        path.moveTo(0, 10);
+        path.lineTo(19, 10);
+
+        ctx.markRenderStart();
+        ctx.applyStroke(path);
+        ctx.markRenderEnd();
+
+        // The spy records every call; the real rasterizer ORs repeats into one dot.
+        const seen = new Set(rasterizer.pixels.map(([x, y]) => `${x},${y}`));
+
+        return [...seen].map(key => key.split(',').map(Number) as [number, number]);
+    }
+
+    /** Counts the distinct rows the stroke occupies in a column clear of its round caps. */
+    function thicknessAt(dots: [number, number][], x: number): number {
+        return dots.filter(dot => dot[0] === x).length;
+    }
+
+    // A Sankey link encodes its flow magnitude entirely in lineWidth, so a hairline loses the data.
+    test('Should stroke wider than one dot when lineWidth asks for it', () => {
+        expect(thicknessAt(strokeLine(() => {}), 10)).toBe(1);
+
+        expect(thicknessAt(strokeLine(ctx => {
+            ctx.lineWidth = 3;
+        }), 10)).toBe(3);
+
+        expect(thicknessAt(strokeLine(ctx => {
+            ctx.lineWidth = 5;
+        }), 10)).toBe(5);
+    });
+
+    test('Should keep a thick stroke centred on its path', () => {
+        const rows = strokeLine(ctx => {
+            ctx.lineWidth = 5;
+        }).filter(dot => dot[0] === 10).map(dot => dot[1]);
+
+        expect(Math.min(...rows)).toBe(8);
+        expect(Math.max(...rows)).toBe(12);
+    });
+
+    // Thickening inside the dash gate would advance the pattern once per stamped dot rather than
+    // per centreline dot, shredding the pattern into far more, far shorter runs. The gap is wider
+    // than the widest brush here, since round caps legitimately bridge a gap narrower than they are.
+    test('Should keep the dash pattern at the same period for any width', () => {
+        const runs = (width: number) => {
+            const columns = [...new Set(strokeLine(ctx => {
+                ctx.lineDash = [4, 8];
+                ctx.lineWidth = width;
+            }).map(dot => dot[0]))].sort(comparitorNumeric);
+
+            return columns.filter((column, index) => index === 0 || column !== columns[index - 1] + 1).length;
+        };
+
+        expect(runs(1)).toBe(2);
+        expect(runs(3)).toBe(2);
+        expect(runs(5)).toBe(2);
+    });
+
+    test('Should thicken a dashed stroke within each dash', () => {
+        const dashed = strokeLine(ctx => {
+            ctx.lineDash = [4, 8];
+            ctx.lineWidth = 3;
+        });
+
+        expect(thicknessAt(dashed, 1)).toBe(3);
+    });
+
+    test('Should leave fills at their traced geometry', () => {
+        const rasterizer = createSpyRasterizer(20, 5);
+        const ctx = createContext(createMockOutput(20, 5), {
+            rasterizer,
+        });
+
+        ctx.fill = '#ffffff';
+        ctx.lineWidth = 9;
+
+        const path = ctx.createPath();
+
+        path.rect(2, 2, 6, 6);
+
+        ctx.markRenderStart();
+        ctx.applyFill(path);
+        ctx.markRenderEnd();
+
+        expect(rasterizer.pixels.every(([x]) => x >= 2 && x <= 8)).toBe(true);
     });
 
 });

--- a/sandbox/node/package.json
+++ b/sandbox/node/package.json
@@ -7,7 +7,8 @@
         "static": "npx tsx static.ts",
         "animated": "npx tsx animated.ts",
         "chart": "npx tsx chart.ts",
-        "charts": "npx tsx charts.ts"
+        "charts": "npx tsx charts.ts",
+        "sankey": "npx tsx sankey.ts"
     },
     "dependencies": {
         "@ripl/charts": "1.0.0-beta.0",

--- a/sandbox/node/sankey.ts
+++ b/sandbox/node/sankey.ts
@@ -1,0 +1,74 @@
+import '@ripl/node';
+
+import {
+    createContext,
+    createTerminalOutput,
+} from '@ripl/node';
+
+import {
+    createSankeyChart,
+} from '@ripl/charts';
+
+// A Sankey carries its data entirely in stroke width, so it is the sharpest test of a backend's
+// stroke geometry: without it every link renders as the same hairline curve.
+const output = createTerminalOutput();
+const context = createContext(output);
+
+createSankeyChart(context, {
+    animation: false,
+    nodes: [
+        {
+            id: 'coal',
+            label: 'Coal',
+        },
+        {
+            id: 'gas',
+            label: 'Gas',
+        },
+        {
+            id: 'solar',
+            label: 'Solar',
+        },
+        {
+            id: 'grid',
+            label: 'Grid',
+        },
+        {
+            id: 'homes',
+            label: 'Homes',
+        },
+        {
+            id: 'industry',
+            label: 'Industry',
+        },
+    ],
+    links: [
+        {
+            source: 'coal',
+            target: 'grid',
+            value: 60,
+        },
+        {
+            source: 'gas',
+            target: 'grid',
+            value: 25,
+        },
+        {
+            source: 'solar',
+            target: 'grid',
+            value: 5,
+        },
+        {
+            source: 'grid',
+            target: 'homes',
+            value: 30,
+        },
+        {
+            source: 'grid',
+            target: 'industry',
+            value: 60,
+        },
+    ],
+});
+
+process.stdout.write('\n');


### PR DESCRIPTION
Stacked on #72 — review that first; this PR's diff is only the stroke-width commit.

## The problem

A Sankey rendered to a terminal draws every link as the same hairline curve. `@ripl/terminal` never read `lineWidth` — the identifier appeared exactly once in `packages/terminal/src`, in a JSDoc line saying it is ignored:

> **Stroke geometry is 1 pixel wide**: `lineWidth`, `lineCap`, `lineJoin` and `miterLimit` have no expressible form in a 1-bit raster and are ignored.

That rationale conflates colour depth with resolution. "1-bit" means a dot is lit or unlit; a braille cell holds **2×4** of them, so a 40×12 terminal is an 80×48 dot canvas. Thickness is geometry, and it is perfectly expressible.

The cost is not cosmetic. `SankeyLink` is stroke-only (`autoFill: false`) — a single cubic Bézier centreline with `lineWidth: link.width`, where widths run **20–200 logical px**. The flow magnitude *is* the stroke width, so the entire encoding was lost:

**Before** — links are dotted centrelines (`⠤⠔⠒⠒`, `⡠⠖⠁`), indistinguishable from each other:

```
        ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇           ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡏⠉⠑⠒⢤       ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇
        ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇           ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇    ⠉⠢⢄    ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇
        ⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⡄           ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇      ⠈⠑⠒⠤⠤⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇ Industry
        ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇      ⢀⠤⠔⠒⠒⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇           ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇
        ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇    ⡠⠖⠁    ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇           ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇
```

**After** — bands whose thickness tracks their value:

```
      ⢀⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇
     ⢠⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇ Homes
   ⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿Solar⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿Grid⣿⣿⣿⣿⡇
   ⢼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿Coal⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠿⠿⠿⠿⠿⠟⠛⠛⠛⠛⠛⠛⠛⠛⠛⠃
        ⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣴⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿Industry
```

Sankey is the worst case, not the only one. Auditing `packages/charts` for `lineWidth` that carries data rather than decoration:

| Chart | `lineWidth` encodes | Was |
|---|---|---|
| `sankey` | flow magnitude, 20–200px | **Total loss** |
| `radial-bar` | the ring band itself (`lineWidth: thickness`) | **Severe** — rings collapsed to concentric hairlines |
| `arc-diagram` | link value, 1–6px | Ordinal weight lost |
| `force-directed` | edge weight, 1–4px | Same |

Everything else uses `lineWidth` at 0.5–2px for decoration and was already correct. `gauge` and `chord` look like candidates but are safe — both draw **filled** shapes, which is precisely why they already worked.

## The fix

`thickenPixels` mirrors `dashPixels`, which #72 landed: a `PixelCallback` decorator. Every rasterizer in `algorithms.ts` terminates in a `plot` callback, and `_executeCommands` hands one callback to all of them via `RasterContext` — so decorating that callback covers lines, arcs, ellipses, both Béziers and rects with **no change to any rasterizer**. It keeps `dashPixels`' fast path too, returning `plot` unchanged for a hairline.

### Why the nesting order is load-bearing

```ts
this._executeCommands(path, this._dashPlot(this._thickPlot(plot)));
```

`dashPixels` measures arc length by counting the dots it receives. Dash must be the **outer** decorator so it counts *centreline* dots and thickens only the survivors. Inverted, it would advance the pattern once per stamped dot and stretch every gap by roughly the brush area. There is a test for exactly this.

Fills keep the raw `plot` — a fill has no stroke width — and stroked text is untouched.

### Brush geometry

A round brush, centred on a dot, so **thickness quantises to an odd number of dots**: widths of 1, 2, 3, 4, 5 give strokes 1, 3, 3, 5, 5 dots across — monotonic and symmetric. At Sankey's magnitudes ±1 dot is invisible. Dots are square *on screen* (a cell is 2 dots wide and 4 tall, and a monospace cell is roughly 1:2), so an isotropic brush reads as circular; no aspect correction needed.

The width is clamped to the raster's larger dimension. A brush wider than the grid is discarded entirely by `setPixel`'s bounds check, and the cost is `O(centrelineDots × width²)` — the clamp stops a pathological `lineWidth` burning millions of no-op stamps.

`lineCap`, `lineJoin` and `miterLimit` remain unimplemented — the round brush makes every cap and join round. That is now documented as *approximated*, not *dropped*, in all three places that previously claimed the opposite: the `TerminalContext` JSDoc, `packages/terminal/README.md`, and `docs/migrations/context-audit.md`.

## Verification

`yarn lint` 0 · `yarn typecheck` 0 · `yarn build` 0 · `yarn typecheck:dist` 0. `yarn test` **183 files / 2195 passed, 1 skipped, 1 todo**, against a branch point of 183 / 2184 / 1 / 1. Coverage **85.79 / 74.15 / 80.69 / 86.00**, up on all four from the branch point's 85.76 / 74.13 / 80.64 / 85.98 measured in the same tree. Node 24.18.1.

Branch-point proof: reverting `packages/terminal/src` fails 3 of the 5 new context tests. The other two pass either way **by design** and are labelled as such — "keep the dash pattern at the same period" is a composition guard that only becomes meaningful once thickening exists, and "leave fills at their traced geometry" is an over-correction guard. The `thickenPixels` unit tests cannot run at all at the branch point, since the export does not exist.

**No existing test changed.** The `TerminalContext line dash` suite from #72 uses the default `lineWidth`, so the fast path keeps it byte-identical — including `'Should draw a solid stroke with no dash pattern'`, whose `toHaveLength(20)` is an implicit 1-dot-wide assertion.

End-to-end: `sandbox/node/sankey.ts` (new, `yarn workspace ripl-node-demo sankey`) is the first Sankey terminal example in the repo. Both renders above were captured from it at 96×24.

Two tests were tightened during development after they caught real geometry rather than bugs: a round **cap** column is legitimately thinner than the middle of the stroke, and a round cap legitimately bridges a dash gap narrower than the stroke is wide — both are what canvas does.

## Breaking

Not breaking under the repo's convention — this makes a documented-as-ignored option take effect — but **any scene stroking wider than 1 now emits different terminal bytes**, which matters to anyone snapshotting output. Recorded as a **behaviour** entry in `docs/migrations/context-audit.md`.

## Follow-ups

`lineCap`, `lineJoin` and `miterLimit` stay unimplemented and always round. Implementing them means offsetting each flattened contour into a closed polygon and filling it — a different mechanism from the brush, and one that does not compose with dash as cleanly. Worth doing only if a real case needs butt caps or mitre joins; documented as a known approximation rather than left as a silent gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156vGhahurZUzVHRFeUXtnc)_