### PR TITLE
Place module constants above the functions and classes that use them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,7 +412,7 @@ Files should follow this ordering:
    - Classes
 6. **Main exports** (barrel `export * from` statements in index files)
 
-When a file accumulates several constants, extract them into a dedicated `constants.ts` file.
+Put every `UPPER_SNAKE_CASE` constant after the file's type declarations and before its first function or class declaration — never trailing at the bottom or wedged between functions. When a file accumulates several constants, extract them into a dedicated `constants.ts` file. The only exception is a constant whose initializer calls a function or reads a binding declared in the same file: leave it below what it depends on.
 
 ### Control Flow
 

--- a/packages/canvas/src/constants.ts
+++ b/packages/canvas/src/constants.ts
@@ -1,0 +1,59 @@
+import {
+    degreesToRadians,
+} from '@ripl/core';
+
+import type {
+    Gradient,
+    GradientBounds,
+    TextAlignment,
+} from '@ripl/core';
+
+type CanvasGradientFactory = (context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds) => CanvasGradient;
+
+/** Native `CanvasGradient` construction keyed by parsed gradient type. */
+export const CANVAS_GRADIENT_FACTORIES: Record<string, CanvasGradientFactory> = {
+    linear: (context, gradient, { x, y, width, height }) => {
+        const angleRad = degreesToRadians((gradient as { angle: number }).angle - 90);
+        const cos = Math.cos(angleRad);
+        const sin = Math.sin(angleRad);
+        const halfW = width / 2;
+        const halfH = height / 2;
+        const length = Math.abs(halfW * cos) + Math.abs(halfH * sin);
+
+        return context.createLinearGradient(
+            x + halfW - cos * length,
+            y + halfH - sin * length,
+            x + halfW + cos * length,
+            y + halfH + sin * length
+        );
+    },
+    radial: (context, gradient, { x, y, width, height }) => {
+        const cx = x + ((gradient as { position: [number, number] }).position[0] / 100) * width;
+        const cy = y + ((gradient as { position: [number, number] }).position[1] / 100) * height;
+        const radius = Math.max(width, height) / 2;
+
+        return context.createRadialGradient(cx, cy, 0, cx, cy, radius);
+    },
+    conic: (context, gradient, { x, y, width, height }) => {
+        const cx = x + ((gradient as { position: [number, number] }).position[0] / 100) * width;
+        const cy = y + ((gradient as { position: [number, number] }).position[1] / 100) * height;
+        const startAngle = degreesToRadians((gradient as { angle: number }).angle);
+
+        return context.createConicGradient(startAngle, cx, cy);
+    },
+};
+
+/** Maximum number of gradients or patterns cached against a single context before the cache is dropped. */
+export const PAINT_CACHE_LIMIT = 256;
+
+/** Maximum number of path length and sample results cached before the cache is dropped. */
+export const PATH_CACHE_LIMIT = 1024;
+
+/** Where a glyph's anchor sits within its own advance, per the alignment `fillText` will draw it with. */
+export const TEXT_PATH_ANCHORS: Record<TextAlignment, (advance: number) => number> = {
+    start: () => 0,
+    left: () => 0,
+    center: advance => advance / 2,
+    right: advance => advance,
+    end: advance => advance,
+};

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -1,6 +1,5 @@
 import {
     ContextText,
-    degreesToRadians,
     factory,
     getPathLength,
     getPatternTileGeometry,
@@ -21,7 +20,6 @@ import type {
     GradientBounds,
     PathPoint,
     Scale,
-    TextAlignment,
 } from '@ripl/core';
 
 import {
@@ -30,11 +28,16 @@ import {
     typeIsNumber,
 } from '@ripl/utilities';
 
+import {
+    CANVAS_GRADIENT_FACTORIES,
+    PAINT_CACHE_LIMIT,
+    PATH_CACHE_LIMIT,
+    TEXT_PATH_ANCHORS,
+} from './constants';
+
 import type {
     CanvasPath,
 } from './path';
-
-type CanvasGradientFactory = (context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds) => CanvasGradient;
 
 /** Anything with an intrinsic pixel size `drawImage` can fall back to, across the `CanvasImageSource` union. */
 interface IntrinsicallySized {
@@ -47,38 +50,6 @@ interface IntrinsicallySized {
     width?: unknown;
     height?: unknown;
 }
-
-const CANVAS_GRADIENT_FACTORIES: Record<string, CanvasGradientFactory> = {
-    linear: (context, gradient, { x, y, width, height }) => {
-        const angleRad = degreesToRadians((gradient as { angle: number }).angle - 90);
-        const cos = Math.cos(angleRad);
-        const sin = Math.sin(angleRad);
-        const halfW = width / 2;
-        const halfH = height / 2;
-        const length = Math.abs(halfW * cos) + Math.abs(halfH * sin);
-
-        return context.createLinearGradient(
-            x + halfW - cos * length,
-            y + halfH - sin * length,
-            x + halfW + cos * length,
-            y + halfH + sin * length
-        );
-    },
-    radial: (context, gradient, { x, y, width, height }) => {
-        const cx = x + ((gradient as { position: [number, number] }).position[0] / 100) * width;
-        const cy = y + ((gradient as { position: [number, number] }).position[1] / 100) * height;
-        const radius = Math.max(width, height) / 2;
-
-        return context.createRadialGradient(cx, cy, 0, cx, cy, radius);
-    },
-    conic: (context, gradient, { x, y, width, height }) => {
-        const cx = x + ((gradient as { position: [number, number] }).position[0] / 100) * width;
-        const cy = y + ((gradient as { position: [number, number] }).position[1] / 100) * height;
-        const startAngle = degreesToRadians((gradient as { angle: number }).angle);
-
-        return context.createConicGradient(startAngle, cx, cy);
-    },
-};
 
 /** Converts a parsed gradient definition into a native `CanvasGradient` within the given bounds. */
 export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gradient, bounds: GradientBounds): CanvasGradient {
@@ -95,9 +66,6 @@ export function toCanvasGradient(context: CanvasRenderingContext2D, gradient: Gr
 
     return canvasGradient;
 }
-
-const PAINT_CACHE_LIMIT = 256;
-const PATH_CACHE_LIMIT = 1024;
 
 // Paint is cached per context: a `CanvasPattern`/`CanvasGradient` outlives the context that built it,
 // so a module-global cache handed a destroyed context's objects — and their tiles — to the next one.
@@ -315,15 +283,6 @@ export function rescaleCanvas(
         scaleY: scaleContinuous([0, height], [0, height * dpr]),
     };
 }
-
-// Where a glyph's anchor sits within its own advance, per the alignment `fillText` will draw it with.
-const TEXT_PATH_ANCHORS: Record<TextAlignment, (advance: number) => number> = {
-    start: () => 0,
-    left: () => 0,
-    center: advance => advance / 2,
-    right: advance => advance,
-    end: advance => advance,
-};
 
 /**
  * Renders text character-by-character along a path using fill or stroke.

--- a/packages/charts/src/core/labels.ts
+++ b/packages/charts/src/core/labels.ts
@@ -47,6 +47,18 @@ export interface DataLabelSpec {
     offset?: number;
 }
 
+/** Resolved placement for a data label: the offset position and the text alignment that anchors it. */
+export interface DataLabelLayout {
+    /** The x coordinate of the label, offset from the mark along the anchor direction. */
+    x: number;
+    /** The y coordinate of the label, offset from the mark along the anchor direction. */
+    y: number;
+    /** Horizontal text alignment that keeps the label text anchored toward the mark. */
+    textAlign: TextAlignment;
+    /** Vertical text baseline that keeps the label text anchored toward the mark. */
+    textBaseline: TextBaseline;
+}
+
 /** Per-anchor offset direction (multiplied by `offset`) and text alignment for data labels. */
 const DATA_LABEL_ANCHORS: Record<LabelAnchor, {
     dx: number;
@@ -80,17 +92,17 @@ const DATA_LABEL_ANCHORS: Record<LabelAnchor, {
     },
 };
 
-/** Resolved placement for a data label: the offset position and the text alignment that anchors it. */
-export interface DataLabelLayout {
-    /** The x coordinate of the label, offset from the mark along the anchor direction. */
-    x: number;
-    /** The y coordinate of the label, offset from the mark along the anchor direction. */
-    y: number;
-    /** Horizontal text alignment that keeps the label text anchored toward the mark. */
-    textAlign: TextAlignment;
-    /** Vertical text baseline that keeps the label text anchored toward the mark. */
-    textBaseline: TextBaseline;
-}
+/**
+ * Shared segment-label style constants. Every chart routes its segment labels through these so the
+ * appearance is identical across chart types **and** across the Canvas and SVG contexts. The
+ * cross-context inconsistency this fixes came from labels that omitted `font`, leaving each backend
+ * to fall back to its own default, so always set an explicit font.
+ */
+export const SEGMENT_LABEL_FONT = '600 11px sans-serif';
+/** Fill for labels drawn inside a segment (on top of the filled shape). */
+export const SEGMENT_LABEL_INSIDE_FILL = '#ffffff';
+/** Fill for labels drawn outside a segment (on the chart background). */
+export const SEGMENT_LABEL_OUTSIDE_FILL = '#333333';
 
 /** Resolves the anchored position and text alignment for a data label. */
 export function resolveDataLabelLayout(spec: Pick<DataLabelSpec, 'x' | 'y' | 'anchor' | 'offset'>): DataLabelLayout {
@@ -106,18 +118,6 @@ export function resolveDataLabelLayout(spec: Pick<DataLabelSpec, 'x' | 'y' | 'an
 }
 
 // Segment labels (pie, polar-area, treemap, funnel, sunburst)
-
-/**
- * Shared segment-label style constants. Every chart routes its segment labels through these so the
- * appearance is identical across chart types **and** across the Canvas and SVG contexts. The
- * cross-context inconsistency this fixes came from labels that omitted `font`, leaving each backend
- * to fall back to its own default, so always set an explicit font.
- */
-export const SEGMENT_LABEL_FONT = '600 11px sans-serif';
-/** Fill for labels drawn inside a segment (on top of the filled shape). */
-export const SEGMENT_LABEL_INSIDE_FILL = '#ffffff';
-/** Fill for labels drawn outside a segment (on the chart background). */
-export const SEGMENT_LABEL_OUTSIDE_FILL = '#333333';
 
 /** Describes a single segment label to render. */
 export interface SegmentLabelSpec {

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -28,13 +28,6 @@ import type {
 } from './types';
 
 
-export * from './parsers';
-export * from './serializers';
-export * from './utilities';
-export * from './scales';
-export * from './schemes';
-export * from './types';
-
 const PARSER_MAP = [
     {
         pattern: PATTERNS.hex,
@@ -86,3 +79,10 @@ export function parseColor(value: string): ColorRGBA | undefined {
         return parser.parse(value);
     }
 }
+
+export * from './parsers';
+export * from './serializers';
+export * from './utilities';
+export * from './scales';
+export * from './schemes';
+export * from './types';

--- a/packages/core/src/core/query.ts
+++ b/packages/core/src/core/query.ts
@@ -41,10 +41,6 @@ type QueryableContainer = Queryable & {
     graph(includeGroups?: boolean): Queryable[];
 };
 
-function isQueryableContainer(value: Queryable): value is QueryableContainer {
-    return typeIsFunction(value.graph);
-}
-
 const ELEMENT_PATTERNS = {
     id: /#/,
     class: /\./,
@@ -84,6 +80,10 @@ const COMBINATOR_PRODUCERS = [
     pattern: RegExp;
     produce: (element: Queryable) => Queryable[];
 }[];
+
+function isQueryableContainer(value: Queryable): value is QueryableContainer {
+    return typeIsFunction(value.graph);
+}
 
 function serializeAttribute(value: unknown) {
     if (typeIsString(value)) {

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -146,6 +146,13 @@ export interface RendererOptions {
     debug?: boolean | RendererDebugOptions;
 }
 
+/** Transition options can be a static object or a per-element factory function. */
+export type RendererTransitionOptionsArg<TElement extends Element> = RendererTransitionOptions<TElement> | ((
+    element: TElement extends Group ? Element : TElement,
+    index: number,
+    length: number
+) => RendererTransitionOptions<TElement>);
+
 const DEBUG_DEFAULTS: Required<RendererDebugOptions> = {
     fps: false,
     elementCount: false,
@@ -170,13 +177,6 @@ function resolveDebugOptions(debug: boolean | RendererDebugOptions): Required<Re
         ...debug,
     };
 }
-
-/** Transition options can be a static object or a per-element factory function. */
-export type RendererTransitionOptionsArg<TElement extends Element> = RendererTransitionOptions<TElement> | ((
-    element: TElement extends Group ? Element : TElement,
-    index: number,
-    length: number
-) => RendererTransitionOptions<TElement>);
 
 /** Drives the animation loop via `requestAnimationFrame`, managing per-element transitions and rendering the scene each frame. */
 export class Renderer extends EventBus<RendererEventMap> {

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -55,6 +55,12 @@ export interface RenderInstruction {
     element: Element;
 }
 
+/** Options for constructing a scene, extending group options with an optional auto-render-on-resize flag. */
+export interface SceneOptions extends GroupOptions {
+    /** Whether the scene re-renders automatically when its context is resized. Defaults to `true`. */
+    renderOnResize?: boolean;
+}
+
 /** Render-instruction dispatch keyed by instruction type: open a group boundary, draw a leaf, or close a group boundary. */
 const RENDER_OPERATIONS: Record<RenderInstructionType, (context: Context, element: Element) => void> = {
     push: (context, element) => context.pushGroup(element),
@@ -64,12 +70,6 @@ const RENDER_OPERATIONS: Record<RenderInstructionType, (context: Context, elemen
     },
     draw: (context, element) => element.render(context),
 };
-
-/** Options for constructing a scene, extending group options with an optional auto-render-on-resize flag. */
-export interface SceneOptions extends GroupOptions {
-    /** Whether the scene re-renders automatically when its context is resized. Defaults to `true`. */
-    renderOnResize?: boolean;
-}
 
 /** The top-level group bound to a rendering context, maintaining a hoisted flat instruction stream for O(n) rendering. */
 export class Scene<TContext extends Context = Context> extends Group<SceneEventMap> {

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -22,15 +22,6 @@ import {
     typeIsNil,
 } from '@ripl/utilities';
 
-/** Abstract base class for renderable shapes, extending `Element` with a type-constrained constructor. */
-export abstract class Shape<TState extends BaseElementState = BaseElementState> extends Element<TState> {
-
-    constructor(type: string, options: ElementOptions<TState>) {
-        super(type, options);
-    }
-
-}
-
 /** Options for a 2D shape, adding automatic fill/stroke and clipping controls. */
 export type Shape2DOptions<TState extends BaseElementState = BaseElementState> = ElementOptions<TState> & {
     /** Whether the shape automatically strokes its outline after rendering when a stroke is set. Defaults to `true`. */
@@ -62,6 +53,15 @@ const STROKE_HIT_PROPERTIES = [
     'lineWidth',
     'miterLimit',
 ] as const;
+
+/** Abstract base class for renderable shapes, extending `Element` with a type-constrained constructor. */
+export abstract class Shape<TState extends BaseElementState = BaseElementState> extends Element<TState> {
+
+    constructor(type: string, options: ElementOptions<TState>) {
+        super(type, options);
+    }
+
+}
 
 /** A concrete 2D shape with path management, automatic fill/stroke rendering, clipping support, and path-based hit testing. */
 export class Shape2D<TState extends BaseElementState = BaseElementState> extends Shape<TState> {

--- a/packages/core/src/gradient/parser.ts
+++ b/packages/core/src/gradient/parser.ts
@@ -27,6 +27,13 @@ const DIRECTION_MAP: Record<string, number> = {
     'to top left': 315,
 };
 
+/** Parser dispatch keyed by gradient function name (`linear-gradient`, etc.). */
+const GRADIENT_PARSERS: Record<string, (args: string[], repeating: boolean) => Gradient> = {
+    linear: parseLinearGradient,
+    radial: parseRadialGradient,
+    conic: parseConicGradient,
+};
+
 function splitGradientArgs(input: string): string[] {
     const args: string[] = [];
     let depth = 0;
@@ -235,13 +242,6 @@ function parseConicGradient(args: string[], repeating: boolean): ConicGradient {
         stops: normalizeStopOffsets(parseColorStops(stopArgs)),
     };
 }
-
-/** Parser dispatch keyed by gradient function name (`linear-gradient`, etc.). */
-const GRADIENT_PARSERS: Record<string, (args: string[], repeating: boolean) => Gradient> = {
-    linear: parseLinearGradient,
-    radial: parseRadialGradient,
-    conic: parseConicGradient,
-};
 
 /** Parses a CSS gradient string (linear, radial, or conic) into a structured `Gradient` object, or returns `undefined` if the string is not a recognized gradient. */
 export function parseGradient(value: string): Gradient | undefined {

--- a/packages/core/src/gradient/serializer.ts
+++ b/packages/core/src/gradient/serializer.ts
@@ -8,6 +8,13 @@ import type {
 } from './types';
 
 
+/** Serializer dispatch keyed by gradient type. */
+const GRADIENT_SERIALIZERS: Record<GradientType, (gradient: Gradient) => string> = {
+    linear: gradient => serializeLinearGradient(gradient as LinearGradient),
+    radial: gradient => serializeRadialGradient(gradient as RadialGradient),
+    conic: gradient => serializeConicGradient(gradient as ConicGradient),
+};
+
 function serializeStop(stop: GradientColorStop): string {
     if (stop.offset !== undefined) {
         return `${stop.color} ${(stop.offset * 100).toFixed(2)}%`;
@@ -80,13 +87,6 @@ function serializeConicGradient(gradient: ConicGradient): string {
 
     return `${prefix}conic-gradient(${parts.join(', ')})`;
 }
-
-/** Serializer dispatch keyed by gradient type. */
-const GRADIENT_SERIALIZERS: Record<GradientType, (gradient: Gradient) => string> = {
-    linear: gradient => serializeLinearGradient(gradient as LinearGradient),
-    radial: gradient => serializeRadialGradient(gradient as RadialGradient),
-    conic: gradient => serializeConicGradient(gradient as ConicGradient),
-};
 
 /** Serializes a structured `Gradient` object back into a CSS gradient string. */
 export function serializeGradient(gradient: Gradient): string {

--- a/packages/core/src/interpolators/gradient.ts
+++ b/packages/core/src/interpolators/gradient.ts
@@ -29,44 +29,6 @@ import {
     typeIsString,
 } from '@ripl/utilities';
 
-function canInterpolateGradients(gradientA: Gradient, gradientB: Gradient): boolean {
-    if (gradientA.type !== gradientB.type) {
-        return false;
-    }
-
-    if (gradientA.repeating !== gradientB.repeating) {
-        return false;
-    }
-
-    if (gradientA.stops.length !== gradientB.stops.length) {
-        return false;
-    }
-
-    if (gradientA.type === 'radial' && gradientB.type === 'radial') {
-        if (gradientA.shape !== gradientB.shape) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-function interpolateStops(stopsA: GradientColorStop[], stopsB: GradientColorStop[]) {
-    const interpolators = stopsA.map((stopA, index) => {
-        const stopB = stopsB[index];
-
-        return {
-            color: interpolateColor(stopA.color, stopB.color),
-            offset: interpolateNumber(stopA.offset ?? 0, stopB.offset ?? 0),
-        };
-    });
-
-    return (position: number): GradientColorStop[] => interpolators.map(({ color, offset }) => ({
-        color: color(position),
-        offset: offset(position),
-    }));
-}
-
 type StopsInterpolator = (position: number) => GradientColorStop[];
 type GradientInterpolator = (position: number) => Gradient;
 
@@ -117,6 +79,44 @@ const GRADIENT_INTERPOLATORS: Record<GradientType, (gradientA: Gradient, gradien
         });
     },
 };
+
+function canInterpolateGradients(gradientA: Gradient, gradientB: Gradient): boolean {
+    if (gradientA.type !== gradientB.type) {
+        return false;
+    }
+
+    if (gradientA.repeating !== gradientB.repeating) {
+        return false;
+    }
+
+    if (gradientA.stops.length !== gradientB.stops.length) {
+        return false;
+    }
+
+    if (gradientA.type === 'radial' && gradientB.type === 'radial') {
+        if (gradientA.shape !== gradientB.shape) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function interpolateStops(stopsA: GradientColorStop[], stopsB: GradientColorStop[]) {
+    const interpolators = stopsA.map((stopA, index) => {
+        const stopB = stopsB[index];
+
+        return {
+            color: interpolateColor(stopA.color, stopB.color),
+            offset: interpolateNumber(stopA.offset ?? 0, stopB.offset ?? 0),
+        };
+    });
+
+    return (position: number): GradientColorStop[] => interpolators.map(({ color, offset }) => ({
+        color: color(position),
+        offset: offset(position),
+    }));
+}
 
 function interpolateMatchingGradients(gradientA: Gradient, gradientB: Gradient): GradientInterpolator {
     const stopsInterpolator = interpolateStops(gradientA.stops, gradientB.stops);

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -25,8 +25,6 @@ import type {
     DOMEventHandler,
 } from './dom';
 
-const INTERACTION_KEY = Symbol('interaction');
-
 interface InteractionState {
     left: number;
     top: number;
@@ -39,6 +37,8 @@ interface InteractionState {
     suppressClick: boolean;
     scheduleHitTest: ReturnType<typeof createFrameBuffer>;
 }
+
+const INTERACTION_KEY = Symbol('interaction');
 
 /** DOM-aware rendering context that extends the base `Context` with element mounting, resize observation, and interaction handling. */
 export abstract class DOMContext<TElement extends Element = Element, TMeta extends Record<string, unknown> = Record<string, unknown>> extends Context<TElement, TMeta> {

--- a/packages/svg/src/definitions.ts
+++ b/packages/svg/src/definitions.ts
@@ -62,6 +62,16 @@ export interface ShadowCacheEntry {
     shadowElement: SVGElement;
 }
 
+const GRADIENT_ELEMENT_FACTORIES: Record<string, GradientElementFactory> = {
+    linear: () => createSVGElement('linearGradient'),
+    radial: () => createSVGElement('radialGradient'),
+};
+
+const GRADIENT_ELEMENT_UPDATERS: Record<string, GradientElementUpdater> = {
+    linear: applyLinearGradientAttributes,
+    radial: applyRadialGradientAttributes,
+};
+
 function applyGradientStops(gradientEl: SVGElement, stops: GradientColorStop[]) {
     gradientEl.replaceChildren();
 
@@ -101,16 +111,6 @@ function applyRadialGradientAttributes(element: SVGElement, gradient: Gradient, 
 
     element.setAttribute('gradientTransform', `translate(${cx.toFixed(4)},${cy.toFixed(4)}) scale(1,${scaleY.toFixed(4)}) translate(${(-cx).toFixed(4)},${(-cy).toFixed(4)})`);
 }
-
-const GRADIENT_ELEMENT_FACTORIES: Record<string, GradientElementFactory> = {
-    linear: () => createSVGElement('linearGradient'),
-    radial: () => createSVGElement('radialGradient'),
-};
-
-const GRADIENT_ELEMENT_UPDATERS: Record<string, GradientElementUpdater> = {
-    linear: applyLinearGradientAttributes,
-    radial: applyRadialGradientAttributes,
-};
 
 /** Determines whether a parsed gradient maps to a native SVG gradient primitive (linear or radial). */
 export function isSupportedSVGGradient(gradient: Gradient): boolean {

--- a/packages/terminal/src/constants.ts
+++ b/packages/terminal/src/constants.ts
@@ -1,4 +1,39 @@
 /**
+ * Braille dot layout per cell (2 wide × 4 tall):
+ *
+ * ```
+ * [0,0] [1,0]    bit 0  bit 3
+ * [0,1] [1,1]    bit 1  bit 4
+ * [0,2] [1,2]    bit 2  bit 5
+ * [0,3] [1,3]    bit 6  bit 7
+ * ```
+ */
+export const BRAILLE_BASE = 0x2800;
+
+/** Dot bit per (row, column) within a braille cell, indexed `[dy][dx]`. */
+export const BRAILLE_DOT_MAP = [
+    [0x01, 0x08],
+    [0x02, 0x10],
+    [0x04, 0x20],
+    [0x40, 0x80],
+];
+
+/** Every dot of a braille cell, used to stand in for a glyph when rasterizing to pixels. */
+export const BRAILLE_ALL_DOTS = 0xff;
+
+/** Fallback RGB used when a cell has no stored color (matches a light terminal foreground). */
+export const DEFAULT_RGB: [number, number, number] = [230, 230, 230];
+
+/** Erases from the cursor to the end of the line, clearing columns a narrower grid no longer covers. */
+export const ANSI_ERASE_LINE_END = '\x1b[K';
+
+/** Erases from the cursor to the end of the display, clearing rows a shorter grid no longer covers. */
+export const ANSI_ERASE_DISPLAY_END = '\x1b[J';
+
+/** Matches an ANSI truecolor foreground escape (`\x1b[38;2;r;g;bm`), capturing its RGB components. */
+export const ANSI_TRUECOLOR_REGEX = /38;2;(\d+);(\d+);(\d+)/;
+
+/**
  * The CSS Color Module Level 4 named colors, as packed `0xRRGGBB` integers.
  *
  * A terminal has no CSSOM to resolve a keyword against, so the table is the only way `fill: 'red'`

--- a/packages/terminal/src/context.ts
+++ b/packages/terminal/src/context.ts
@@ -62,69 +62,6 @@ import type {
     TerminalOutput,
 } from './output';
 
-/** Converts a base64 data URL into a `Blob` synchronously. */
-function dataURLToBlob(dataURL: string): Blob {
-    const [header, data] = dataURL.split(',');
-    const mimeMatch = /:(.*?);/.exec(header);
-    const mime = mimeMatch ? mimeMatch[1] : 'image/png';
-    const binary = atob(data);
-    const bytes = new Uint8Array(binary.length);
-
-    for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i);
-    }
-
-    return new Blob([bytes], {
-        type: mime,
-    });
-}
-
-/**
- * Produces an openable URL for a rasterized terminal snapshot. In a browser this is a PNG `Blob`
- * object URL; in a headless environment it falls back to a `text/plain` data URL of the braille art.
- */
-function terminalSnapshotToURL(imageData: ImageData, text: string): string {
-    if (typeof document !== 'undefined' && imageData.width > 0 && imageData.height > 0) {
-        const canvas = document.createElement('canvas');
-
-        canvas.width = imageData.width;
-        canvas.height = imageData.height;
-
-        const context = canvas.getContext('2d');
-
-        if (context) {
-            context.putImageData(imageData, 0, 0);
-
-            const dataURL = canvas.toDataURL('image/png');
-
-            if (dataURL?.startsWith('data:image')) {
-                return URL.createObjectURL(dataURLToBlob(dataURL));
-            }
-        }
-    }
-
-    return `data:text/plain;charset=utf-8,${encodeURIComponent(text)}`;
-}
-
-/** Fraction of the text width to shift the anchor left by, per `textAlign` (LTR). */
-const TEXT_ALIGN_FACTORS: Record<string, number> = {
-    left: 0,
-    start: 0,
-    center: 0.5,
-    right: 1,
-    end: 1,
-};
-
-/** Number of cells to shift the anchor up by, per `textBaseline` (glyphs are one cell tall). */
-const TEXT_BASELINE_FACTORS: Record<string, number> = {
-    top: 0,
-    hanging: 0,
-    middle: 0.5,
-    alphabetic: 1,
-    ideographic: 1,
-    bottom: 1,
-};
-
 /** Options for constructing a terminal rendering context. */
 export interface TerminalContextOptions extends ContextOptions {
     /** Grid width in terminal columns. Defaults to the output adapter's `columns`. */
@@ -169,6 +106,25 @@ interface TerminalCommandHandler {
     toContour(context: ContourContext, args: number[]): void;
     rasterize(context: RasterContext, args: number[]): void;
 }
+
+/** Fraction of the text width to shift the anchor left by, per `textAlign` (LTR). */
+const TEXT_ALIGN_FACTORS: Record<string, number> = {
+    left: 0,
+    start: 0,
+    center: 0.5,
+    right: 1,
+    end: 1,
+};
+
+/** Number of cells to shift the anchor up by, per `textBaseline` (glyphs are one cell tall). */
+const TEXT_BASELINE_FACTORS: Record<string, number> = {
+    top: 0,
+    hanging: 0,
+    middle: 0.5,
+    alphabetic: 1,
+    ideographic: 1,
+    bottom: 1,
+};
 
 /**
  * Dispatch table keyed by path command type, replacing the parallel `switch` statements in
@@ -274,6 +230,50 @@ const TERMINAL_COMMAND_HANDLERS: Record<TerminalPathCommandType, TerminalCommand
         },
     },
 };
+
+/** Converts a base64 data URL into a `Blob` synchronously. */
+function dataURLToBlob(dataURL: string): Blob {
+    const [header, data] = dataURL.split(',');
+    const mimeMatch = /:(.*?);/.exec(header);
+    const mime = mimeMatch ? mimeMatch[1] : 'image/png';
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+
+    return new Blob([bytes], {
+        type: mime,
+    });
+}
+
+/**
+ * Produces an openable URL for a rasterized terminal snapshot. In a browser this is a PNG `Blob`
+ * object URL; in a headless environment it falls back to a `text/plain` data URL of the braille art.
+ */
+function terminalSnapshotToURL(imageData: ImageData, text: string): string {
+    if (typeof document !== 'undefined' && imageData.width > 0 && imageData.height > 0) {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = imageData.width;
+        canvas.height = imageData.height;
+
+        const context = canvas.getContext('2d');
+
+        if (context) {
+            context.putImageData(imageData, 0, 0);
+
+            const dataURL = canvas.toDataURL('image/png');
+
+            if (dataURL?.startsWith('data:image')) {
+                return URL.createObjectURL(dataURLToBlob(dataURL));
+            }
+        }
+    }
+
+    return `data:text/plain;charset=utf-8,${encodeURIComponent(text)}`;
+}
 
 /**
  * Terminal rendering context that rasterizes Ripl elements into character-based output via a

--- a/packages/terminal/src/rasterizer.ts
+++ b/packages/terminal/src/rasterizer.ts
@@ -1,4 +1,14 @@
 import {
+    ANSI_ERASE_DISPLAY_END,
+    ANSI_ERASE_LINE_END,
+    ANSI_TRUECOLOR_REGEX,
+    BRAILLE_ALL_DOTS,
+    BRAILLE_BASE,
+    BRAILLE_DOT_MAP,
+    DEFAULT_RGB,
+} from './constants';
+
+import {
     ANSI_RESET,
 } from './color';
 
@@ -28,44 +38,11 @@ export interface Rasterizer {
     toImageData(): ImageData;
 }
 
-/**
- * Braille dot layout per cell (2 wide × 4 tall):
- *
- * ```
- * [0,0] [1,0]    bit 0  bit 3
- * [0,1] [1,1]    bit 1  bit 4
- * [0,2] [1,2]    bit 2  bit 5
- * [0,3] [1,3]    bit 6  bit 7
- * ```
- */
-const BRAILLE_BASE = 0x2800;
-
-const BRAILLE_DOT_MAP = [
-    [0x01, 0x08],
-    [0x02, 0x10],
-    [0x04, 0x20],
-    [0x40, 0x80],
-];
-
 /** Each braille cell is 2 pixels wide and 4 pixels tall. */
 export const BRAILLE_CELL_WIDTH = 2;
 
 /** Each braille cell is 2 pixels wide and 4 pixels tall. */
 export const BRAILLE_CELL_HEIGHT = 4;
-
-/** Fallback RGB used when a cell has no stored color (matches a light terminal foreground). */
-const DEFAULT_RGB: [number, number, number] = [230, 230, 230];
-
-/** Erases from the cursor to the end of the line, clearing columns a narrower grid no longer covers. */
-const ANSI_ERASE_LINE_END = '\x1b[K';
-
-/** Erases from the cursor to the end of the display, clearing rows a shorter grid no longer covers. */
-const ANSI_ERASE_DISPLAY_END = '\x1b[J';
-
-/** Every dot of a braille cell, used to stand in for a glyph when rasterizing to pixels. */
-const BRAILLE_ALL_DOTS = 0xff;
-
-const ANSI_TRUECOLOR_REGEX = /38;2;(\d+);(\d+);(\d+)/;
 
 /** Parses an ANSI truecolor foreground escape (`\x1b[38;2;r;g;bm`) back to an RGB tuple. */
 function parseAnsiColor(ansi: string): [number, number, number] {


### PR DESCRIPTION
AGENTS.md has said since the File Structure section was written that a file orders itself imports → types → constants → functions → classes, and that "when a file accumulates several constants, extract them into a dedicated `constants.ts` file". A sweep found that rule was widely unenforced, so a reader looking for a module's tunables had to scroll past the code that consumes them.

Some examples of what the sweep turned up:

- `packages/core/src/core/shape.ts` declared `POINTER_EVENT_HIT_TESTS` and `STROKE_HIT_PROPERTIES` *after* the exported `Shape` class.
- `packages/core/src/gradient/parser.ts` put `GRADIENT_PARSERS` below eight function declarations — while three sibling constants at the top of the same file were correctly placed.
- `packages/core/src/gradient/serializer.ts` had `GRADIENT_SERIALIZERS` at the very bottom of the file.
- `packages/canvas/src/utilities.ts` carried four constants scattered mid-file, past the exported functions, with no `constants.ts` in the package at all.

## The fix

Twelve files get a pure within-file reorder. Two hit the "several constants" threshold and get an extraction instead: a new `packages/canvas/src/constants.ts`, and seven Braille/ANSI constants moved out of `packages/terminal/src/rasterizer.ts` into the `constants.ts` that package already had.

Where a type declaration sat between the imports and the constants, it moved up with them, so types still precede constants. In `packages/core/src/color/index.ts` the `export * from` block moved to the bottom, which is where the same File Structure rule puts barrel re-exports.

**No export path changed.** That matters for two cases that look inconsistent on purpose:

- `BRAILLE_CELL_WIDTH`/`BRAILLE_CELL_HEIGHT` stay in `rasterizer.ts` while their seven siblings move to `constants.ts`, because `terminal/src/index.ts` re-exports `./rasterizer` but not `./constants` — moving them would have quietly dropped two documented, `@ripl/node`-consumed symbols from the public barrel.
- `packages/canvas/src/constants.ts` is deliberately not added to the canvas barrel, so nothing new became public.

Pruning genuinely-internal exports is a separate change; this one is not allowed to alter the public surface.

Two constants were deliberately left where they are, both for the same reason: their initializers read values declared above them, so hoisting would throw a TDZ `ReferenceError` at module load. `THEME_REGISTRY` in `packages/charts/src/core/theme.ts` builds a `Map` from `lightTheme`/`darkTheme`/`colorBlindTheme`; `packages/core/src/core/constants.ts` calls local helper functions. Both already sit above their file's first function declaration, so both satisfy the headline rule. AGENTS.md now records this exception alongside the rule so the next reader does not "fix" them.

## Verification

- `yarn test` — 193 files, **2424 passed, 2 skipped, 1 todo**, identical to `main`. The two skips are the pre-existing `conformance.test.ts` jsdom `toDataURL` cases.
- `tsc -p tsconfig.typecheck.json` — clean.
- `eslint` on all 16 changed files — clean.
- Every one of the twelve within-file reorders was checked to be **content-identical to `main` modulo line order** (normalising each file to a sorted multiset of its non-blank lines). The only four files whose content genuinely differs are the two extractions and their origins, which necessarily gain imports and JSDoc. An unchanged test count plus content-identity is the whole safety argument for a refactor that is supposed to change nothing.

## Follow-ups

The sweep found 30 further occurrences outside this PR's scope, left deliberately:

- `packages/charts/src/core/options.ts` accounts for 20 of them. They follow a consistent co-location pattern — each `*_DEFAULTS` sits directly above the normalizer that reads it — so hoisting them all to the top of a 1000-line file is a judgement call that deserves its own review rather than a silent ride-along here.
- Seven are cheap one-file fixes (`packages/dom/src/dom.ts`, `packages/3d/src/math/matrix.ts`, `packages/charts/src/components/axis.ts`, `packages/charts/src/charts/treemap.ts`, `packages/svg/src/utilities.ts` — the last arguably a cache rather than a constant).
- Two are in `packages/test-utils/src/canvas.ts`, and the remaining four are the sanctioned `core/src/core/constants.ts` exception.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnbBNvcQzqikWSyApb47Xb)_