### PR TITLE
Fix SVG hit testing on transformed elements, and retire the last untestable deferrals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,31 @@ jobs:
           vite-config-path: vitest.config.ts
           json-summary-path: .reports/coverage/coverage-summary.json
           json-final-path: .reports/coverage/coverage-final.json
+
+  # The canvas↔SVG suites need a real browser: jsdom rasterizes nothing and implements no
+  # `SVGGeometryElement`, which is why these findings outlived the audit's unit tests.
+  browser:
+    name: Browser Parity
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Chromium
+        run: yarn playwright install --with-deps chromium
+
+      # Invoked through the workspace's own binary: `@playwright/test` is a root devDependency, so a
+      # `playwright` earlier on PATH would load these specs with a version that cannot parse them.
+      - name: Run browser parity suites
+        working-directory: packages/charts
+        run: yarn playwright test -c test/visual/playwright.config.ts parity.spec.ts hit.spec.ts

--- a/docs/migrations/context-audit.md
+++ b/docs/migrations/context-audit.md
@@ -331,14 +331,45 @@ deliberately **not** memoized and still re-encode per call. An `HTMLImageElement
 so swapping the source re-encodes; mutating a canvas source's pixels was never observable through
 this function's identity and still is not.
 
+### Hit testing
+
+**`SVGContext.isPointInPath`** and **`SVGContext.isPointInStroke`** — **behaviour**, and the one
+change that can move which element receives a click. The hit point is mapped into the target's own
+coordinate space through the live DOM's `getCTM()` before it reaches
+`isPointInFill`/`isPointInStroke`. Those methods are specified to read the point in the **element's
+own** space, but a hit arrives in the SVG root's, and `_setElementStyles` stamps a `transform` on
+the element while its ancestors are transformed `<g>`s — so **hit testing was wrong for every
+transformed element**, and increasingly wrong the further the transform moved it. Canvas was always
+correct: it leaves `hitTestHonorsTransform` false and maps the point through
+`Element.getWorldTransform`.
+
+A scene with no transforms is unaffected. A scene that compensated for the old behaviour — offsetting
+a hit target, or relying on a transformed element never being hit — changes, and should drop the
+compensation. `hitTestHonorsTransform` stays `true` on SVG: the context now genuinely handles the
+mapping, so a caller must still not pre-map the point.
+
+The inverse CTM is cached per element and cleared on every commit, because `getCTM()` flushes layout
+and a hit test runs against every rendered element on each pointer move.
+
 ### Known gaps
 
-Three findings need a real browser and are left for the Playwright harness: `<feDropShadow>`
-geometry scales with ancestor transforms where canvas shadows do not (**S-18**); `isPointInFill` is
-fed a root-space point but is specified in the element's own local space, so hit testing on a
-transformed element is wrong — the reconciler-cache lookup was fixed, the coordinate space was not
-(**S-19**, HIGH); and `filter="url(#shadow-…) blur(…)"` blurs the drop shadow along with the shape,
-where canvas derives the shadow from the filtered result (**S-20**).
+**S-18** and **S-20** are now **measured and pinned** rather than untested. Both are real, both are
+LOW-to-LOW-MEDIUM, and both are left as-is with a guard rather than partially fixed:
+
+- **S-18** — `<feDropShadow>` writes `dx`/`dy`/`stdDeviation` in the filter's user space, which
+  inherits every ancestor `<g>` transform; canvas shadow geometry is CTM-independent. Inside a
+  `scale(2)` group SVG casts the shadow at twice the offset and blur — a **14.3%** pixel divergence.
+  Not fixed because `<feDropShadow>` takes one scalar `stdDeviation` and an axis-aligned offset, so
+  counter-transforming closes the uniform-scale case and still cannot reproduce canvas under
+  rotation or a non-uniform scale.
+- **S-20** — `filter="url(#shadow-…) blur(…)"` blurs the drop shadow along with the shape, where
+  canvas derives the shadow from the filtered result — a **9.1%** divergence. Not fixed because
+  correcting the order means composing both into one `<filter>` chain rather than concatenating two
+  `filter` list entries.
+
+Both are asserted in `packages/charts/test/visual/parity.spec.ts` to stay inside a band around those
+measurements, from both sides: a regression that widens the gap fails, and so does a fix that closes
+it without updating the record.
 
 ## @ripl/dom
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -36,7 +36,9 @@
         "build": "tsdown",
         "test:visual": "playwright test -c test/visual/playwright.config.ts charts.spec.ts",
         "test:visual:update": "playwright test -c test/visual/playwright.config.ts charts.spec.ts --update-snapshots",
-        "test:parity": "playwright test -c test/visual/playwright.config.ts parity.spec.ts"
+        "test:parity": "playwright test -c test/visual/playwright.config.ts parity.spec.ts",
+        "test:hit": "playwright test -c test/visual/playwright.config.ts hit.spec.ts",
+        "test:browser": "playwright test -c test/visual/playwright.config.ts parity.spec.ts hit.spec.ts"
     },
     "dependencies": {
         "@ripl/canvas": "workspace:^",

--- a/packages/charts/test/visual/README.md
+++ b/packages/charts/test/visual/README.md
@@ -1,10 +1,15 @@
 # Chart visual tests
 
-Two Playwright suites share one Vite server and one browser:
+Three Playwright suites share one Vite server and one browser:
 
 - **`charts.spec.ts`** — snapshots of every chart against committed baselines.
 - **`parity.spec.ts`** — the canvas↔SVG parity harness, which diffs the two backends **against each
   other** rather than against a baseline.
+- **`hit.spec.ts`** — canvas↔SVG hit testing, which compares what a click *reaches* rather than
+  what the backends *paint*.
+
+The directory is named for the first of those, but what the three share is needing a real browser,
+not comparing pixels. `hit.spec.ts` takes no screenshots.
 
 ## Visual regression (`charts.spec.ts`)
 
@@ -35,8 +40,32 @@ resolving against the group's composed box (`canvas.md` 3 / `svg.md` S-4), and g
 compositing multiplicatively (`canvas.md` 11 / `svg.md` S-5). Both currently measure a mismatch of
 **0** with a maximum channel delta of 1; reverting either fix moves a quarter of the frame or more.
 
+A second describe block covers `KNOWN_DIVERGENCE_SCENES` — gaps that were **decided rather than
+fixed**, each asserted to stay inside a band around its measured mismatch. The assertion runs from
+both sides, so a regression that widens the gap fails and so does a fix that closes it without
+updating the record. Currently `group-shadow` (S-18) at 14.3% and `filter-shadow-order` (S-20) at
+9.1%; see `parity-ids.ts` for why neither is fixed.
+
 ```bash
 yarn workspace @ripl/charts test:parity
+```
+
+## Canvas ↔ SVG hit testing (`hit.spec.ts`)
+
+Pins `svg.md` S-19. `SVGContext._isPointIn` used to hand `isPointInFill`/`isPointInStroke` a point
+in the SVG root's user space, which SVG 2 specifies to read in the **element's own** space, so hit
+testing was wrong for anything transformed. A pixel diff cannot see that, hence a separate suite.
+
+Every scene transforms its target and clicks a point that lies inside the rendered shape but
+**outside** its untransformed geometry, so a hit test that skips the mapping has to miss. Canvas maps
+the point itself through `Element.getWorldTransform`, so it is the reference — and the spec asserts
+canvas hits too, which is what proves the click point is valid rather than merely unreachable.
+
+```bash
+yarn workspace @ripl/charts test:hit
+
+# Or both browser suites together, which is what CI runs
+yarn workspace @ripl/charts test:browser
 ```
 
 ## Running
@@ -52,6 +81,9 @@ yarn workspace @ripl/charts test:visual
 
 # Diff the canvas and SVG backends against each other
 yarn workspace @ripl/charts test:parity
+
+# Compare which element a click reaches on each backend
+yarn workspace @ripl/charts test:hit
 ```
 
 `@playwright/test` is a root devDependency, so a workspace script only finds it when no other

--- a/packages/charts/test/visual/hit-ids.ts
+++ b/packages/charts/test/visual/hit-ids.ts
@@ -1,0 +1,87 @@
+/**
+ * The canonical list of canvas↔SVG hit-test scenes. Imported by both `hit.ts` (to build each scene
+ * and record what a click reached) and `hit.spec.ts` (to drive the click) so the two never drift.
+ *
+ * These pin `svg.md` S-19: `SVGContext._isPointIn` used to hand `isPointInFill`/`isPointInStroke` a
+ * point in the SVG root's user space, which SVG 2 specifies to read in the **element's own** space.
+ * Every scene therefore transforms its target so the two spaces disagree, and clicks a point that
+ * lies inside the rendered shape but **outside** its untransformed geometry — a hit test that
+ * skips the mapping has to miss.
+ *
+ * Canvas maps the point itself through `Element.getWorldTransform`, so it is the reference: an
+ * SVG-only failure is S-19 and nothing else.
+ */
+
+/** A backend a hit scene is mounted through. */
+export type HitBackend = 'canvas' | 'svg';
+
+/** The backends every scene is mounted through, in mount order. */
+export const HIT_BACKENDS = ['canvas', 'svg'] as const satisfies readonly HitBackend[];
+
+/** A single hit-test scene: what to build, where to click, and what the click must reach. */
+export interface HitScene {
+    /** Scene identifier, used for the mount's `data-hit` attribute and the test title. */
+    id: string;
+    /** What the scene transforms, for the test title to read as a sentence. */
+    description: string;
+    /** The point, in surface coordinates, the spec clicks on every backend. */
+    point: [number, number];
+    /** Id of the element the click must reach on every backend. */
+    target: string;
+}
+
+/** The scenes, ordered by how sharply they discriminate an unmapped hit point. */
+export const HIT_SCENES = [
+    {
+        id: 'translated',
+        description: 'a rect inside a translated group',
+        point: [130, 70],
+        target: 'translated-target',
+    },
+    {
+        id: 'scaled',
+        description: 'a rect inside a scaled group',
+        point: [70, 70],
+        target: 'scaled-target',
+    },
+    {
+        id: 'rotated',
+        description: 'a rect rotated about its own centre',
+        point: [122, 102],
+        target: 'rotated-target',
+    },
+] as const satisfies readonly HitScene[];
+
+/** A single hit-scene id. */
+export type HitSceneId = typeof HIT_SCENES[number]['id'];
+
+/** The width, in CSS pixels, every hit surface is mounted at. */
+export const HIT_WIDTH = 200;
+
+/** The height, in CSS pixels, every hit surface is mounted at. */
+export const HIT_HEIGHT = 140;
+
+/** One element-level `click` the harness observed. */
+export interface HitRecord {
+    /** The scene whose surface was clicked. */
+    scene: string;
+    /** The backend that surface was rendered through. */
+    backend: HitBackend;
+    /** Id of the element that received the click. */
+    target: string;
+}
+
+/** The recorder the hit page exposes to Playwright. */
+export interface HitHarness {
+    /** Every element-level `click` observed since the last {@link HitHarness.reset}, in order. */
+    records: HitRecord[];
+    /** Drops every recorded click, so one scene's assertions cannot see another's. */
+    reset(): void;
+}
+
+declare global {
+    interface Window {
+        /** The hit-test recorder, installed by `hit.ts` once every scene has rendered. */
+        riplHit: HitHarness;
+    }
+}

--- a/packages/charts/test/visual/hit.html
+++ b/packages/charts/test/visual/hit.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Ripl canvas ↔ svg hit-test harness</title>
+    <style>
+        body { margin: 0; padding: 16px; display: flex; flex-wrap: wrap; gap: 16px; background: #fff; font-family: sans-serif; }
+        body > div { border: 0; }
+    </style>
+</head>
+<body>
+    <script type="module" src="./hit.ts"></script>
+</body>
+</html>

--- a/packages/charts/test/visual/hit.spec.ts
+++ b/packages/charts/test/visual/hit.spec.ts
@@ -1,0 +1,40 @@
+import {
+    expect,
+    test,
+} from '@playwright/test';
+
+import {
+    HIT_BACKENDS,
+    HIT_SCENES,
+} from './hit-ids';
+
+test.describe('canvas ↔ svg hit testing', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/hit.html');
+        // Wait until the harness signals every scene has rendered through both backends.
+        await page.waitForSelector('body[data-ready="true"]');
+        await page.evaluate(() => window.riplHit.reset());
+    });
+
+    for (const scene of HIT_SCENES) {
+        test(`${scene.description} is hit at the same point on both backends`, async ({ page }) => {
+            for (const backend of HIT_BACKENDS) {
+                const box = await page.locator(`[data-hit="${scene.id}"][data-backend="${backend}"]`).boundingBox();
+
+                expect(box, `${backend} surface is not laid out`).not.toBeNull();
+
+                await page.mouse.click(box!.x + scene.point[0], box!.y + scene.point[1]);
+            }
+
+            const records = await page.evaluate(() => window.riplHit.records);
+
+            // Asserted per backend rather than as a set: canvas passing is what proves the click point is valid.
+            for (const backend of HIT_BACKENDS) {
+                expect(
+                    records.filter(record => record.backend === backend).map(record => record.target),
+                    `${backend} did not deliver the click to ${scene.target}`
+                ).toEqual([scene.target]);
+            }
+        });
+    }
+});

--- a/packages/charts/test/visual/hit.ts
+++ b/packages/charts/test/visual/hit.ts
@@ -1,0 +1,168 @@
+/**
+ * Canvas↔SVG hit-test harness: every scene in `hit-ids.ts` is mounted twice — once through
+ * `@ripl/canvas`, once through `@ripl/svg` — with a `click` listener on the transformed target, and
+ * the element each click reaches is recorded for the spec to compare.
+ *
+ * This is the non-pixel half of the parity work. `parity.ts` diffs what the two backends *paint*;
+ * a hit-test defect is invisible to that, so this diffs what they *hit*.
+ */
+
+// Side-effect import: `@ripl/web` registers the browser factory (text measurement, rAF, DPR).
+import '@ripl/web';
+
+import {
+    HIT_BACKENDS,
+    HIT_HEIGHT,
+    HIT_SCENES,
+    HIT_WIDTH,
+} from './hit-ids';
+
+import type {
+    HitBackend,
+    HitRecord,
+    HitSceneId,
+} from './hit-ids';
+
+import {
+    createGroup,
+    createRect,
+    createScene,
+} from '@ripl/core';
+
+import type {
+    Context,
+    Element,
+    Scene,
+} from '@ripl/core';
+
+import {
+    createContext as createCanvasContext,
+} from '@ripl/canvas';
+
+import {
+    createContext as createSVGContext,
+} from '@ripl/svg';
+
+const FILL = 'rgb(64, 128, 255)';
+
+const records: HitRecord[] = [];
+
+interface TargetBox {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+function createTarget(id: string, box: TargetBox, report: (target: string) => void, transform?: Record<string, number>): Element {
+    const rect = createRect({
+        id,
+        fill: FILL,
+        ...box,
+        ...transform,
+    });
+
+    rect.on('click', () => report(id));
+
+    return rect;
+}
+
+const SCENES: Record<HitSceneId, (context: Context, report: (target: string) => void) => Scene> = {
+    // Rendered at x 100–160; the authored rect sits at x 10–70, so the clicked centre misses it unmapped.
+    translated: (context, report) => createScene(context, {
+        children: [
+            createGroup({
+                id: 'translated-group',
+                translateX: 90,
+                children: [
+                    createTarget('translated-target', {
+                        x: 10,
+                        y: 40,
+                        width: 60,
+                        height: 60,
+                    }, report),
+                ],
+            }),
+        ],
+    }),
+    // Scaling about the default origin renders 20–50 as 40–100, so the clicked centre lands outside the authored box.
+    scaled: (context, report) => createScene(context, {
+        children: [
+            createGroup({
+                id: 'scaled-group',
+                transformScaleX: 2,
+                transformScaleY: 2,
+                children: [
+                    createTarget('scaled-target', {
+                        x: 20,
+                        y: 20,
+                        width: 30,
+                        height: 30,
+                    }, report),
+                ],
+            }),
+        ],
+    }),
+    // The clicked point sits on the rotated long axis but below the authored rect's lower edge.
+    rotated: (context, report) => createScene(context, {
+        children: [
+            createTarget('rotated-target', {
+                x: 40,
+                y: 50,
+                width: 100,
+                height: 40,
+            }, report, {
+                rotation: Math.PI / 4,
+                transformOriginX: 90,
+                transformOriginY: 70,
+            }),
+        ],
+    }),
+};
+
+const CONTEXTS: Record<HitBackend, (host: HTMLElement) => Context> = {
+    canvas: host => createCanvasContext(host),
+    svg: host => createSVGContext(host),
+};
+
+function mount(id: HitSceneId, backend: HitBackend): HTMLElement {
+    const el = document.createElement('div');
+
+    el.style.width = `${HIT_WIDTH}px`;
+    el.style.height = `${HIT_HEIGHT}px`;
+    el.style.background = '#ffffff';
+    el.setAttribute('data-hit', id);
+    el.setAttribute('data-backend', backend);
+
+    document.body.appendChild(el);
+
+    return el;
+}
+
+HIT_SCENES.forEach(scene => {
+    HIT_BACKENDS.forEach(backend => {
+        const host = mount(scene.id, backend);
+        const report = (target: string) => records.push({
+            scene: scene.id,
+            backend,
+            target,
+        });
+
+        SCENES[scene.id](CONTEXTS[backend](host), report).render();
+    });
+});
+
+window.riplHit = {
+    records,
+    reset() {
+        records.length = 0;
+    },
+};
+
+const mounted = HIT_SCENES.every(scene => document.querySelectorAll(`[data-hit="${scene.id}"]`).length === HIT_BACKENDS.length);
+
+requestAnimationFrame(() => {
+    if (mounted) {
+        document.body.setAttribute('data-ready', 'true');
+    }
+});

--- a/packages/charts/test/visual/parity-ids.ts
+++ b/packages/charts/test/visual/parity-ids.ts
@@ -15,8 +15,43 @@ export const PARITY_SCENE_IDS = [
     'group-opacity',
 ] as const;
 
-/** A single parity scene id. */
-export type ParitySceneId = typeof PARITY_SCENE_IDS[number];
+/**
+ * Scenes where canvas and SVG are **known** to diverge, each pinned to a band around the mismatch
+ * measured when it was characterized rather than to the parity threshold. They keep a decided gap
+ * honest: the suite stays green, the number is on the record, and either direction fails — a
+ * regression that widens the gap, or a fix that closes it without anyone updating the band.
+ *
+ * - `group-shadow` — `svg.md` S-18, measured at **14.3%**. `<feDropShadow>` writes
+ *   `dx`/`dy`/`stdDeviation` in the filter's user space, which inherits every ancestor `<g>`
+ *   transform; canvas shadow geometry is explicitly CTM-independent, so inside a `scale(2)` group
+ *   SVG casts the shadow at twice the offset and blur. Not fixed: `<feDropShadow>` takes one scalar
+ *   `stdDeviation` and an axis-aligned offset, so counter-transforming it closes the uniform-scale
+ *   case and still cannot reproduce canvas under rotation or a non-uniform scale.
+ * - `filter-shadow-order` — `svg.md` S-20, measured at **9.1%**. `_resolveElementFilter` emits
+ *   `filter="url(#shadow-…) <cssFilter>"`, so a CSS `blur()` blurs the shape **and** its drop
+ *   shadow; canvas derives the shadow from the filtered result and does not re-blur it. Not fixed:
+ *   correcting the order means composing both into one `<filter>` chain rather than concatenating
+ *   two `filter` list entries.
+ */
+export const KNOWN_DIVERGENCE_SCENES = [
+    {
+        id: 'group-shadow',
+        maxMismatch: 0.18,
+    },
+    {
+        id: 'filter-shadow-order',
+        maxMismatch: 0.12,
+    },
+] as const;
+
+/** A single parity scene id, whether it must match or is a pinned known divergence. */
+export type ParitySceneId = typeof PARITY_SCENE_IDS[number] | typeof KNOWN_DIVERGENCE_SCENES[number]['id'];
+
+/** Every scene the harness mounts, in mount order. */
+export const ALL_PARITY_SCENE_IDS = [
+    ...PARITY_SCENE_IDS,
+    ...KNOWN_DIVERGENCE_SCENES.map(scene => scene.id),
+] as ParitySceneId[];
 
 /** The width, in CSS pixels, every parity surface is mounted at. */
 export const PARITY_WIDTH = 260;

--- a/packages/charts/test/visual/parity.spec.ts
+++ b/packages/charts/test/visual/parity.spec.ts
@@ -3,10 +3,19 @@ import {
     test,
 } from '@playwright/test';
 
+import type {
+    Page,
+} from '@playwright/test';
+
 import {
+    KNOWN_DIVERGENCE_SCENES,
     PARITY_HEIGHT,
     PARITY_SCENE_IDS,
     PARITY_WIDTH,
+} from './parity-ids';
+
+import type {
+    ParitySceneId,
 } from './parity-ids';
 
 /** Per-channel difference a pixel may vary by before it counts as a mismatch; the two backends measure at 1. */
@@ -15,26 +24,44 @@ const TOLERANCE = 4;
 /** Fraction of pixels allowed to exceed {@link TOLERANCE}. Both seeded divergences move a quarter of the frame or more. */
 const MAX_MISMATCH = 0.001;
 
-test.describe('canvas ↔ svg parity', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto('/parity.html');
-        // Wait until the harness signals every scene has rendered through both backends.
-        await page.waitForSelector('body[data-ready="true"]');
-    });
+async function measure(page: Page, scene: ParitySceneId) {
+    const canvas = await page.locator(`[data-parity="${scene}"][data-backend="canvas"]`).screenshot();
+    const svg = await page.locator(`[data-parity="${scene}"][data-backend="svg"]`).screenshot();
 
+    return page.evaluate(
+        ([left, right, tolerance]) => window.riplParity.diff(left as string, right as string, tolerance as number),
+        [canvas.toString('base64'), svg.toString('base64'), TOLERANCE] as const
+    );
+}
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/parity.html');
+    // Wait until the harness signals every scene has rendered through both backends.
+    await page.waitForSelector('body[data-ready="true"]');
+});
+
+test.describe('canvas ↔ svg parity', () => {
     for (const scene of PARITY_SCENE_IDS) {
         test(`${scene} renders identically on canvas and svg`, async ({ page }) => {
-            const canvas = await page.locator(`[data-parity="${scene}"][data-backend="canvas"]`).screenshot();
-            const svg = await page.locator(`[data-parity="${scene}"][data-backend="svg"]`).screenshot();
-
-            const result = await page.evaluate(
-                ([left, right, tolerance]) => window.riplParity.diff(left as string, right as string, tolerance as number),
-                [canvas.toString('base64'), svg.toString('base64'), TOLERANCE] as const
-            );
+            const result = await measure(page, scene);
 
             expect(result.width).toBe(PARITY_WIDTH);
             expect(result.height).toBe(PARITY_HEIGHT);
             expect(result.mismatch).toBeLessThanOrEqual(MAX_MISMATCH);
+        });
+    }
+});
+
+test.describe('canvas ↔ svg known divergences', () => {
+    for (const scene of KNOWN_DIVERGENCE_SCENES) {
+        // Asserted from both sides: below the band is a fix nobody recorded, above it is a regression.
+        test(`${scene.id} diverges within its recorded band`, async ({ page }) => {
+            const result = await measure(page, scene.id);
+
+            expect(result.width).toBe(PARITY_WIDTH);
+            expect(result.height).toBe(PARITY_HEIGHT);
+            expect(result.mismatch).toBeGreaterThan(MAX_MISMATCH);
+            expect(result.mismatch).toBeLessThanOrEqual(scene.maxMismatch);
         });
     }
 });

--- a/packages/charts/test/visual/parity.ts
+++ b/packages/charts/test/visual/parity.ts
@@ -12,8 +12,8 @@
 import '@ripl/web';
 
 import {
+    ALL_PARITY_SCENE_IDS,
     PARITY_HEIGHT,
-    PARITY_SCENE_IDS,
     PARITY_WIDTH,
 } from './parity-ids';
 
@@ -45,6 +45,7 @@ type ParityBackend = 'canvas' | 'svg';
 
 const GRADIENT = 'linear-gradient(90deg, rgb(255, 0, 0), rgb(0, 0, 255))';
 const OPAQUE_BLACK = 'rgb(0, 0, 0)';
+const SHADOW = 'rgb(255, 0, 0)';
 
 const LEFT = {
     x: 20,
@@ -99,6 +100,45 @@ const SCENES: Record<ParitySceneId, (context: Context) => Scene> = {
                         ...RIGHT,
                     }),
                 ],
+            }),
+        ],
+    }),
+    // S-18: the scaled group doubles the SVG shadow's offset and blur; canvas ignores the CTM.
+    'group-shadow': context => createScene(context, {
+        children: [
+            createGroup({
+                id: 'shadow-scale',
+                transformScaleX: 2,
+                transformScaleY: 2,
+                children: [
+                    createRect({
+                        id: 'shadow-rect',
+                        fill: OPAQUE_BLACK,
+                        shadowColor: SHADOW,
+                        shadowOffsetX: 4,
+                        shadowOffsetY: 4,
+                        shadowBlur: 8,
+                        x: 20,
+                        y: 15,
+                        width: 45,
+                        height: 40,
+                    }),
+                ],
+            }),
+        ],
+    }),
+    // S-20: SVG applies the CSS blur to the shape and its drop shadow; canvas blurs only the shape.
+    'filter-shadow-order': context => createScene(context, {
+        children: [
+            createRect({
+                id: 'filtered-shadow',
+                fill: OPAQUE_BLACK,
+                filter: 'blur(4px)',
+                shadowColor: SHADOW,
+                shadowOffsetX: 10,
+                shadowOffsetY: 10,
+                shadowBlur: 4,
+                ...LEFT,
             }),
         ],
     }),
@@ -185,7 +225,7 @@ async function diff(left: string, right: string, tolerance: number): Promise<Par
     };
 }
 
-PARITY_SCENE_IDS.forEach(id => {
+ALL_PARITY_SCENE_IDS.forEach(id => {
     Object.entries(CONTEXTS).forEach(([backend, createContext]) => {
         SCENES[id](createContext(mount(id, backend as ParityBackend))).render();
     });
@@ -195,7 +235,7 @@ window.riplParity = {
     diff,
 };
 
-const mounted = PARITY_SCENE_IDS.every(id => document.querySelectorAll(`[data-parity="${id}"]`).length === 2);
+const mounted = ALL_PARITY_SCENE_IDS.every(id => document.querySelectorAll(`[data-parity="${id}"]`).length === 2);
 
 requestAnimationFrame(() => {
     if (mounted) {

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -87,6 +87,7 @@ import type {
 
 import {
     stringUniqueId,
+    typeIsFunction,
 } from '@ripl/utilities';
 
 type SVGVNode = VNode<SVGContextElement>;
@@ -109,6 +110,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     private _clipScopeStack: SVGVNode[];
     private _currentParentVNode: SVGVNode;
     private _vnodeStack: SVGVNode[];
+    private _inverseCTMCache: Map<Element, DOMMatrix | null>;
 
     constructor(target: string | HTMLElement, options?: ContextOptions) {
         const svg = createSVGElement('svg');
@@ -125,7 +127,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
 
         super('svg', target, svg, options);
 
-        // SVG hit testing runs against live DOM geometry, which already composes ancestor `<g>` transforms.
+        // `_isPointIn` maps the hit point through the live DOM's own CTM, so callers must not pre-map it.
         this.hitTestHonorsTransform = true;
         this._vtree = {
             id: '__root__',
@@ -158,6 +160,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         this._shadowCache = new Map();
         this._usedDefs = new Set();
         this._clipScopeStack = [];
+        this._inverseCTMCache = new Map();
         this._defs = createSVGElement('defs');
         this.element.appendChild(this._defs);
 
@@ -347,17 +350,40 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             : this.element.getElementById(id);
     }
 
+    // `getCTM` flushes layout, and a hit test runs against every rendered element on each pointer move.
+    private _resolveInverseCTM(element: SVGGraphicsElement): DOMMatrix | null {
+        if (this._inverseCTMCache.has(element)) {
+            return this._inverseCTMCache.get(element) ?? null;
+        }
+
+        // A partial DOM declares neither `getCTM` nor a transform to map through, so the raw point stands.
+        const ctm = typeIsFunction(element.getCTM) ? element.getCTM() : null;
+        const inverse = ctm ? ctm.inverse() : null;
+
+        this._inverseCTMCache.set(element, inverse);
+
+        return inverse;
+    }
+
     private _isPointIn(method: 'stroke' | 'fill', path: SVGPath, x: number, y: number) {
         const element = this._resolveHitNode(path.id);
+
+        if (!(element instanceof SVGGeometryElement)) {
+            return false;
+        }
+
         const point = this.element.createSVGPoint();
 
         point.x = x;
         point.y = y;
 
-        return element instanceof SVGGeometryElement && (method === 'stroke'
-            ? element.isPointInStroke(point)
-            : element.isPointInFill(point)
-        );
+        // SVG 2 reads this point in the element's own space, but a hit arrives in the root's.
+        const inverse = this._resolveInverseCTM(element);
+        const local = inverse ? point.matrixTransform(inverse) : point;
+
+        return method === 'stroke'
+            ? element.isPointInStroke(local)
+            : element.isPointInFill(local);
     }
 
     private _addToVTree(contextElement: SVGContextElement): void {
@@ -407,6 +433,9 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     private _commit() {
         this._render();
         this._sweepDefs();
+
+        // A transform can change on any frame, so the inverses cannot outlive the DOM they were read from.
+        this._inverseCTMCache.clear();
     }
 
     /** Signals the start of a render pass; resets the virtual DOM tree, group-nesting pointer, and `<defs>` usage tracking at the outermost depth. */
@@ -774,6 +803,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         this._clipCache.clear();
         this._shadowCache.clear();
         this._usedDefs.clear();
+        this._inverseCTMCache.clear();
 
         this._vtree = {
             id: '__root__',

--- a/packages/svg/test/commit.test.ts
+++ b/packages/svg/test/commit.test.ts
@@ -97,9 +97,22 @@ describe('SVG commit', () => {
         ctx.element.createSVGPoint = vi.fn(() => ({
             x: 0,
             y: 0,
+            matrixTransform: (matrix: unknown) => `mapped:${matrix}`,
         })) as never;
 
         return isPointInFill;
+    }
+
+    function stubCTM(id: string) {
+        const getCTM = vi.fn(() => ({
+            inverse: () => 'inverse-ctm',
+        }));
+
+        Object.assign(ctx.element.querySelector(`#${id}`)!, {
+            getCTM,
+        });
+
+        return getCTM;
     }
 
     test('Should hit test against the node committed in the same pass', () => {
@@ -133,6 +146,50 @@ describe('SVG commit', () => {
 
         expect(ctx.isPointInPath(ctx.createPath('unknown'), 5, 5)).toBe(false);
         expect(getElementById).toHaveBeenCalledWith('unknown');
+    });
+
+    // S-19: the point arrives in the root's space, but SVG 2 reads it in the element's own.
+    test('Should map the hit point into the element space through the inverse CTM', () => {
+        renderPass(() => drawRect('hit'));
+
+        const isPointInFill = makeHitTestable('hit');
+
+        stubCTM('hit');
+
+        ctx.isPointInPath(ctx.createPath('hit'), 5, 5);
+
+        expect(isPointInFill).toHaveBeenCalledWith('mapped:inverse-ctm');
+    });
+
+    // jsdom declares no `getCTM`, and neither does any other partial DOM this could run under.
+    test('Should hit test against the raw point when the DOM declares no getCTM', () => {
+        renderPass(() => drawRect('hit'));
+
+        const isPointInFill = makeHitTestable('hit');
+
+        expect(ctx.isPointInPath(ctx.createPath('hit'), 5, 5)).toBe(true);
+        expect(isPointInFill).toHaveBeenCalledWith(expect.objectContaining({
+            x: 5,
+            y: 5,
+        }));
+    });
+
+    test('Should re-read the CTM after a commit rather than reusing the previous frame’s', () => {
+        renderPass(() => drawRect('hit'));
+
+        makeHitTestable('hit');
+
+        const getCTM = stubCTM('hit');
+
+        ctx.isPointInPath(ctx.createPath('hit'), 5, 5);
+        ctx.isPointInPath(ctx.createPath('hit'), 5, 5);
+
+        expect(getCTM).toHaveBeenCalledTimes(1);
+
+        renderPass(() => drawRect('hit'));
+        ctx.isPointInPath(ctx.createPath('hit'), 5, 5);
+
+        expect(getCTM).toHaveBeenCalledTimes(2);
     });
 
 });


### PR DESCRIPTION
Closes **S-19**, the only HIGH/MEDIUM finding the rendering-context audit left unfixed, and retires the deferral class it belonged to.

**Stacked on #74** — retarget to `main` once that merges.

## S-19

`SVGContext._isPointIn` built an `SVGPoint` from coordinates that arrive in the **SVG root's** user space and handed it straight to `isPointInFill`/`isPointInStroke`. SVG 2 specifies both to read the point in the **element's own** local space, and `_setElementStyles` stamps a `transform` on the element while its ancestors are transformed `&lt;g&gt;`s — so hit testing was wrong for every transformed element, and further wrong the further the transform moved it.

The compounding error was one line above it:

```ts
// SVG hit testing runs against live DOM geometry, which already composes ancestor `<g>` transforms.
this.hitTestHonorsTransform = true;
```

That states the reason backwards. The DOM composing those transforms is precisely why the point **must** be mapped through them — instead the flag told `Shape2D.intersectsWith` not to map it either, so both halves skipped the mapping, each believing the other handled it. Canvas leaves the flag `false` and maps via `getWorldTransform()`, which is why **canvas was always correct** and is the reference for every test here.

The point is now mapped through the live DOM's `getCTM()` rather than ripl's own `getWorldTransform()`. `getCTM()` is ground truth for what was actually rendered and cannot drift from what the context believes it stamped — and a drift between the two is exactly what the parity harness exists to catch. `hitTestHonorsTransform` stays `true`; it now describes something true rather than aspirational.

Two details the fix needed:

- **Layout cost.** `getCTM()` flushes layout and a hit test runs against every rendered element on each pointer move, so the inverse is cached per element and cleared in `_commit()` — transforms change per frame, so `_domCache`'s construct-once lifetime was the wrong one to copy.
- **Partial DOMs.** jsdom declares no `getCTM` at all, which surfaced as two red tests in `packages/svg/test/commit.test.ts`. A runtime without it degrades to the raw point rather than throwing, following the `typeIsFunction` guard `@ripl/core`'s image element already uses for this class of runtime.

## Proving it

A screenshot diff cannot see a hit-test defect, so `parity.spec.ts` was never going to catch this. **`hit.spec.ts`** is the non-pixel half: it compares what a click *reaches* on each backend rather than what they paint, reusing the same Vite server, Playwright config and `CHROMIUM_PATH` wiring.

Every scene transforms its target and clicks a point inside the rendered shape but **outside its untransformed geometry**, so an unmapped hit test has to miss:

| Scene | Transform | Click | Authored geometry |
|---|---|---|---|
| `translated` | group `translateX: 90` | (130, 70) | x 10–70 |
| `scaled` | group `scale(2)` | (70, 70) | x 20–50 |
| `rotated` | rect rotated 45° about its centre | (122, 102) | y 50–90 |

**The branch-point check, which is the actual proof:**

```
✘ a rect inside a translated group …  → svg did not deliver the click to translated-target
✘ a rect inside a scaled group …      → svg did not deliver the click to scaled-target
✘ a rect rotated about its own centre → svg did not deliver the click to rotated-target
3 failed
```

All three fail with the fix reverted, and **only on SVG** — canvas delivered every click, which is what proves the click points are valid rather than merely unreachable. The spec asserts both backends deliberately for that reason.

The mapping is also pinned at unit level in `packages/svg/test/commit.test.ts` (3 new cases: the inverse-CTM mapping, the partial-DOM fallback, and that the cache is re-read after a commit). Reverting the mapping fails 2 of the file's 9.

## S-18 and S-20 — the rest of the deferral class

Of the audit's eleven deferrals, ten are reasoned design decisions. **Three shared one reason: "jsdom rasterizes nothing and implements no `SVGGeometryElement`."** #74's harness dissolved that reason for all three, so closing the audit honestly means retiring the class, not just its worst member.

Both are now measured as parity scenes:

| Finding | Divergence | Cause |
|---|---|---|
| **S-18** `group-shadow` | **14.3%** | `&lt;feDropShadow&gt;` writes `dx`/`dy`/`stdDeviation` in the filter's user space, inheriting ancestor `&lt;g&gt;` transforms; canvas shadow geometry is CTM-independent |
| **S-20** `filter-shadow-order` | **9.1%** | `filter="url(#shadow-…) blur(…)"` blurs the shape **and** its drop shadow; canvas derives the shadow from the filtered result |

**Neither is fixed, and both now have a guard instead of silence.** S-18 is not fixable in general: `&lt;feDropShadow&gt;` takes one scalar `stdDeviation` and an axis-aligned offset, so counter-transforming closes the uniform-scale case and still cannot reproduce canvas under rotation or a non-uniform scale — a partial fix that quietly keeps the hard case is worse than a measured gap. S-20 needs both filters composed into one `&lt;filter&gt;` chain rather than two `filter` list entries, which is a larger change than a LOW finding earns.

A `KNOWN_DIVERGENCE_SCENES` block asserts each stays inside a band around its measurement, **from both sides**: a regression that widens the gap fails, and so does a fix that closes it without updating the record.

## CI

**Neither browser suite ran in CI** — `.github/workflows/test.yml` runs `yarn test`, which is vitest only — so the S-19 regression test would have landed gating nothing. A `Browser Parity` job now runs both. It invokes the workspace's own binary directly, because `@playwright/test` is a root devDependency and a `playwright` earlier on `PATH` cannot parse these specs (the failure mode already documented in the visual README).

## Verification

| Gate | Result |
|---|---|
| `yarn lint` | 0 |
| `yarn typecheck` | 0 |
| `yarn build` | 0 |
| `yarn typecheck:dist` | 0 |
| `yarn test` | **193 files / 2424 passed**, 2 skipped, 1 todo |
| Coverage | 89.22 / 76.61 / 82.89 / 89.55 |
| `parity.spec.ts` + `hit.spec.ts` | **7 passed** |
| Branch-point check | **3 failed, SVG only** |

## Breaking

- **`SVGContext.isPointInPath` / `isPointInStroke`** — a click over a transformed SVG element now resolves to the element actually under the cursor. A scene that compensated for the old behaviour — offsetting a hit target, or relying on a transformed element never being hit — should drop the compensation. Untransformed scenes are byte-identical.

Recorded in `docs/migrations/context-audit.md` under a new `@ripl/svg` → Hit testing section, with S-18 and S-20's dispositions replacing the old "three findings need a real browser" note.

## Honest limits

- **`isPointInFill`'s point space is verified against one engine.** SVG 2 says element-local and Chromium implements that, but engines have historically differed here. The harness is Chromium-only.
- **`test/visual/` now holds a non-visual spec.** What the three suites share is needing a real browser, not comparing pixels. Renaming the directory was out of scope; the README says so.
- **The 26 chart baselines are still failing** and still need a per-chart judgement call. Unchanged by this PR, and `charts.spec.ts` is not in the new CI job for that reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156vGhahurZUzVHRFeUXtnc)_