### PR TITLE
Resolve CSS named colours in core so they parse and tween like every other format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 .output/
 
 # dependencies
-node_modules/
+node_modules
 
 .pnp.*
 .yarn/*

--- a/apps/website/src/docs/core/advanced/color.md
+++ b/apps/website/src/docs/core/advanced/color.md
@@ -4,7 +4,7 @@ outline: "deep"
 
 # Color
 
-Ripl includes a complete color toolkit for parsing, converting, and serializing colors across multiple color spaces. Any CSS color string you pass to `fill` or `stroke` is automatically parsed, but you can also use the color utilities directly for programmatic color manipulation, palette generation, and animation.
+Ripl includes a complete color toolkit for parsing, converting, and serializing colors across multiple color spaces. Every format in the [supported color spaces](#supported-color-spaces) table — hexadecimal, the functional notations, and the CSS named colors — is parsed automatically when you pass it to `fill` or `stroke`, but you can also use the color utilities directly for programmatic color manipulation, palette generation, and animation.
 
 > [!NOTE]
 > For the full API, see the [Color API Reference](/docs/api/@ripl/core/).
@@ -146,6 +146,9 @@ watch(pickedColor, redraw);
 | HSLA | `parseHSLA` | `serializeHSLA` | `hsla(216, 100%, 61%, 0.5)` |
 | HSV | `parseHSV` | `serializeHSV` | `hsv(216, 77%, 100%)` |
 | HSVA | `parseHSVA` | `serializeHSVA` | `hsva(216, 77%, 100%, 0.5)` |
+| Named | `parseKeyword` | — | `red`, `rebeccapurple`, `transparent` |
+
+Named colors are the CSS Color Module Level 4 keywords. They are matched case-insensitively, and `transparent` resolves to `rgba(0, 0, 0, 0)`. There is no serializer — a color rarely lands back on a keyword's exact value.
 
 ## Parsing Colors
 
@@ -159,6 +162,9 @@ import {
 parseColor('#3a86ff'); // [58, 134, 255, 1]
 parseColor('rgb(58, 134, 255)'); // [58, 134, 255, 1]
 parseColor('hsl(216, 100%, 61%)'); // [58, 134, 255, 1]
+parseColor('red'); // [255, 0, 0, 1]
+parseColor('transparent'); // [0, 0, 0, 0]
+parseColor('currentColor'); // undefined
 ```
 
 For a specific format, use the named parser:

--- a/apps/website/src/docs/core/advanced/color.md
+++ b/apps/website/src/docs/core/advanced/color.md
@@ -4,7 +4,7 @@ outline: "deep"
 
 # Color
 
-Ripl includes a complete color toolkit for parsing, converting, and serializing colors across multiple color spaces. Every format in the [supported color spaces](#supported-color-spaces) table — hexadecimal, the functional notations, and the CSS named colors — is parsed automatically when you pass it to `fill` or `stroke`, but you can also use the color utilities directly for programmatic color manipulation, palette generation, and animation.
+Ripl includes a complete color toolkit for parsing, converting, and serializing colors across multiple color spaces. Every [supported color space](#supported-color-spaces) — hexadecimal and the functional notations — plus the [CSS named colors](#named-colors) is parsed automatically when you pass it to `fill` or `stroke`, but you can also use the color utilities directly for programmatic color manipulation, palette generation, and animation.
 
 > [!NOTE]
 > For the full API, see the [Color API Reference](/docs/api/@ripl/core/).
@@ -146,9 +146,10 @@ watch(pickedColor, redraw);
 | HSLA | `parseHSLA` | `serializeHSLA` | `hsla(216, 100%, 61%, 0.5)` |
 | HSV | `parseHSV` | `serializeHSV` | `hsv(216, 77%, 100%)` |
 | HSVA | `parseHSVA` | `serializeHSVA` | `hsva(216, 77%, 100%, 0.5)` |
-| Named | `parseKeyword` | — | `red`, `rebeccapurple`, `transparent` |
 
-Named colors are the CSS Color Module Level 4 keywords. They are matched case-insensitively, and `transparent` resolves to `rgba(0, 0, 0, 0)`. There is no serializer — a color rarely lands back on a keyword's exact value.
+### Named Colors
+
+The CSS Color Module Level 4 keywords — `red`, `rebeccapurple`, `transparent` — are accepted anywhere a color string is, and `parseKeyword` resolves one directly. They are a keyword lookup rather than a color space: there is no `ColorSpace` identifier for them, `getColorParser` does not match them, and there is no serializer — a color rarely lands back on a keyword's exact value. Matching is case-insensitive, and `transparent` resolves to `rgba(0, 0, 0, 0)`.
 
 ## Parsing Colors
 

--- a/apps/website/src/docs/core/advanced/interpolators.md
+++ b/apps/website/src/docs/core/advanced/interpolators.md
@@ -56,7 +56,7 @@ interpolate(0.5); // 'rgba(157, 67, 162, 1)' (midpoint)
 interpolate(1); // 'rgba(255, 0, 110, 1)'
 ```
 
-Color interpolation works across different color formats, so you can interpolate from a hex color to an RGB color seamlessly.
+Color interpolation works across different color formats, so you can interpolate from a hex color to an RGB color — or from a CSS named color such as `red` to either — seamlessly. Anything `parseColor` cannot resolve (`currentColor`, say) falls back to a hard step at the halfway point.
 
 ### Any Interpolation
 
@@ -192,7 +192,7 @@ circle.radius = interp(t);
 
 ### Color
 
-Interpolates between CSS color strings by parsing to RGBA, interpolating each channel independently, and serializing back.
+Interpolates between CSS color strings by parsing to RGBA, interpolating each channel independently, and serializing back. Named colors are parsed like any other format, so `interpolateColor('red', 'blue')` tweens rather than stepping.
 
 :::tabs
 == Code

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/ripl/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/ripl/node_modules

--- a/packages/3d/test/shape.test.ts
+++ b/packages/3d/test/shape.test.ts
@@ -72,8 +72,6 @@ describe('Shape3D', () => {
 
     describe('Fill parsing', () => {
 
-        // 3D-1: `parseColor` returns undefined for anything but hex/rgb/hsl, and the unguarded
-        // `triangulateFacesFlat` then threw out of the whole render pass.
         test('Should render a shape whose fill is a named colour', () => {
             const context = createFixture();
             const scene = createScene(context, {
@@ -89,20 +87,20 @@ describe('Shape3D', () => {
             expect(faceFills()).toHaveLength(6);
         });
 
+        // 3D-1: the unguarded `triangulateFacesFlat` threw out of the whole render pass here.
         test('Should degrade an unparseable fill to the raw style string', () => {
             const context = createFixture();
             const scene = createScene(context, {
                 children: [
                     createCube({
                         size: 1,
-                        fill: 'red',
+                        fill: 'currentColor',
                     }),
                 ],
             });
 
-            scene.render();
-
-            expect(faceFills()[0].fillStyle).toBe('red');
+            expect(() => scene.render()).not.toThrow();
+            expect(faceFills()[0].fillStyle).toBe('currentColor');
         });
 
         test('Should render a shape whose fill is a gradient', () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,7 @@ npm install @ripl/core
 - **Animation**: High-performance async transitions with CSS-like keyframe support and custom interpolators
 - **Event system**: Event bubbling, delegation, and stop propagation (mimics the DOM)
 - **Scales**: 14 scale types for data mapping: continuous, discrete, ordinal, band, point, diverging, logarithmic, symmetric-log, power, radial, quantile, quantize, threshold, and time
-- **Color**: Color parsing, interpolation, and conversion (RGB, HSL, Hex)
+- **Color**: Color parsing, interpolation, and conversion (RGB, HSL, HSV, Hex, and the CSS named colors)
 - **Math**: Geometry utilities, vector operations, and easing functions
 - **Zero dependencies**: Fully self-contained
 - **Tree-shakable**: Only ship what you use

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -3,6 +3,10 @@ import {
 } from './constants';
 
 import {
+    parseKeyword,
+} from './keywords';
+
+import {
     parseHEX,
     parseHSL,
     parseHSLA,
@@ -28,6 +32,7 @@ import type {
 } from './types';
 
 
+export * from './keywords';
 export * from './parsers';
 export * from './serializers';
 export * from './utilities';
@@ -78,11 +83,19 @@ export function getColorParser(value: string): ColorParser | undefined {
     return PARSER_MAP.find(({ pattern }) => pattern.test(value));
 }
 
-/** Parses any supported color string into an RGBA tuple, or returns `undefined` if no parser matches. */
+/**
+ * Parses any supported color string into an RGBA tuple, or returns `undefined` if nothing matches.
+ *
+ * The functional and hexadecimal formats are tried first via {@link getColorParser}; anything left
+ * over falls through to {@link parseKeyword}, so a CSS named color such as `red` or `transparent`
+ * resolves without a CSSOM.
+ */
 export function parseColor(value: string): ColorRGBA | undefined {
     const parser = getColorParser(value);
 
     if (parser) {
         return parser.parse(value);
     }
+
+    return parseKeyword(value);
 }

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -32,13 +32,14 @@ import type {
 } from './types';
 
 
-export * from './keywords';
 export * from './parsers';
 export * from './serializers';
 export * from './utilities';
 export * from './scales';
 export * from './schemes';
 export * from './types';
+
+export { parseKeyword } from './keywords';
 
 const PARSER_MAP = [
     {

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -79,7 +79,13 @@ const PARSER_MAP = [
     },
 ] as ColorParser[];
 
-/** Finds the first color parser whose pattern matches the given color string. */
+/**
+ * Finds the first color parser whose pattern matches the given color string.
+ *
+ * Matching is purely pattern-based, so a CSS named color such as `red` has no parser and returns
+ * `undefined` here even though {@link parseColor} resolves it. Reach for {@link parseColor} to ask
+ * whether a string is a color Ripl understands.
+ */
 export function getColorParser(value: string): ColorParser | undefined {
     return PARSER_MAP.find(({ pattern }) => pattern.test(value));
 }

--- a/packages/core/src/color/keywords.ts
+++ b/packages/core/src/color/keywords.ts
@@ -179,14 +179,17 @@ export function parseKeyword(value: string): ColorRGBA | undefined {
         return [0, 0, 0, 0];
     }
 
+    // An inherited key such as `constructor` packs to NaN, and `NaN >> 16` is a perfectly valid 0.
+    if (!Object.hasOwn(CSS_COLOR_KEYWORDS, keyword)) {
+        return undefined;
+    }
+
     const packed = CSS_COLOR_KEYWORDS[keyword];
 
-    if (packed !== undefined) {
-        return [
-            (packed >> 16) & 255,
-            (packed >> 8) & 255,
-            packed & 255,
-            1,
-        ];
-    }
+    return [
+        (packed >> 16) & 255,
+        (packed >> 8) & 255,
+        packed & 255,
+        1,
+    ];
 }

--- a/packages/core/src/color/keywords.ts
+++ b/packages/core/src/color/keywords.ts
@@ -10,8 +10,11 @@ import type {
  * packed into one number rather than a tuple to keep the table small; {@link parseKeyword} unpacks
  * on lookup. `transparent` is absent — it is the one keyword carrying an alpha, and packing it here
  * would make it read as opaque black.
+ *
+ * Not exported from the package barrel — {@link parseKeyword} is the public surface. The table is
+ * mutable, so exporting it would let a consumer redefine `red` for every backend at once.
  */
-export const CSS_COLOR_KEYWORDS: Record<string, number> = {
+const CSS_COLOR_KEYWORDS: Record<string, number> = {
     aliceblue: 0xf0f8ff,
     antiquewhite: 0xfaebd7,
     aqua: 0x00ffff,

--- a/packages/core/src/color/keywords.ts
+++ b/packages/core/src/color/keywords.ts
@@ -1,9 +1,15 @@
+import type {
+    ColorRGBA,
+} from './types';
+
 /**
  * The CSS Color Module Level 4 named colors, as packed `0xRRGGBB` integers.
  *
- * A terminal has no CSSOM to resolve a keyword against, so the table is the only way `fill: 'red'`
- * can reach the rasterizer as anything other than "no color". Not exported from the package
- * barrel — {@link colorToAnsiFg} is the public surface.
+ * Only a browser has a CSSOM to resolve a keyword against, so the table is the only way `fill:
+ * 'red'` reaches a canvas, SVG or terminal backend as anything other than "no color". Channels are
+ * packed into one number rather than a tuple to keep the table small; {@link parseKeyword} unpacks
+ * on lookup. `transparent` is absent — it is the one keyword carrying an alpha, and packing it here
+ * would make it read as opaque black.
  */
 export const CSS_COLOR_KEYWORDS: Record<string, number> = {
     aliceblue: 0xf0f8ff,
@@ -155,3 +161,32 @@ export const CSS_COLOR_KEYWORDS: Record<string, number> = {
     yellow: 0xffff00,
     yellowgreen: 0x9acd32,
 };
+
+/**
+ * Parses a CSS named color into an RGBA tuple, tolerating any casing and surrounding whitespace.
+ *
+ * Unlike the format parsers this returns `undefined` rather than throwing, because a keyword cannot
+ * be recognised by shape — an unknown name is indistinguishable from a name of a color space Ripl
+ * does not implement.
+ *
+ * @param value - The color keyword, e.g. `red`, `REBECCAPURPLE`, or `transparent`.
+ * @returns The RGBA tuple, or `undefined` when the name is not a CSS color keyword.
+ */
+export function parseKeyword(value: string): ColorRGBA | undefined {
+    const keyword = value.trim().toLowerCase();
+
+    if (keyword === 'transparent') {
+        return [0, 0, 0, 0];
+    }
+
+    const packed = CSS_COLOR_KEYWORDS[keyword];
+
+    if (packed !== undefined) {
+        return [
+            (packed >> 16) & 255,
+            (packed >> 8) & 255,
+            packed & 255,
+            1,
+        ];
+    }
+}

--- a/packages/core/src/color/utilities.ts
+++ b/packages/core/src/color/utilities.ts
@@ -32,20 +32,19 @@ export function setColorAlpha(color: string, alpha: number) {
 
 /** Determines whether a color string resolves to a fully transparent color. */
 export function isTransparentColor(color: string): boolean {
+    // Overwhelmingly the value asked about, and answering it here skips the whole parser sweep.
+    if (color === 'transparent') {
+        return true;
+    }
+
     const rgba = parseColor(color);
 
     if (rgba) {
         return rgba[3] === 0;
     }
 
-    const trimmed = color.trim().toLowerCase();
-
-    if (trimmed === 'transparent') {
-        return true;
-    }
-
-    // The core rgba/hsla parser rejects a bare `0` alpha (e.g. `rgba(0, 0, 0, 0)`), so match it here.
-    return /^(?:rgba|hsla)\([^)]*[,/]\s*(?:0|0?\.0+|0%)\s*\)$/.test(trimmed);
+    // The core rgba/hsla patterns require comma-separated channels, so match the space/slash form here.
+    return /^(?:rgba|hsla)\([^)]*[,/]\s*(?:0|0?\.0+|0%)\s*\)$/.test(color.trim().toLowerCase());
 }
 
 /** Converts RGBA channel values to an HSLA tuple. */

--- a/packages/core/src/interpolators/color.ts
+++ b/packages/core/src/interpolators/color.ts
@@ -1,5 +1,5 @@
 import {
-    getColorParser,
+    parseColor,
     serializeRGBA,
 } from '../color';
 
@@ -17,15 +17,12 @@ import type {
 
 /** Interpolator factory that smoothly transitions between two CSS color strings by interpolating their RGBA channels. */
 export const interpolateColor: InterpolatorFactory<string> = (valueA, valueB) => {
-    const parserA = getColorParser(valueA);
-    const parserB = getColorParser(valueB);
+    const rgbaA = parseColor(valueA);
+    const rgbaB = parseColor(valueB);
 
-    if (!(parserA && parserB)) {
+    if (!(rgbaA && rgbaB)) {
         return position => position > 0.5 ? valueB : valueA;
     }
-
-    const rgbaA = parserA.parse(valueA);
-    const rgbaB = parserB.parse(valueB);
 
     const interpolators = rgbaA.map((value, index) => {
         return interpolateNumber(value, rgbaB[index]);
@@ -40,4 +37,4 @@ export const interpolateColor: InterpolatorFactory<string> = (valueA, valueB) =>
 };
 
 /** Predicate that matches when the value is a parseable color string. */
-interpolateColor.test = value => typeIsString(value) && !!getColorParser(value);
+interpolateColor.test = value => typeIsString(value) && !!parseColor(value);

--- a/packages/core/test/color/parsers.test.ts
+++ b/packages/core/test/color/parsers.test.ts
@@ -334,6 +334,29 @@ describe('Color', () => {
 
     });
 
+    describe('Named colors', () => {
+
+        test('Should parse a named color to RGBA', () => {
+            expect(parseColor('red')).toEqual([255, 0, 0, 1]);
+            expect(parseColor('steelblue')).toEqual([70, 130, 180, 1]);
+        });
+
+        test('Should parse a named color regardless of case or surrounding space', () => {
+            expect(parseColor('REBECCAPURPLE')).toEqual([102, 51, 153, 1]);
+            expect(parseColor('  ReD  ')).toEqual([255, 0, 0, 1]);
+        });
+
+        test('Should parse "transparent" to a zero alpha', () => {
+            expect(parseColor('transparent')).toEqual([0, 0, 0, 0]);
+        });
+
+        test('Should return undefined for an unknown keyword', () => {
+            expect(parseColor('currentColor')).toBeUndefined();
+            expect(parseColor('notacolor')).toBeUndefined();
+        });
+
+    });
+
     describe('Zero alpha', () => {
 
         // The alpha alternation had no integer branch, so the idiomatic fully-transparent form

--- a/packages/core/test/color/parsers.test.ts
+++ b/packages/core/test/color/parsers.test.ts
@@ -355,6 +355,15 @@ describe('Color', () => {
             expect(parseColor('notacolor')).toBeUndefined();
         });
 
+        // A plain-object lookup reached Object.prototype, and `Number(Object) >> 16` is 0, so every
+        // inherited member resolved to opaque black.
+        test('Should return undefined for an Object.prototype member name', () => {
+            expect(parseColor('constructor')).toBeUndefined();
+            expect(parseColor('__proto__')).toBeUndefined();
+            expect(parseColor('hasOwnProperty')).toBeUndefined();
+            expect(parseColor('toString')).toBeUndefined();
+        });
+
     });
 
     describe('Zero alpha', () => {

--- a/packages/core/test/interpolators/color.test.ts
+++ b/packages/core/test/interpolators/color.test.ts
@@ -58,6 +58,14 @@ describe('Interpolators', () => {
             expect(b).toBeCloseTo(127.5, 1);
         });
 
+        // Named colors had no parser, so the factory fell back to a hard step at the halfway point.
+        test('Should interpolate between named colors', () => {
+            const interpolator = interpolateColor('red', 'blue');
+            const result = interpolator(0.5);
+
+            expect(result).toBe('rgba(127.5, 0, 127.5, 1)');
+        });
+
         test('Should preserve alpha interpolation', () => {
             const interpolator = interpolateColor('rgba(0, 0, 0, 0.2)', 'rgba(0, 0, 0, 0.8)');
             const result = interpolator(0.5);

--- a/packages/terminal/src/color.ts
+++ b/packages/terminal/src/color.ts
@@ -1,6 +1,7 @@
 import {
     isGradientString,
     isPatternString,
+    isTransparentColor,
     parseColor,
     parseGradientCached,
     parsePatternCached,
@@ -32,9 +33,19 @@ const NO_PAINT_KEYWORDS = new Set([
 const ZERO_ALPHA_REGEX = /^(?:rgba|hsla|hsva)\([^)]*,\s*0\s*\)$/i;
 
 /**
- * Resolves a CSS paint string to RGBA, covering everything the shared parsers cover plus the first
- * stop of a gradient or pattern (a character cell cannot interpolate, so the first stop is the
- * closest single color available).
+ * Resolves the single color that stands in for a multi-color paint: the first that is not fully
+ * transparent, so a mostly opaque gradient or pattern still paints rather than vanishing.
+ */
+function resolveRepresentative(colors: string[]): ColorRGBA | undefined {
+    const representative = colors.find(color => !isTransparentColor(color)) ?? colors[0];
+
+    return representative ? resolvePaint(representative) : undefined;
+}
+
+/**
+ * Resolves a CSS paint string to RGBA, covering everything the shared parsers cover plus the
+ * representative color of a gradient or pattern (a character cell cannot interpolate, so one of its
+ * colors is the closest available).
  */
 function resolvePaint(color: string): ColorRGBA | undefined {
     const parsed = parseColor(color);
@@ -44,15 +55,15 @@ function resolvePaint(color: string): ColorRGBA | undefined {
     }
 
     if (isGradientString(color)) {
-        const stop = parseGradientCached(color)?.stops[0];
+        const stops = parseGradientCached(color)?.stops ?? [];
 
-        return stop ? resolvePaint(stop.color) : undefined;
+        return resolveRepresentative(stops.map(stop => stop.color));
     }
 
     if (isPatternString(color)) {
         const pattern = parsePatternCached(color);
 
-        return pattern ? resolvePaint(pattern.foreground) : undefined;
+        return pattern ? resolveRepresentative([pattern.foreground, pattern.background]) : undefined;
     }
 }
 
@@ -94,7 +105,8 @@ function toAnsiSequence(parameter: number, color: string, opacity: number): stri
  *
  * @param color - The paint to resolve. Named colors, hex (including shorthand), `rgb()`/`rgba()`,
  * `hsl()`/`hsla()`, `hsv()`/`hsva()`, gradients and patterns are all supported; a gradient or
- * pattern resolves to its first stop, which is the closest single color a character cell can show.
+ * pattern resolves to its first non-transparent color, the closest single color a character cell
+ * can show.
  * @param opacity - Additional alpha to composite over the paint's own, typically
  * `Context.opacity`. Defaults to `1`.
  * @returns The escape sequence; `''` when the paint is a color the terminal cannot resolve (draw

--- a/packages/terminal/src/color.ts
+++ b/packages/terminal/src/color.ts
@@ -25,11 +25,7 @@ const NO_PAINT_KEYWORDS = new Set([
     'transparent',
 ]);
 
-/**
- * A functional paint whose alpha argument is an explicit integer zero. The shared `rgba`/`hsla`/
- * `hsva` patterns only accept a fractional or percentage alpha, so `rgba(0, 0, 0, 0)` parses as
- * nothing at all and would otherwise be painted as an unresolvable color rather than skipped.
- */
+/** A zero alpha written loosely enough that the shared patterns reject it (`hsla(0, 100, 50, 0)`, stray whitespace), which would otherwise paint as an unresolvable color rather than being skipped. */
 const ZERO_ALPHA_REGEX = /^(?:rgba|hsla|hsva)\([^)]*,\s*0\s*\)$/i;
 
 /**

--- a/packages/terminal/src/color.ts
+++ b/packages/terminal/src/color.ts
@@ -10,10 +10,6 @@ import type {
     ColorRGBA,
 } from '@ripl/core';
 
-import {
-    CSS_COLOR_KEYWORDS,
-} from './constants';
-
 /** ANSI SGR reset sequence. */
 export const ANSI_RESET = '\x1b[0m';
 
@@ -35,32 +31,16 @@ const NO_PAINT_KEYWORDS = new Set([
  */
 const ZERO_ALPHA_REGEX = /^(?:rgba|hsla|hsva)\([^)]*,\s*0\s*\)$/i;
 
-/** Unpacks a `0xRRGGBB` integer into an opaque RGBA tuple. */
-function unpackKeyword(value: number): ColorRGBA {
-    return [
-        (value >> 16) & 255,
-        (value >> 8) & 255,
-        value & 255,
-        1,
-    ];
-}
-
 /**
- * Resolves a CSS paint string to RGBA, covering everything the shared parsers cover plus the CSS
- * named colors and the first stop of a gradient or pattern (a character cell cannot interpolate,
- * so the first stop is the closest single color available).
+ * Resolves a CSS paint string to RGBA, covering everything the shared parsers cover plus the first
+ * stop of a gradient or pattern (a character cell cannot interpolate, so the first stop is the
+ * closest single color available).
  */
 function resolvePaint(color: string): ColorRGBA | undefined {
     const parsed = parseColor(color);
 
     if (parsed) {
         return parsed;
-    }
-
-    const keyword = CSS_COLOR_KEYWORDS[color.trim().toLowerCase()];
-
-    if (keyword !== undefined) {
-        return unpackKeyword(keyword);
     }
 
     if (isGradientString(color)) {

--- a/packages/terminal/test/color.test.ts
+++ b/packages/terminal/test/color.test.ts
@@ -54,11 +54,13 @@ describe('colorToAnsiFg', () => {
         expect(colorToAnsiFg('rgba(255, 0, 0, 0.0)')).toBeUndefined();
     });
 
-    // The shared rgba/hsla/hsva patterns reject an integer alpha, so this parses as nothing at all
-    // and has to be recognised as transparent before it reaches the parsers.
-    test('Should return undefined for an integer zero alpha the shared parsers reject', () => {
+    test('Should return undefined for an integer zero alpha', () => {
         expect(colorToAnsiFg('rgba(255, 0, 0, 0)')).toBeUndefined();
         expect(colorToAnsiFg('hsla(0, 100%, 50%, 0)')).toBeUndefined();
+    });
+
+    test('Should return undefined for a zero alpha the shared patterns reject', () => {
+        expect(colorToAnsiFg('hsla(0, 100, 50, 0)')).toBeUndefined();
     });
 
     test('Should return undefined for zero opacity', () => {

--- a/packages/terminal/test/color.test.ts
+++ b/packages/terminal/test/color.test.ts
@@ -92,6 +92,21 @@ describe('colorToAnsiFg', () => {
         expect(colorToAnsiFg('pattern(diagonal, #ff0000, #ffffff, 8)')).toBe('\x1b[38;2;255;0;0m');
     });
 
+    // A transparent first stop does not make the paint invisible, and dropping it took a
+    // mostly-opaque fill out of the output altogether.
+    test('Should skip a transparent leading gradient stop', () => {
+        expect(colorToAnsiFg('linear-gradient(transparent, red)')).toBe('\x1b[38;2;255;0;0m');
+    });
+
+    test('Should fall back to a pattern\'s background when its foreground is transparent', () => {
+        expect(colorToAnsiFg('pattern(diagonal, transparent, #fff, 8)')).toBe('\x1b[38;2;255;255;255m');
+    });
+
+    test('Should return undefined for a wholly transparent gradient or pattern', () => {
+        expect(colorToAnsiFg('linear-gradient(transparent, transparent)')).toBeUndefined();
+        expect(colorToAnsiFg('pattern(diagonal, transparent, transparent, 8)')).toBeUndefined();
+    });
+
     test('Should fall back to no color for a malformed gradient or pattern', () => {
         expect(colorToAnsiFg('linear-gradient()')).toBe('');
         expect(colorToAnsiFg('pattern()')).toBe('');


### PR DESCRIPTION
`parseColor('red')` returned `undefined`. The CSS named-colour table existed, but it lived in `@ripl/terminal` — the one backend that has to resolve colours in JavaScript rather than handing them to a browser — so core never saw it.

That had a visible consequence beyond the missing lookup. `interpolateColor` falls back to a hard step when either endpoint fails to parse:

```ts
// packages/core/src/interpolators/color.ts
return position > 0.5 ? valueB : valueA;
```

So a transition between named colours snapped at the halfway point instead of tweening. `element.transitionTo({ fill: 'blue' })` from a `fill: 'red'` element jumped; the same two colours written as `#ff0000` and `#0000ff` animated smoothly.

## The fix

The table moves to `packages/core/src/color/keywords.ts` (via `git mv`, so history follows) and `parseColor` gains a keyword fallback after the pattern parsers miss. `interpolateColor` switches from `getColorParser` to `parseColor`, which is what actually picks up the fix — leaving it on `getColorParser` would have kept named colours hard-stepping.

The packed `0xRRGGBB` representation is kept as-is. It is what makes the table small (a tuple form roughly triples it), and terminal already unpacks it with the identical expression.

`transparent` is handled in `parseKeyword` rather than added to the table: it is the only keyword carrying an alpha, and packing it would read as opaque black to anything unpacking the table directly.

Terminal's own keyword branch and its `unpackKeyword` helper are deleted rather than repointed. Once `parseColor` resolves keywords, `resolvePaint` reaches them first and the branch is unreachable — the two unpack expressions are character-identical and both normalise with `.trim().toLowerCase()`.

## Verification

- `yarn test` — 193 files, **2434 passed, 2 skipped, 1 todo**. The 2 skips are the pre-existing `conformance.test.ts` jsdom `toDataURL` cases, unchanged.
- `tsc -p tsconfig.typecheck.json` clean; `eslint` clean on all changed files; TypeDoc `notDocumented` clean for `@ripl/core` and `@ripl/terminal`.
- The interpolation regression test genuinely fails without the fix — confirmed by running it first:
  ```
  FAIL  Should interpolate between named colors
  Expected: "rgba(127.5, 0, 127.5, 1)"
  Received: "red"
  ```
- Bundle cost measured with esbuild on a `parseColor`-only entry: **+2,849 B minified, ~+1,450 B gzipped**. Every `parseColor` consumer pays it. That is the deliberate trade for making `parseColor('red')` work out of the box; the escape hatch, if it is ever judged too expensive, is an opt-in `registerColorKeywords()` at the cost of the fallback no longer being automatic.

## Review findings, fixed in this branch

An adversarial pass found five issues, all addressed here:

1. **Prototype-chain leak.** The table is a plain object literal, so `CSS_COLOR_KEYWORDS['constructor']` reached `Object.prototype` and the `!== undefined` guard passed — `Number(Object)` is `NaN`, `NaN >> 16` is `0`, so `parseColor('constructor')` and `parseColor('__proto__')` returned opaque black. Pre-existing in terminal, but promoting it into core's `parseColor` would have widened it to every backend and interpolator. Now guarded with `Object.hasOwn`, with tests.
2. **A terminal regression.** A gradient or pattern whose *first* stop is `transparent` began returning `undefined` ("do not draw") instead of `''` ("draw, uncoloured") — so `linear-gradient(transparent, red)`, which is mostly opaque red, vanished from terminal output entirely. `resolvePaint` now picks the first stop with a non-zero alpha. Both the gradient and pattern-foreground cases are tested; neither was covered on either revision.
3. **`CSS_COLOR_KEYWORDS` is no longer public.** Only `parseKeyword` is exported. The table's own doc comment on `main` said it was deliberately not barrelled, the analogous `PATTERNS` table is likewise internal, and as a mutable `Record<string, number>` a consumer could have corrupted colour parsing globally.
4. A stale comment in `terminal/src/color.ts` claiming the shared patterns reject a bare `0` alpha — false on both revisions, and the identical claim had already been corrected in `core/src/color/utilities.ts`.
5. `getColorParser`'s JSDoc now states it is pattern-based only and does not recognise named colours, so it is no longer mistaken for an is-this-a-colour predicate — which is exactly what `interpolateColor.test` used it as before this change.

The review also tested the risk I was most worried about and cleared it: CSS colour names include ordinary words (`tan`, `linen`, `snow`, `plum`, `peru`), so widening `interpolateColor.test` could have hijacked a non-colour string property. All 521 string-literal union tokens across the packages were intersected with the 148 names; the only overlap is `transparent`, which is a colour everywhere it appears. Every string-valued state enum is clean.

## Breaking

- **`parseColor` returns a value for named colours** where it previously returned `undefined`. Code branching on `undefined` as a proxy for "let the CSSOM handle this" now takes the other branch — `@ripl/3d` is the in-repo example, where a named `fill` used to degrade to the raw style string and now gets per-face shading like any other colour. `currentColor`, `inherit`, `lab()` and space-separated `rgb()` still return `undefined`.
- **Named colours now tween.** Any chart configured with a named-colour array (`interpolateColors(['red','green','blue'])`, heatmap ranges, ordinal scales) goes from hard bands to a smooth gradient. This is the intended fix, but it changes rendered output for existing users — worth knowing before you look at the preview.
- **`@ripl/terminal`'s `CSS_COLOR_KEYWORDS` is gone.** It was never in that package's barrel, so only a deep import into `@ripl/terminal/src/constants` breaks.

## Follow-up

`interpolateColor.test('transparent')` is now `true`, so a pattern whose background is the default `'transparent'` interpolates to `rgba(0, 0, 0, 0)` rather than staying the literal string. Canvas and SVG both gate on `background !== 'transparent'`, so both now take the paint branch — a zero-alpha `fillRect` and a redundant `<rect>` respectively. Traced both: visually a no-op under default compositing, so this is wasted work and a stray DOM node rather than a regression. Best folded in whenever the pattern code is next touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnbBNvcQzqikWSyApb47Xb)_