### PR TITLE
Give arcs a constant-width gap and make borderRadius actually round the corners

### DIFF
--- a/.claude/skills/ripl-charts/SKILL.md
+++ b/.claude/skills/ripl-charts/SKILL.md
@@ -150,13 +150,21 @@ Use `createSegmentLabel({ id, x, y, content, font })` (fades via `text.data = { 
 
 ## Element toolkit (`@ripl/core`)
 
-`createCircle` (`cx,cy,radius`), `createArc` (`cx,cy,radius,innerRadius?,startAngle,endAngle,padAngle?`),
+`createCircle` (`cx,cy,radius`), `createArc` (`cx,cy,radius,innerRadius?,startAngle,endAngle,padAngle?,padWidth?,borderRadius?`),
 `createLine` (`x1,y1,x2,y2`), `createPolyline` (`points`, `renderer`), `createText`, `createGroup`,
 `createRect`. Shapes take `autoFill`/`autoStroke` toggles.
 
-- **Rounded radial/progress bars**: draw an **open arc** (no `innerRadius`) on the band centerline,
-  stroked with `lineWidth = band thickness` and `lineCap: 'round'` — a round cap rounds the sweeping
-  end. `Arc`'s `borderRadius` is not implemented in render; don't rely on it.
+- **Rounded radial/progress bars**: prefer a **filled** annular arc (`innerRadius` + `radius` at the
+  band edges) with a scalar `borderRadius` — it rounds all four corners and clamps itself to half the
+  band thickness, so an over-rounded segment becomes a capsule rather than self-intersecting. The
+  **stroked open arc** (no `innerRadius`, on the band centerline, `lineWidth = band thickness`,
+  `lineCap: 'round'`) is still the right tool for a genuinely **stroke-only** bar — a track/value pair
+  where you want caps without a fill, or where the band is a stroke you also dash. An open arc's
+  `borderRadius` rounds only its two outer corners and keeps a sharp center point.
+- **Arc padding**: `padAngle` (radians) opens a wedge that widens with radius; `padWidth` (pixels)
+  insets each radius by `asin(padWidth / 2r)` so the gap keeps a constant width and neighbouring
+  segments have parallel edges. `padWidth` wins where both are set, and padding is applied before
+  corner rounding.
 - **Polyline curves**: `renderer` is a named type (`'linear' | 'spline' | 'cardinal' | 'monotoneX' | …`)
   or a custom `(context, path, points) => void`. Resolve a named one with `resolvePolylineRenderer`.
 - **`matches`/`closest`** are on **every `Element`** (via the `Queryable` contract), not just `Group`:
@@ -263,7 +271,8 @@ Add a `create<Name>Chart(mount('<name>'), { animation: false, … })` block to
 - **Non-tweenable props** (`renderer`, `lineCap`, `lineDash`, `stroke`, text `content`) must be set
   **directly** on the element, not put in the transition `state` — the tween would snap them at t=0.5.
 - **Curved area fills** gap against the line unless you use the `core/fill.ts` band renderers.
-- **Stroked arcs** for rounded bars; `Arc.borderRadius` does nothing.
+- **`Arc.borderRadius` is a scalar**, not the Rect family's `number | [tl, tr, br, bl] | 'full'`; it
+  clamps to half the band thickness, so passing a huge number gives a capsule, not an error.
 - **Reweight/reflow** should animate from current positions — persist layout state (force positions,
   morph keys) between renders.
 - Call **`this.init()` last** in the constructor; it triggers the first render.

--- a/.claude/skills/ripl-charts/SKILL.md
+++ b/.claude/skills/ripl-charts/SKILL.md
@@ -160,11 +160,16 @@ Use `createSegmentLabel({ id, x, y, content, font })` (fades via `text.data = { 
   **stroked open arc** (no `innerRadius`, on the band centerline, `lineWidth = band thickness`,
   `lineCap: 'round'`) is still the right tool for a genuinely **stroke-only** bar — a track/value pair
   where you want caps without a fill, or where the band is a stroke you also dash. An open arc's
-  `borderRadius` rounds only its two outer corners and keeps a sharp center point.
+  `borderRadius` rounds only its two outer corners and keeps a sharp center point. **It also flips the
+  open arc's topology**: `0` emits a bare arc (a fill closes it with a chord — a circular segment),
+  any non-zero value closes it through the centre (a wedge), so filled area, `isPointInPath` hit
+  region and the stroke (which gains two radial spokes) all jump at that boundary. Never animate an
+  open arc's `borderRadius` up from `0` — use an annular arc if the rounding must animate.
 - **Arc padding**: `padAngle` (radians) opens a wedge that widens with radius; `padWidth` (pixels)
-  insets each radius by `asin(padWidth / 2r)` so the gap keeps a constant width and neighbouring
-  segments have parallel edges. `padWidth` wins where both are set, and padding is applied before
-  corner rounding.
+  insets each radius by `asin(padWidth / 2r)` so the gap keeps a constant width — parallel facing
+  edges on an annular sector, a single outer-radius trim on an open arc. `padWidth` wins wherever it
+  is *provided* (`padWidth: 0` means no padding, not "use `padAngle`", so animating it up from `0` is
+  continuous), and padding is applied before corner rounding.
 - **Polyline curves**: `renderer` is a named type (`'linear' | 'spline' | 'cardinal' | 'monotoneX' | …`)
   or a custom `(context, path, points) => void`. Resolve a named one with `resolvePolylineRenderer`.
 - **`matches`/`closest`** are on **every `Element`** (via the `Queryable` contract), not just `Group`:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 .output/
 
 # dependencies
-node_modules/
+node_modules
 
 .pnp.*
 .yarn/*

--- a/apps/website/src/charts/shared-options.md
+++ b/apps/website/src/charts/shared-options.md
@@ -257,6 +257,12 @@ createBarChart('#container', {
 | `maxWidth` | `number` | `200` | Maximum width |
 | `wrap` | `boolean` | `false` | Wrap long text |
 
+> [!NOTE]
+> The `number | [tl, tr, br, bl] | 'full'` shape is the **Rect family's**
+> `borderRadius`. The [Arc](/docs/core/elements/arc) element takes a plain
+> `number` instead — an annular sector has no meaningful corner order — and
+> clamps it to half the band thickness and to what the sector's span allows.
+
 ## Legend
 
 Series legend with interactive highlighting.

--- a/apps/website/src/docs/core/elements/arc.md
+++ b/apps/website/src/docs/core/elements/arc.md
@@ -4,7 +4,9 @@ outline: "deep"
 
 # Arc
 
-An **Arc** draws a circular or annular (donut) arc segment defined by a center point, radius, and angular range. It supports `innerRadius` for donut shapes, `padAngle` for spacing between segments, and `borderRadius` for rounded corners. The `getCentroid()` method returns the visual center of the arc, making it easy to position labels on pie or donut slices.
+An **Arc** draws a circular or annular (donut) arc segment defined by a center point, radius, and angular range. It supports `innerRadius` for donut shapes, `padAngle` and `padWidth` for spacing between segments, and `borderRadius` for rounded corners. The `getCentroid()` method returns the visual center of the arc, making it easy to position labels on pie or donut slices.
+
+`padAngle` insets both ends by a fixed **angle**, so the resulting gap is a wedge — narrow at the inner radius and wide at the outer. `padWidth` insets each radius by `asin(padWidth / 2r)` instead, so the gap keeps a constant width in **pixels** and neighbouring segments face each other with parallel edges. When both are set, `padWidth` wins.
 
 ## Example
 
@@ -17,10 +19,12 @@ An **Arc** draws a circular or annular (donut) arc segment defined by a center p
             <RiplInputRange v-model="endAnglePct" :min="0" :max="100" :step="1" @update:model-value="redraw" />
             <span>Inner Radius %</span>
             <RiplInputRange v-model="innerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redraw" />
-            <span>Pad Angle</span>
+            <span>Pad Angle (set Pad Width to 0)</span>
             <RiplInputRange v-model="padAngleVal" :min="0" :max="20" :step="1" @update:model-value="redraw" />
+            <span>Pad Width</span>
+            <RiplInputRange v-model="padWidthVal" :min="0" :max="40" :step="1" @update:model-value="redraw" />
             <span>Border Radius</span>
-            <RiplInputRange v-model="borderRadiusVal" :min="0" :max="20" :step="1" @update:model-value="redraw" />
+            <RiplInputRange v-model="borderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redraw" />
         </RiplControlGroup>
     </template>
 </ripl-example>
@@ -39,8 +43,8 @@ createArc({
     radius: 80,
     innerRadius: 40,
     startAngle: 0,
-    endAngle: TAU * 0.75,
-    padAngle: 0.05,
+    endAngle: TAU * 0.25,
+    padWidth: 6,
     borderRadius: 4,
 }).render(context);
 ```
@@ -65,10 +69,12 @@ import {
 } from 'vue';
 
 const TAU = Math.PI * 2;
+const SEGMENT_FILLS = ['#3a86ff', '#8338ec', '#ff006e'];
 const endAnglePct = ref(75);
 const innerRadiusPct = ref(50);
-const padAngleVal = ref(2);
-const borderRadiusVal = ref(4);
+const padAngleVal = ref(0);
+const padWidthVal = ref(8);
+const borderRadiusVal = ref(6);
 let currentContext: Context | undefined;
 
 function renderDemo(context: Context) {
@@ -77,23 +83,26 @@ function renderDemo(context: Context) {
     const r = Math.min(w, h) / 3;
 
     context.batch(() => {
-        const endAngle = TAU * (endAnglePct.value / 100);
+        const sweep = TAU * (endAnglePct.value / 100);
         const innerRadius = r * (innerRadiusPct.value / 100);
         const padAngle = padAngleVal.value * 0.01;
 
-        createArc({
-            fill: '#3a86ff',
-            cx: w / 2, cy: h / 2, radius: r,
-            innerRadius,
-            startAngle: 0,
-            endAngle,
-            padAngle,
-            borderRadius: borderRadiusVal.value,
-        }).render(context);
+        SEGMENT_FILLS.forEach((fill, index) => {
+            createArc({
+                fill,
+                cx: w / 2, cy: h / 2, radius: r,
+                innerRadius,
+                startAngle: sweep * (index / SEGMENT_FILLS.length),
+                endAngle: sweep * ((index + 1) / SEGMENT_FILLS.length),
+                padAngle,
+                padWidth: padWidthVal.value,
+                borderRadius: borderRadiusVal.value,
+            }).render(context);
+        });
 
         createText({
             x: w / 2, y: h / 2 + r + 24,
-            content: `endAngle: ${Math.round(endAnglePct.value)}%  inner: ${innerRadiusPct.value}%  pad: ${padAngleVal.value}  radius: ${borderRadiusVal.value}`,
+            content: `sweep: ${Math.round(endAnglePct.value)}%  inner: ${innerRadiusPct.value}%  padAngle: ${padAngleVal.value}  padWidth: ${padWidthVal.value}  radius: ${borderRadiusVal.value}`,
             fill: '#666', textAlign: 'center', font: '12px sans-serif',
         }).render(context);
     });
@@ -131,7 +140,9 @@ const arc = createArc({
 
 ## Properties
 
-The arc's geometry is defined by `cx`, `cy`, `radius`, `startAngle`, and `endAngle`. Optional properties include `innerRadius` (for donut arcs), `padAngle` (spacing between segments), and `borderRadius` (corner rounding).
+The arc's geometry is defined by `cx`, `cy`, `radius`, `startAngle`, and `endAngle`. Optional properties include `innerRadius` (for donut arcs), `padAngle` (angular spacing between segments, in radians), `padWidth` (constant-width spacing between segments, in pixels — takes precedence over `padAngle`), and `borderRadius` (corner rounding).
+
+`borderRadius` is a single number — unlike the Rect family, an annular sector has no meaningful per-corner order, so the `[tl, tr, br, bl]` tuple form is not accepted. It is clamped to half the band thickness (`(radius - innerRadius) / 2`) and to what the sector's span allows, so an over-rounded segment degrades into a capsule rather than self-intersecting. An annular sector rounds all four corners; an open arc rounds its two outer corners and keeps a sharp center point. Padding is applied before rounding, so gaps stay constant.
 
 > [!NOTE]
 > For the full property list, see the [Arc API Reference](/docs/api/@ripl/core/).

--- a/apps/website/src/docs/core/elements/arc.md
+++ b/apps/website/src/docs/core/elements/arc.md
@@ -6,7 +6,7 @@ outline: "deep"
 
 An **Arc** draws a circular or annular (donut) arc segment defined by a center point, radius, and angular range. It supports `innerRadius` for donut shapes, `padAngle` and `padWidth` for spacing between segments, and `borderRadius` for rounded corners. The `getCentroid()` method returns the visual center of the arc, making it easy to position labels on pie or donut slices.
 
-`padAngle` insets both ends by a fixed **angle**, so the resulting gap is a wedge — narrow at the inner radius and wide at the outer. `padWidth` insets each radius by `asin(padWidth / 2r)` instead, so the gap keeps a constant width in **pixels** and neighbouring segments face each other with parallel edges. When both are set, `padWidth` wins.
+`padAngle` insets both ends by a fixed **angle**, so the resulting gap is a wedge — narrow at the inner radius and wide at the outer. `padWidth` insets each radius by `asin(padWidth / 2r)` instead, so the gap keeps a constant width in **pixels**. On an annular sector (one with an `innerRadius`) that makes neighbouring segments face each other with parallel edges; an **open** arc has no inner edge to inset, so `padWidth` degenerates to a single trim at the outer radius and adjacent edges converge to nothing at the centre. `padWidth` wins wherever it is **provided** — including `padWidth: 0`, which means *no padding* rather than *fall back to `padAngle`*, so animating `padWidth` up from `0` is continuous.
 
 ## Example
 
@@ -95,7 +95,7 @@ function renderDemo(context: Context) {
                 startAngle: sweep * (index / SEGMENT_FILLS.length),
                 endAngle: sweep * ((index + 1) / SEGMENT_FILLS.length),
                 padAngle,
-                padWidth: padWidthVal.value,
+                padWidth: padWidthVal.value || undefined,
                 borderRadius: borderRadiusVal.value,
             }).render(context);
         });
@@ -140,9 +140,12 @@ const arc = createArc({
 
 ## Properties
 
-The arc's geometry is defined by `cx`, `cy`, `radius`, `startAngle`, and `endAngle`. Optional properties include `innerRadius` (for donut arcs), `padAngle` (angular spacing between segments, in radians), `padWidth` (constant-width spacing between segments, in pixels — takes precedence over `padAngle`), and `borderRadius` (corner rounding).
+The arc's geometry is defined by `cx`, `cy`, `radius`, `startAngle`, and `endAngle`. Optional properties include `innerRadius` (for donut arcs), `padAngle` (angular spacing between segments, in radians), `padWidth` (constant-width spacing between segments, in pixels — takes precedence over `padAngle` wherever it is provided), and `borderRadius` (corner rounding).
 
 `borderRadius` is a single number — unlike the Rect family, an annular sector has no meaningful per-corner order, so the `[tl, tr, br, bl]` tuple form is not accepted. It is clamped to half the band thickness (`(radius - innerRadius) / 2`) and to what the sector's span allows, so an over-rounded segment degrades into a capsule rather than self-intersecting. An annular sector rounds all four corners; an open arc rounds its two outer corners and keeps a sharp center point. Padding is applied before rounding, so gaps stay constant.
+
+> [!WARNING]
+> On an **open** arc (no `innerRadius`), `borderRadius` also changes the path's topology. At `borderRadius: 0` the arc is a bare arc command, which a fill closes with a chord — a circular *segment*. Any non-zero `borderRadius` closes the path through the centre instead, making it a *wedge*. Filled area, the `isPointInPath` hit region, and the stroke (which gains two radial spokes to the centre) all jump at that boundary, so do not animate an open arc's `borderRadius` up from `0`. Annular sectors are unaffected — set an `innerRadius` if you need to animate corner rounding.
 
 > [!NOTE]
 > For the full property list, see the [Arc API Reference](/docs/api/@ripl/core/).

--- a/apps/website/src/docs/core/elements/arc.md
+++ b/apps/website/src/docs/core/elements/arc.md
@@ -11,20 +11,33 @@ An **Arc** draws a circular or annular (donut) arc segment defined by a center p
 ## Example
 
 :::tabs
-== Demo
-<ripl-example @context-changed="contextChanged">
+== Single
+<ripl-example @context-changed="singleChanged">
     <template #footer>
         <RiplControlGroup>
             <span>End Angle</span>
-            <RiplInputRange v-model="endAnglePct" :min="0" :max="100" :step="1" @update:model-value="redraw" />
+            <RiplInputRange v-model="singleEndAnglePct" :min="0" :max="100" :step="1" @update:model-value="redrawSingle" />
             <span>Inner Radius %</span>
-            <RiplInputRange v-model="innerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redraw" />
-            <span>Pad Angle (set Pad Width to 0)</span>
-            <RiplInputRange v-model="padAngleVal" :min="0" :max="20" :step="1" @update:model-value="redraw" />
-            <span>Pad Width</span>
-            <RiplInputRange v-model="padWidthVal" :min="0" :max="40" :step="1" @update:model-value="redraw" />
+            <RiplInputRange v-model="singleInnerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redrawSingle" />
             <span>Border Radius</span>
-            <RiplInputRange v-model="borderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redraw" />
+            <RiplInputRange v-model="singleBorderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redrawSingle" />
+        </RiplControlGroup>
+    </template>
+</ripl-example>
+== Stacked
+<ripl-example @context-changed="stackedChanged">
+    <template #footer>
+        <RiplControlGroup>
+            <span>End Angle</span>
+            <RiplInputRange v-model="stackedEndAnglePct" :min="0" :max="100" :step="1" @update:model-value="redrawStacked" />
+            <span>Inner Radius %</span>
+            <RiplInputRange v-model="stackedInnerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redrawStacked" />
+            <span>Pad Width (px, takes precedence)</span>
+            <RiplInputRange v-model="stackedPadWidthVal" :min="0" :max="40" :step="1" @update:model-value="redrawStacked" />
+            <span>Pad Angle (applies only at Pad Width 0)</span>
+            <RiplInputRange v-model="stackedPadAngleVal" :min="0" :max="20" :step="1" @update:model-value="redrawStacked" />
+            <span>Border Radius</span>
+            <RiplInputRange v-model="stackedBorderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redrawStacked" />
         </RiplControlGroup>
     </template>
 </ripl-example>
@@ -50,6 +63,8 @@ createArc({
 ```
 :::
 
+**Single** is one `createArc` call. **Stacked** is three of them sharing a centre, which is the only arrangement where padding has anything to separate — hence the two extra controls.
+
 <script lang="ts" setup>
 import {
     useRiplExample,
@@ -70,22 +85,51 @@ import {
 
 const TAU = Math.PI * 2;
 const SEGMENT_FILLS = ['#3a86ff', '#8338ec', '#ff006e'];
-const endAnglePct = ref(75);
-const innerRadiusPct = ref(50);
-const padAngleVal = ref(0);
-const padWidthVal = ref(8);
-const borderRadiusVal = ref(6);
-let currentContext: Context | undefined;
 
-function renderDemo(context: Context) {
+const singleEndAnglePct = ref(75);
+const singleInnerRadiusPct = ref(50);
+const singleBorderRadiusVal = ref(6);
+let singleContext: Context | undefined;
+
+const stackedEndAnglePct = ref(100);
+const stackedInnerRadiusPct = ref(50);
+const stackedPadWidthVal = ref(8);
+const stackedPadAngleVal = ref(0);
+const stackedBorderRadiusVal = ref(6);
+let stackedContext: Context | undefined;
+
+function renderSingle(context: Context) {
     const w = context.width;
     const h = context.height;
     const r = Math.min(w, h) / 3;
 
     context.batch(() => {
-        const sweep = TAU * (endAnglePct.value / 100);
-        const innerRadius = r * (innerRadiusPct.value / 100);
-        const padAngle = padAngleVal.value * 0.01;
+        createArc({
+            fill: '#3a86ff',
+            cx: w / 2, cy: h / 2, radius: r,
+            innerRadius: r * (singleInnerRadiusPct.value / 100),
+            startAngle: 0,
+            endAngle: TAU * (singleEndAnglePct.value / 100),
+            borderRadius: singleBorderRadiusVal.value,
+        }).render(context);
+
+        createText({
+            x: w / 2, y: h / 2 + r + 24,
+            content: `endAngle: ${singleEndAnglePct.value}%  inner: ${singleInnerRadiusPct.value}%  borderRadius: ${singleBorderRadiusVal.value}`,
+            fill: '#666', textAlign: 'center', font: '12px sans-serif',
+        }).render(context);
+    });
+}
+
+function renderStacked(context: Context) {
+    const w = context.width;
+    const h = context.height;
+    const r = Math.min(w, h) / 3;
+
+    context.batch(() => {
+        const sweep = TAU * (stackedEndAnglePct.value / 100);
+        const innerRadius = r * (stackedInnerRadiusPct.value / 100);
+        const padAngle = stackedPadAngleVal.value * 0.01;
 
         SEGMENT_FILLS.forEach((fill, index) => {
             createArc({
@@ -95,29 +139,41 @@ function renderDemo(context: Context) {
                 startAngle: sweep * (index / SEGMENT_FILLS.length),
                 endAngle: sweep * ((index + 1) / SEGMENT_FILLS.length),
                 padAngle,
-                padWidth: padWidthVal.value || undefined,
-                borderRadius: borderRadiusVal.value,
+                padWidth: stackedPadWidthVal.value || undefined,
+                borderRadius: stackedBorderRadiusVal.value,
             }).render(context);
         });
 
         createText({
             x: w / 2, y: h / 2 + r + 24,
-            content: `sweep: ${Math.round(endAnglePct.value)}%  inner: ${innerRadiusPct.value}%  padAngle: ${padAngleVal.value}  padWidth: ${padWidthVal.value}  radius: ${borderRadiusVal.value}`,
+            content: `sweep: ${stackedEndAnglePct.value}%  inner: ${stackedInnerRadiusPct.value}%  padWidth: ${stackedPadWidthVal.value}  padAngle: ${stackedPadAngleVal.value}  borderRadius: ${stackedBorderRadiusVal.value}`,
             fill: '#666', textAlign: 'center', font: '12px sans-serif',
         }).render(context);
     });
 }
 
 const {
-    contextChanged
+    contextChanged: singleChanged
 } = useRiplExample(context => {
-    currentContext = context;
-    renderDemo(context);
-    context.on('resize', () => renderDemo(context));
+    singleContext = context;
+    renderSingle(context);
+    context.on('resize', () => renderSingle(context));
 });
 
-function redraw() {
-    if (currentContext) renderDemo(currentContext);
+const {
+    contextChanged: stackedChanged
+} = useRiplExample(context => {
+    stackedContext = context;
+    renderStacked(context);
+    context.on('resize', () => renderStacked(context));
+});
+
+function redrawSingle() {
+    if (singleContext) renderSingle(singleContext);
+}
+
+function redrawStacked() {
+    if (stackedContext) renderStacked(stackedContext);
 }
 </script>
 
@@ -133,8 +189,10 @@ const arc = createArc({
     cx: 200,
     cy: 200,
     radius: 100,
+    innerRadius: 50,
     startAngle: 0,
-    endAngle: Math.PI,
+    endAngle: Math.PI * 1.5,
+    borderRadius: 6,
 });
 ```
 

--- a/packages/charts/OPTIONS.md
+++ b/packages/charts/OPTIONS.md
@@ -67,6 +67,14 @@ all.
   internally. `startAngle`, `endAngle`, `padAngle`.
 - **`gap` is always pixels.** A proportional gap between band-scaled marks is
   `bandPadding` (0–1), matching band-scale terminology.
+- **`padWidth` is pixels, between radial segments.** It is the linear sibling of
+  `padAngle`: where `padAngle` insets each end of a sector by a fixed *angle* and
+  so opens a wedge that widens with radius, `padWidth` insets each radius by
+  `asin(padWidth / 2r)` and so opens a gap of constant width whose facing edges
+  are parallel. Use `padWidth` when the gap must read the same at the inner and
+  outer edge of a donut; use `padAngle` when the gap should scale with the
+  segment. `padWidth` takes precedence where both are set. It is distinct from
+  `gap`, which separates non-radial marks along an axis.
 - **Radii accept `number | \`${number}%\``**: a value ≤ 1 or a percent string is a
   fraction of the outer radius, a value > 1 is pixels. `innerRadius`,
   `outerRadius`.
@@ -93,6 +101,13 @@ One shape per property name, across every chart:
 
 `palette` and `gradient` are distinct because a positional palette and a
 sequential ramp are not interchangeable — they were both called `colors`.
+
+`borderRadius` on the **Arc** element is the one exception to that shape: it is a
+plain `number`. An annular sector's corners have no `[tl, tr, br, bl]` order to
+address, and the radius is clamped per-corner to half the band thickness and to
+what the sector's span allows, so a `'full'` sentinel would mean nothing beyond
+passing a large number. Anything laying out arcs (pie, donut, radial, gauge)
+passes a scalar through.
 
 A shared shape may still be *narrower* on a chart where the wider form has no
 meaning. `TrendChartOptions.stacked` takes `boolean` rather than

--- a/packages/charts/OPTIONS.md
+++ b/packages/charts/OPTIONS.md
@@ -70,10 +70,14 @@ all.
 - **`padWidth` is pixels, between radial segments.** It is the linear sibling of
   `padAngle`: where `padAngle` insets each end of a sector by a fixed *angle* and
   so opens a wedge that widens with radius, `padWidth` insets each radius by
-  `asin(padWidth / 2r)` and so opens a gap of constant width whose facing edges
-  are parallel. Use `padWidth` when the gap must read the same at the inner and
-  outer edge of a donut; use `padAngle` when the gap should scale with the
-  segment. `padWidth` takes precedence where both are set. It is distinct from
+  `asin(padWidth / 2r)` and so opens a gap of constant width. The facing edges
+  are parallel on an **annular** sector; an open arc has no inner edge to inset,
+  so `padWidth` becomes a single trim at the outer radius and adjacent edges
+  converge to nothing at the centre. Use `padWidth` when the gap must read the
+  same at the inner and outer edge of a donut; use `padAngle` when the gap should
+  scale with the segment. `padWidth` takes precedence wherever it is
+  **provided** — `padWidth: 0` means *no padding*, not *fall back to
+  `padAngle`* — so animating it up from `0` is continuous. It is distinct from
   `gap`, which separates non-radial marks along an axis.
 - **Radii accept `number | \`${number}%\``**: a value ≤ 1 or a percent string is a
   fraction of the outer radius, a value > 1 is pixels. `innerRadius`,
@@ -107,7 +111,11 @@ plain `number`. An annular sector's corners have no `[tl, tr, br, bl]` order to
 address, and the radius is clamped per-corner to half the band thickness and to
 what the sector's span allows, so a `'full'` sentinel would mean nothing beyond
 passing a large number. Anything laying out arcs (pie, donut, radial, gauge)
-passes a scalar through.
+passes a scalar through. On an **open** arc (no `innerRadius`) it also flips the
+path's topology: `0` leaves a bare arc that a fill closes with a chord (a
+circular segment), any non-zero value closes it through the centre (a wedge).
+Filled area, hit region and stroke all jump at that boundary, so never animate an
+open arc's `borderRadius` up from `0` — give it an `innerRadius` instead.
 
 A shared shape may still be *narrower* on a chart where the wider form has no
 meaning. `TrendChartOptions.stacked` takes `boolean` rather than

--- a/packages/charts/test/visual/README.md
+++ b/packages/charts/test/visual/README.md
@@ -40,6 +40,10 @@ resolving against the group's composed box (`canvas.md` 3 / `svg.md` S-4), and g
 compositing multiplicatively (`canvas.md` 11 / `svg.md` S-5). Both currently measure a mismatch of
 **0** with a maximum channel delta of 1; reverting either fix moves a quarter of the frame or more.
 
+`arc-sector` joins them: a padded, rounded donut segment, which `SVGPath.arc` used to shatter into
+one sub-path per arc call by emitting an `M` where canvas draws an implicit line. Reverting the fix
+moves **16.1%** of the frame — the annulus fills with a white void.
+
 A second describe block covers `KNOWN_DIVERGENCE_SCENES` — gaps that were **decided rather than
 fixed**, each asserted to stay inside a band around its measured mismatch. The assertion runs from
 both sides, so a regression that widens the gap fails and so does a fix that closes it without

--- a/packages/charts/test/visual/parity-ids.ts
+++ b/packages/charts/test/visual/parity-ids.ts
@@ -9,10 +9,16 @@
  *   leaf against each leaf's own box, restarting the ramp on every child.
  * - `group-opacity` — a group at `0.5` containing a leaf at `0.5` must paint the leaf at `0.25`
  *   on both backends (`canvas.md` 11, `svg.md` S-5).
+ * - `arc-sector` — a padded, rounded donut segment must fill solid on both backends. `SVGPath.arc`
+ *   used to emit an `M` at each arc's start point, which ends the current sub-path and opens a new
+ *   one; canvas's `arc()` joins to the current point with an implicit line and stays in the same
+ *   sub-path. Every arc call therefore split the segment into its own sub-path, and the outer
+ *   (winding +1) and inner (−1) fragments cancelled under `nonzero` into a white void.
  */
 export const PARITY_SCENE_IDS = [
     'group-gradient',
     'group-opacity',
+    'arc-sector',
 ] as const;
 
 /**

--- a/packages/charts/test/visual/parity.ts
+++ b/packages/charts/test/visual/parity.ts
@@ -23,6 +23,7 @@ import type {
 } from './parity-ids';
 
 import {
+    createArc,
     createGroup,
     createRect,
     createScene,
@@ -100,6 +101,23 @@ const SCENES: Record<ParitySceneId, (context: Context) => Scene> = {
                         ...RIGHT,
                     }),
                 ],
+            }),
+        ],
+    }),
+    // Every arc call must extend the one sub-path, or the annulus's windings cancel to a white void.
+    'arc-sector': context => createScene(context, {
+        children: [
+            createArc({
+                id: 'donut-segment',
+                fill: OPAQUE_BLACK,
+                cx: 130,
+                cy: 138,
+                radius: 133.33,
+                innerRadius: 70.67,
+                startAngle: -2.84,
+                endAngle: -1.65,
+                padWidth: 6,
+                borderRadius: 1,
             }),
         ],
     }),

--- a/packages/core/src/elements/arc.ts
+++ b/packages/core/src/elements/arc.ts
@@ -9,18 +9,34 @@ import type {
 
 import type {
     Context,
+    ContextPath,
 } from '../context';
 
 import {
     Box,
+    getPadAngleAtRadius,
     getThetaPoint,
+    TAU,
 } from '../math';
 
 import {
     typeIsNil,
 } from '@ripl/utilities';
 
-/** State interface for an arc element, defining center, angles, radii, pad angle, and border radius. */
+/** Pad-trimmed sector geometry a rounded annular sector is traced from. */
+interface ArcSector {
+    cx: number;
+    cy: number;
+    radius: number;
+    innerRadius: number;
+    startAngle: number;
+    endAngle: number;
+    halfGap: number;
+    outerCornerRadius: number;
+    innerCornerRadius: number;
+}
+
+/** State interface for an arc element, defining center, angles, radii, padding, and border radius. */
 export interface ArcState extends BaseElementState {
     /** The x-coordinate of the arc's center. */
     cx: number;
@@ -34,13 +50,146 @@ export interface ArcState extends BaseElementState {
     radius: number;
     /** The inner radius of the arc, producing an annular sector when set. */
     innerRadius?: number;
-    /** The angular padding between the arc and its neighbors, in radians. */
+    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link ArcState.padWidth} for a gap of constant width. Ignored when `padWidth` is set. */
     padAngle?: number;
-    /** The corner radius applied to the arc's corners. */
+    /** The padding between the arc and its neighbors, in logical pixels, held constant at every radius so adjacent segments face each other with parallel edges. Takes precedence over {@link ArcState.padAngle}. */
+    padWidth?: number;
+    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. */
     borderRadius?: number;
 }
 
-/** An arc or annular sector shape supporting inner radius and pad angle. */
+const HALF_PI = Math.PI / 2;
+
+/** Insets a sector by `inset` at both ends, collapsing it to its mid-angle rather than inverting it. */
+function insetSector(startAngle: number, endAngle: number, inset: number): [number, number] {
+    if (inset <= 0) {
+        return [
+            startAngle,
+            endAngle,
+        ];
+    }
+
+    const start = startAngle + inset;
+    const end = endAngle - inset;
+
+    if (start <= end) {
+        return [
+            start,
+            end,
+        ];
+    }
+
+    const midAngle = (startAngle + endAngle) / 2;
+
+    return [
+        midAngle,
+        midAngle,
+    ];
+}
+
+/** Traces a forward arc, pinning a sub-epsilon inverted sweep to zero rather than letting it wrap a full turn. */
+function traceForwardArc(path: ContextPath, cx: number, cy: number, radius: number, fromAngle: number, toAngle: number): void {
+    path.arc(cx, cy, radius, fromAngle, Math.max(fromAngle, toAngle));
+}
+
+/** Angular offset from a sector edge to the center of a corner circle of `cornerRadius` seated at `centerRadius`. */
+function getCornerCenterOffset(centerRadius: number, halfGap: number, cornerRadius: number): number {
+    const offset = halfGap + cornerRadius;
+
+    if (!(centerRadius > 0)) {
+        return offset > 0 ? HALF_PI : 0;
+    }
+
+    return Math.asin(Math.min(offset / centerRadius, 1));
+}
+
+/** Clamps a requested corner radius to the band thickness and to what the sector's span allows, per arc. */
+function getCornerRadii(radius: number, innerRadius: number, span: number, halfGap: number, cornerRadius: number): [number, number] {
+    const limit = Math.min(cornerRadius, (radius - innerRadius) / 2);
+
+    if (!(limit > 0) || span <= 0 || span >= TAU) {
+        return [0, 0];
+    }
+
+    if (span >= Math.PI) {
+        return [limit, limit];
+    }
+
+    const halfSpanSine = Math.sin(span / 2);
+
+    return [
+        Math.max(0, Math.min(limit, (halfSpanSine * radius - halfGap) / (1 + halfSpanSine))),
+        Math.max(0, Math.min(limit, (halfSpanSine * innerRadius - halfGap) / (1 - halfSpanSine))),
+    ];
+}
+
+/** Traces an annular sector whose four corners are rounded by circles tangent to both an edge and an arc. */
+function traceRoundedAnnularSector(path: ContextPath, sector: ArcSector): void {
+    const {
+        cx,
+        cy,
+        radius,
+        innerRadius,
+        startAngle,
+        endAngle,
+        halfGap,
+        outerCornerRadius,
+        innerCornerRadius,
+    } = sector;
+
+    const outerCenterRadius = radius - outerCornerRadius;
+    const innerCenterRadius = innerRadius + innerCornerRadius;
+
+    const [outerStart, outerEnd] = insetSector(startAngle, endAngle, getCornerCenterOffset(outerCenterRadius, halfGap, outerCornerRadius));
+    const [innerStart, innerEnd] = insetSector(startAngle, endAngle, getCornerCenterOffset(innerCenterRadius, halfGap, innerCornerRadius));
+
+    const startEdgeAngle = startAngle - HALF_PI;
+    const endEdgeAngle = endAngle + HALF_PI;
+
+    const [outerStartX, outerStartY] = getThetaPoint(outerStart, outerCenterRadius, cx, cy);
+    const [outerEndX, outerEndY] = getThetaPoint(outerEnd, outerCenterRadius, cx, cy);
+    const [innerStartX, innerStartY] = getThetaPoint(innerStart, innerCenterRadius, cx, cy);
+    const [innerEndX, innerEndY] = getThetaPoint(innerEnd, innerCenterRadius, cx, cy);
+
+    const [x1, y1] = getThetaPoint(startEdgeAngle, innerCornerRadius, innerStartX, innerStartY);
+    const [x2, y2] = getThetaPoint(startEdgeAngle, outerCornerRadius, outerStartX, outerStartY);
+    const [x3, y3] = getThetaPoint(endEdgeAngle, innerCornerRadius, innerEndX, innerEndY);
+
+    path.moveTo(x1, y1);
+    path.lineTo(x2, y2);
+    traceForwardArc(path, outerStartX, outerStartY, outerCornerRadius, startEdgeAngle, outerStart);
+    traceForwardArc(path, cx, cy, radius, outerStart, outerEnd);
+    traceForwardArc(path, outerEndX, outerEndY, outerCornerRadius, outerEnd, endEdgeAngle);
+    path.lineTo(x3, y3);
+    traceForwardArc(path, innerEndX, innerEndY, innerCornerRadius, endEdgeAngle, innerEnd + Math.PI);
+    path.arc(cx, cy, innerRadius, innerEnd, innerStart, true);
+    traceForwardArc(path, innerStartX, innerStartY, innerCornerRadius, innerStart + Math.PI, startEdgeAngle + TAU);
+    path.closePath();
+}
+
+/** Traces a wedge whose two outer corners are rounded and whose center point stays sharp. */
+function traceRoundedWedge(path: ContextPath, cx: number, cy: number, radius: number, startAngle: number, endAngle: number, cornerRadius: number): void {
+    const centerRadius = radius - cornerRadius;
+
+    const [outerStart, outerEnd] = insetSector(startAngle, endAngle, getCornerCenterOffset(centerRadius, 0, cornerRadius));
+
+    const startEdgeAngle = startAngle - HALF_PI;
+    const endEdgeAngle = endAngle + HALF_PI;
+
+    const [outerStartX, outerStartY] = getThetaPoint(outerStart, centerRadius, cx, cy);
+    const [outerEndX, outerEndY] = getThetaPoint(outerEnd, centerRadius, cx, cy);
+    const [x1, y1] = getThetaPoint(startEdgeAngle, cornerRadius, outerStartX, outerStartY);
+
+    path.moveTo(cx, cy);
+    path.lineTo(x1, y1);
+    traceForwardArc(path, outerStartX, outerStartY, cornerRadius, startEdgeAngle, outerStart);
+    traceForwardArc(path, cx, cy, radius, outerStart, outerEnd);
+    traceForwardArc(path, outerEndX, outerEndY, cornerRadius, outerEnd, endEdgeAngle);
+    path.lineTo(cx, cy);
+    path.closePath();
+}
+
+/** An arc or annular sector shape supporting inner radius, angular or constant-width padding, and rounded corners. */
 export class Arc extends Shape2D<ArcState> {
 
     /** The x-coordinate of the arc's center. */
@@ -97,7 +246,7 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('innerRadius', value);
     }
 
-    /** The angular padding between the arc and its neighbors, in radians. */
+    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link Arc.padWidth} for a gap of constant width. Ignored when `padWidth` is set. */
     public get padAngle() {
         return this.getStateValue('padAngle');
     }
@@ -106,7 +255,16 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('padAngle', value);
     }
 
-    /** The corner radius applied to the arc's corners. */
+    /** The padding between the arc and its neighbors, in logical pixels, held constant at every radius so adjacent segments face each other with parallel edges. Takes precedence over {@link Arc.padAngle}. */
+    public get padWidth() {
+        return this.getStateValue('padWidth');
+    }
+
+    public set padWidth(value) {
+        this.setStateValue('padWidth', value);
+    }
+
+    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. */
     public get borderRadius() {
         return this.getStateValue('borderRadius');
     }
@@ -180,21 +338,25 @@ export class Arc extends Shape2D<ArcState> {
 
     /** Renders the arc to the provided {@link Context}. */
     public render(context: Context) {
-        let {
+        const {
             cx,
             cy,
-            radius,
-            innerRadius,
-            startAngle,
-            endAngle,
             padAngle,
+            padWidth,
+            borderRadius = 0,
         } = this;
 
-        radius = Math.max(0, radius);
-        innerRadius = typeIsNil(innerRadius) ? innerRadius : Math.max(0, innerRadius);
+        const radius = Math.max(0, this.radius);
+        const innerRadius = typeIsNil(this.innerRadius) ? this.innerRadius : Math.max(0, this.innerRadius);
+        const gap = padWidth && padWidth > 0 ? padWidth : 0;
+
+        let {
+            startAngle,
+            endAngle,
+        } = this;
 
         return super.render(context, path => {
-            if (padAngle) {
+            if (padAngle && !gap) {
                 const offset = padAngle / 2;
 
                 startAngle = Math.min(startAngle + offset, endAngle);
@@ -202,16 +364,42 @@ export class Arc extends Shape2D<ArcState> {
             }
 
             if (typeIsNil(innerRadius)) {
-                return path.arc(cx, cy, radius, startAngle, endAngle);
+                const [outerStart, outerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, radius));
+                const [cornerRadius] = getCornerRadii(radius, 0, outerEnd - outerStart, 0, borderRadius);
+
+                if (!cornerRadius) {
+                    return path.arc(cx, cy, radius, outerStart, outerEnd);
+                }
+
+                return traceRoundedWedge(path, cx, cy, radius, outerStart, outerEnd, cornerRadius);
             }
 
-            const [x1, y1] = getThetaPoint(startAngle, radius, cx, cy);
-            const [x2, y2] = getThetaPoint(endAngle, innerRadius, cx, cy);
+            const [outerCornerRadius, innerCornerRadius] = getCornerRadii(radius, innerRadius, endAngle - startAngle, gap / 2, borderRadius);
+
+            if (outerCornerRadius || innerCornerRadius) {
+                return traceRoundedAnnularSector(path, {
+                    cx,
+                    cy,
+                    radius,
+                    innerRadius,
+                    startAngle,
+                    endAngle,
+                    halfGap: gap / 2,
+                    outerCornerRadius,
+                    innerCornerRadius,
+                });
+            }
+
+            const [outerStart, outerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, radius));
+            const [innerStart, innerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, innerRadius));
+
+            const [x1, y1] = getThetaPoint(outerStart, radius, cx, cy);
+            const [x2, y2] = getThetaPoint(innerEnd, innerRadius, cx, cy);
 
             path.moveTo(x1, y1);
-            path.arc(cx, cy, radius, startAngle, endAngle);
+            path.arc(cx, cy, radius, outerStart, outerEnd);
             path.lineTo(x2, y2);
-            path.arc(cx, cy, innerRadius, endAngle, startAngle, true);
+            path.arc(cx, cy, innerRadius, innerEnd, innerStart, true);
             path.lineTo(x1, y1);
         });
     }

--- a/packages/core/src/elements/arc.ts
+++ b/packages/core/src/elements/arc.ts
@@ -16,6 +16,7 @@ import {
     Box,
     getPadAngleAtRadius,
     getThetaPoint,
+    HALF_PI,
     TAU,
 } from '../math';
 
@@ -50,15 +51,13 @@ export interface ArcState extends BaseElementState {
     radius: number;
     /** The inner radius of the arc, producing an annular sector when set. */
     innerRadius?: number;
-    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link ArcState.padWidth} for a gap of constant width. Ignored when `padWidth` is set. */
+    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link ArcState.padWidth} for a gap of constant width. Ignored whenever `padWidth` is provided, `0` included. A `padAngle` wider than the sector collapses it onto its `endAngle`, where an oversized `padWidth` collapses it onto its mid-angle. */
     padAngle?: number;
-    /** The padding between the arc and its neighbors, in logical pixels, held constant at every radius so adjacent segments face each other with parallel edges. Takes precedence over {@link ArcState.padAngle}. */
+    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link ArcState.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
     padWidth?: number;
-    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. */
+    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. A non-zero value on an open arc also closes the path through the center, turning a chord-closed segment into a wedge and so changing its filled area, hit region and stroke — do not animate it up from `0` on an open arc. */
     borderRadius?: number;
 }
-
-const HALF_PI = Math.PI / 2;
 
 /** Insets a sector by `inset` at both ends, collapsing it to its mid-angle rather than inverting it. */
 function insetSector(startAngle: number, endAngle: number, inset: number): [number, number] {
@@ -103,6 +102,15 @@ function getCornerCenterOffset(centerRadius: number, halfGap: number, cornerRadi
     return Math.asin(Math.min(offset / centerRadius, 1));
 }
 
+/** Clamps a corner radius to `limit`, resolving the `0 / 0` a half-span sine of exactly 1 produces to the value either side of it. */
+function clampCornerRadius(limit: number, numerator: number, denominator: number): number {
+    if (!(denominator > 0)) {
+        return numerator > 0 ? limit : 0;
+    }
+
+    return Math.max(0, Math.min(limit, numerator / denominator));
+}
+
 /** Clamps a requested corner radius to the band thickness and to what the sector's span allows, per arc. */
 function getCornerRadii(radius: number, innerRadius: number, span: number, halfGap: number, cornerRadius: number): [number, number] {
     const limit = Math.min(cornerRadius, (radius - innerRadius) / 2);
@@ -118,8 +126,8 @@ function getCornerRadii(radius: number, innerRadius: number, span: number, halfG
     const halfSpanSine = Math.sin(span / 2);
 
     return [
-        Math.max(0, Math.min(limit, (halfSpanSine * radius - halfGap) / (1 + halfSpanSine))),
-        Math.max(0, Math.min(limit, (halfSpanSine * innerRadius - halfGap) / (1 - halfSpanSine))),
+        clampCornerRadius(limit, halfSpanSine * radius - halfGap, 1 + halfSpanSine),
+        clampCornerRadius(limit, halfSpanSine * innerRadius - halfGap, 1 - halfSpanSine),
     ];
 }
 
@@ -246,7 +254,7 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('innerRadius', value);
     }
 
-    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link Arc.padWidth} for a gap of constant width. Ignored when `padWidth` is set. */
+    /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link Arc.padWidth} for a gap of constant width. Ignored whenever `padWidth` is provided, `0` included. A `padAngle` wider than the sector collapses it onto its `endAngle`, where an oversized `padWidth` collapses it onto its mid-angle. */
     public get padAngle() {
         return this.getStateValue('padAngle');
     }
@@ -255,7 +263,7 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('padAngle', value);
     }
 
-    /** The padding between the arc and its neighbors, in logical pixels, held constant at every radius so adjacent segments face each other with parallel edges. Takes precedence over {@link Arc.padAngle}. */
+    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link Arc.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
     public get padWidth() {
         return this.getStateValue('padWidth');
     }
@@ -264,7 +272,7 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('padWidth', value);
     }
 
-    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. */
+    /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. A non-zero value on an open arc also closes the path through the center, turning a chord-closed segment into a wedge and so changing its filled area, hit region and stroke — do not animate it up from `0` on an open arc. */
     public get borderRadius() {
         return this.getStateValue('borderRadius');
     }
@@ -348,7 +356,8 @@ export class Arc extends Shape2D<ArcState> {
 
         const radius = Math.max(0, this.radius);
         const innerRadius = typeIsNil(this.innerRadius) ? this.innerRadius : Math.max(0, this.innerRadius);
-        const gap = padWidth && padWidth > 0 ? padWidth : 0;
+        const hasPadWidth = !typeIsNil(padWidth);
+        const gap = typeIsNil(padWidth) ? 0 : Math.max(0, padWidth);
 
         let {
             startAngle,
@@ -356,7 +365,7 @@ export class Arc extends Shape2D<ArcState> {
         } = this;
 
         return super.render(context, path => {
-            if (padAngle && !gap) {
+            if (padAngle && !hasPadWidth) {
                 const offset = padAngle / 2;
 
                 startAngle = Math.min(startAngle + offset, endAngle);

--- a/packages/core/src/math/constants.ts
+++ b/packages/core/src/math/constants.ts
@@ -1,2 +1,5 @@
 /** Full circle in radians (2π). */
 export const TAU = Math.PI * 2;
+
+/** Quarter turn in radians (π/2). */
+export const HALF_PI = Math.PI / 2;

--- a/packages/core/src/math/geometry.ts
+++ b/packages/core/src/math/geometry.ts
@@ -71,6 +71,30 @@ export function getThetaPoint(angle: number, distance: number, cx?: number, cy?:
     ];
 }
 
+/**
+ * Returns the angular inset, in radians, that trims an arc at `radius` back from a gap of
+ * `padWidth` logical pixels centred on the boundary angle — `asin(padWidth / (2 * radius))`.
+ *
+ * Applying it per radius (rather than insetting by a fixed angle) leaves the straight edge on a
+ * line offset `padWidth / 2` from the radial centreline, so neighbouring segments face each other
+ * with parallel edges a constant `padWidth` apart instead of a wedge that widens outward.
+ *
+ * Saturates at a quarter turn where the gap is at least as wide as the diameter — inside
+ * `radius < padWidth / 2` nothing of the arc survives — and returns `0` for a non-positive or
+ * non-finite `padWidth` or a negative `radius`.
+ *
+ * @param padWidth - The gap width, in logical pixels, held constant at every radius.
+ * @param radius - The radius at which the inset is measured.
+ * @returns The angular inset to apply at each end of the arc, in radians.
+ */
+export function getPadAngleAtRadius(padWidth: number, radius: number): number {
+    if (!(padWidth > 0) || !(radius >= 0)) {
+        return 0;
+    }
+
+    return Math.asin(Math.min(padWidth / (2 * radius), 1));
+}
+
 /** Generates the vertex points of a regular polygon centered at `(cx, cy)` with the given radius and number of sides. */
 export function getPolygonPoints(
     sides: number,

--- a/packages/core/src/math/geometry.ts
+++ b/packages/core/src/math/geometry.ts
@@ -80,8 +80,9 @@ export function getThetaPoint(angle: number, distance: number, cx?: number, cy?:
  * with parallel edges a constant `padWidth` apart instead of a wedge that widens outward.
  *
  * Saturates at a quarter turn where the gap is at least as wide as the diameter — inside
- * `radius < padWidth / 2` nothing of the arc survives — and returns `0` for a non-positive or
- * non-finite `padWidth` or a negative `radius`.
+ * `radius < padWidth / 2` nothing of the arc survives, and an infinite `padWidth` saturates like
+ * any other over-wide gap. Returns `0` for a `padWidth` that is non-positive or `NaN`, and for a
+ * `radius` that is negative or `NaN`.
  *
  * @param padWidth - The gap width, in logical pixels, held constant at every radius.
  * @param radius - The radius at which the inset is measured.

--- a/packages/core/test/elements/arc.test.ts
+++ b/packages/core/test/elements/arc.test.ts
@@ -2,12 +2,123 @@ import {
     describe,
     expect,
     test,
+    vi,
 } from 'vitest';
 
 import {
     createArc,
     elementIsArc,
+    getThetaPoint,
+    TAU,
 } from '../../src';
+
+import type {
+    ArcState,
+    Context,
+    ContextPath,
+    Point,
+    Shape2DOptions,
+} from '../../src';
+
+type PathCommand = (string | number | boolean)[];
+
+/** Records the drawing commands an arc emits, so a test can measure the geometry it actually traced. */
+function renderCommands(options: Shape2DOptions<ArcState>): PathCommand[] {
+    const commands: PathCommand[] = [];
+    const capture = (type: string) => (...args: (number | boolean)[]) => {
+        commands.push([type, ...args]);
+    };
+
+    const path = {
+        id: 'arc',
+        arc: capture('arc'),
+        arcTo: capture('arcTo'),
+        moveTo: capture('moveTo'),
+        lineTo: capture('lineTo'),
+        closePath: capture('closePath'),
+        bezierCurveTo: capture('bezierCurveTo'),
+        quadraticCurveTo: capture('quadraticCurveTo'),
+    } as unknown as ContextPath;
+
+    const context = {
+        save: vi.fn(),
+        restore: vi.fn(),
+        markRenderStart: vi.fn(),
+        markRenderEnd: vi.fn(),
+        createPath: () => path,
+        supportsPathCaching: false,
+    } as unknown as Context;
+
+    createArc(options).render(context);
+
+    return commands;
+}
+
+type ArcCommand = [string, number, number, number, number, number, boolean?];
+
+function arcCommands(commands: PathCommand[]) {
+    return commands.filter(([type]) => type === 'arc') as ArcCommand[];
+}
+
+function arcEndPoint([, cx, cy, radius, , to]: ArcCommand): Point {
+    return getThetaPoint(to, radius, cx, cy);
+}
+
+/** The two straight edges of a sharply traced annular sector, each as its inner then outer endpoint. */
+function sharpEdges(commands: PathCommand[]): { start: [Point, Point];
+    end: [Point, Point]; } {
+    const [outer, inner] = arcCommands(commands);
+    const [, cx, cy, radius, outerStart, outerEnd] = outer;
+    const [,,, innerRadius, innerEnd, innerStart] = inner;
+
+    return {
+        start: [
+            getThetaPoint(innerStart, innerRadius, cx, cy),
+            getThetaPoint(outerStart, radius, cx, cy),
+        ],
+        end: [
+            getThetaPoint(innerEnd, innerRadius, cx, cy),
+            getThetaPoint(outerEnd, radius, cx, cy),
+        ],
+    };
+}
+
+function distanceToLine([px, py]: Point, [ax, ay]: Point, [bx, by]: Point): number {
+    const dx = bx - ax;
+    const dy = by - ay;
+
+    return Math.abs(dy * (px - ax) - dx * (py - ay)) / Math.hypot(dx, dy);
+}
+
+function pointAlong([ax, ay]: Point, [bx, by]: Point, position: number): Point {
+    return [
+        ax + (bx - ax) * position,
+        ay + (by - ay) * position,
+    ];
+}
+
+/** Perpendicular separation between the facing edges of two neighbouring sectors, sampled across the band. */
+function facingEdgeWidths(left: PathCommand[], right: PathCommand[]): number[] {
+    const [leftInner, leftOuter] = sharpEdges(left).end;
+    const [rightInner, rightOuter] = sharpEdges(right).start;
+
+    return [0, 0.25, 0.5, 0.75, 1].map(position => distanceToLine(pointAlong(leftInner, leftOuter, position), rightInner, rightOuter));
+}
+
+function distanceFrom([cx, cy]: Point, [px, py]: Point): number {
+    return Math.hypot(px - cx, py - cy);
+}
+
+/** Deterministic pseudo-random source, so a property sweep reproduces exactly on failure. */
+function createRandom(seed: number) {
+    let state = seed;
+
+    return () => {
+        state = (state * 1664525 + 1013904223) % 4294967296;
+
+        return state / 4294967296;
+    };
+}
 
 describe('Arc', () => {
 
@@ -44,6 +155,8 @@ describe('Arc', () => {
         arc.radius = 100;
         arc.innerRadius = 20;
         arc.padAngle = 0.1;
+        arc.padWidth = 4;
+        arc.borderRadius = 6;
 
         expect(arc.cx).toBe(50);
         expect(arc.cy).toBe(60);
@@ -52,6 +165,8 @@ describe('Arc', () => {
         expect(arc.radius).toBe(100);
         expect(arc.innerRadius).toBe(20);
         expect(arc.padAngle).toBe(0.1);
+        expect(arc.padWidth).toBe(4);
+        expect(arc.borderRadius).toBe(6);
     });
 
     test('Should compute bounding box without innerRadius', () => {
@@ -117,7 +232,305 @@ describe('Arc', () => {
         expect(cx2).not.toBe(cx1);
     });
 
-    test('Should support borderRadius property', () => {
+});
+
+describe('Arc padAngle', () => {
+
+    // Pinned before padWidth and borderRadius existed; padAngle's wedge gap is a compatibility promise.
+    test('Should emit the same annular commands as before padWidth existed', () => {
+        expect(renderCommands({
+            cx: 100,
+            cy: 100,
+            startAngle: 0,
+            endAngle: Math.PI / 2,
+            radius: 80,
+            innerRadius: 40,
+            padAngle: 0.1,
+        })).toEqual([
+            ['moveTo', 179.90002083159732, 103.99833354165426],
+            ['arc', 100, 100, 80, 0.05, 1.5207963267948965],
+            ['lineTo', 101.99916677082713, 139.95001041579866],
+            ['arc', 100, 100, 40, 1.5207963267948965, 0.05, true],
+            ['lineTo', 179.90002083159732, 103.99833354165426],
+        ]);
+    });
+
+    test('Should emit the same open-arc commands as before padWidth existed', () => {
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            startAngle: 0.25,
+            endAngle: 2,
+            radius: 50,
+            padAngle: 0.2,
+        })).toEqual([
+            ['arc', 0, 0, 50, 0.35, 1.9],
+        ]);
+    });
+
+    test('Should collapse an oversized padAngle onto the end angle as before', () => {
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            startAngle: 1,
+            endAngle: 1.05,
+            radius: 30,
+            innerRadius: 10,
+            padAngle: 0.5,
+        })).toEqual([
+            ['moveTo', 14.927131436751809, 26.02269676782051],
+            ['arc', 0, 0, 30, 1.05, 1.05],
+            ['lineTo', 4.97571047891727, 8.67423225594017],
+            ['arc', 0, 0, 10, 1.05, 1.05, true],
+            ['lineTo', 14.927131436751809, 26.02269676782051],
+        ]);
+    });
+
+    test('Should emit the same unpadded commands as before padWidth existed', () => {
+        expect(renderCommands({
+            cx: 10,
+            cy: 20,
+            startAngle: 0,
+            endAngle: 1,
+            radius: 30,
+            innerRadius: 15,
+        })).toEqual([
+            ['moveTo', 40, 20],
+            ['arc', 10, 20, 30, 0, 1],
+            ['lineTo', 18.104534588022098, 32.62206477211845],
+            ['arc', 10, 20, 15, 1, 0, true],
+            ['lineTo', 40, 20],
+        ]);
+
+        expect(renderCommands({
+            cx: 10,
+            cy: 20,
+            startAngle: 0,
+            endAngle: 1,
+            radius: 30,
+        })).toEqual([
+            ['arc', 10, 20, 30, 0, 1],
+        ]);
+    });
+
+    test('Should leave a reversed sector untouched', () => {
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            startAngle: 2,
+            endAngle: 1,
+            radius: 30,
+        })).toEqual([
+            ['arc', 0, 0, 30, 2, 1],
+        ]);
+    });
+
+    test('Should widen the gap with radius', () => {
+        const widths = facingEdgeWidths(
+            renderCommands({
+                cx: 0,
+                cy: 0,
+                radius: 120,
+                innerRadius: 40,
+                startAngle: 0.2,
+                endAngle: 1.2,
+                padAngle: 0.1,
+            }),
+            renderCommands({
+                cx: 0,
+                cy: 0,
+                radius: 120,
+                innerRadius: 40,
+                startAngle: 1.2,
+                endAngle: 2.4,
+                padAngle: 0.1,
+            })
+        );
+
+        expect(widths[0]).toBeCloseTo(40 * Math.sin(0.1), 9);
+        expect(widths[4]).toBeCloseTo(120 * Math.sin(0.1), 9);
+        expect(widths[4] / widths[0]).toBeCloseTo(3, 9);
+    });
+
+});
+
+describe('Arc padWidth', () => {
+
+    test('Should inset the endpoints by asin(padWidth / 2r) at every radius', () => {
+        const padWidth = 9;
+
+        [15, 45, 200].forEach(radius => {
+            const [[,,,, startAngle, endAngle]] = arcCommands(renderCommands({
+                cx: 0,
+                cy: 0,
+                radius,
+                startAngle: 0.4,
+                endAngle: 2.6,
+                padWidth,
+            }));
+
+            const inset = Math.asin(padWidth / (2 * radius));
+
+            expect(startAngle).toBeCloseTo(0.4 + inset, 12);
+            expect(endAngle).toBeCloseTo(2.6 - inset, 12);
+        });
+    });
+
+    test('Should inset the inner and outer arcs by their own radius', () => {
+        const padWidth = 12;
+        const [outer, inner] = arcCommands(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 150,
+            innerRadius: 30,
+            startAngle: 0,
+            endAngle: 1,
+            padWidth,
+        }));
+
+        expect(outer[4]).toBeCloseTo(Math.asin(padWidth / 300), 12);
+        expect(inner[5]).toBeCloseTo(Math.asin(padWidth / 60), 12);
+        expect(inner[5]).toBeGreaterThan(outer[4]);
+    });
+
+    test('Should hold the gap between adjacent segments constant along the whole edge', () => {
+        const padWidth = 6;
+        const base = {
+            cx: 0,
+            cy: 0,
+            radius: 120,
+            innerRadius: 40,
+            padWidth,
+        };
+
+        const widths = facingEdgeWidths(
+            renderCommands({
+                ...base,
+                startAngle: 0.2,
+                endAngle: 1.2,
+            }),
+            renderCommands({
+                ...base,
+                startAngle: 1.2,
+                endAngle: 2.4,
+            })
+        );
+
+        widths.forEach(width => expect(width).toBeCloseTo(padWidth, 9));
+        expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(1e-9);
+    });
+
+    test('Should take precedence over padAngle', () => {
+        const withBoth = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            padAngle: 0.4,
+            padWidth: 8,
+        });
+
+        const withWidthOnly = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            padWidth: 8,
+        });
+
+        expect(withBoth).toEqual(withWidthOnly);
+    });
+
+    test('Should fall back to padAngle when padWidth is zero', () => {
+        const withZero = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            startAngle: 0,
+            endAngle: 1,
+            padAngle: 0.4,
+            padWidth: 0,
+        });
+
+        expect(withZero).toEqual([['arc', 0, 0, 100, 0.2, 0.8]]);
+    });
+
+    test('Should collapse a sliver to its mid-angle without inverting', () => {
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 60,
+            innerRadius: 30,
+            startAngle: 1,
+            endAngle: 1.02,
+            padWidth: 40,
+        });
+
+        const [outer, inner] = arcCommands(commands);
+
+        expect(outer[4]).toBeCloseTo(1.01, 12);
+        expect(outer[5]).toBe(outer[4]);
+        expect(inner[4]).toBe(outer[4]);
+        expect(inner[5]).toBe(outer[4]);
+        commands.flat().forEach(value => expect(Number.isNaN(value as number)).toBe(false));
+    });
+
+    test('Should collapse an arc whose radius is inside the gap', () => {
+        const [outer, inner] = arcCommands(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 2,
+            startAngle: 0,
+            endAngle: 1,
+            padWidth: 20,
+        }));
+
+        expect(outer[4]).toBeCloseTo(Math.asin(0.1), 12);
+        expect(inner[4]).toBeCloseTo(0.5, 12);
+        expect(inner[5]).toBe(inner[4]);
+    });
+
+    test('Should trim only the outer radius of an open arc', () => {
+        const padWidth = 10;
+        const commands = renderCommands({
+            cx: 5,
+            cy: 5,
+            radius: 80,
+            startAngle: 0,
+            endAngle: 2,
+            padWidth,
+        });
+
+        const inset = Math.asin(padWidth / 160);
+
+        expect(commands).toEqual([
+            ['arc', 5, 5, 80, inset, 2 - inset],
+        ]);
+    });
+
+    test('Should ignore a negative padWidth', () => {
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            padWidth: -10,
+        })).toEqual([
+            ['arc', 0, 0, 50, 0, 1],
+        ]);
+    });
+
+});
+
+describe('Arc borderRadius', () => {
+
+    test('Should store the configured value', () => {
         const arc = createArc({
             cx: 0,
             cy: 0,
@@ -128,6 +541,270 @@ describe('Arc', () => {
         });
 
         expect(arc.borderRadius).toBe(5);
+    });
+
+    test('Should seat all four corner circles tangent to their arc and their edge', () => {
+        const borderRadius = 10;
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: Math.PI / 2,
+            borderRadius,
+        });
+
+        const corners = arcCommands(commands).filter(([,,, radius]) => radius === borderRadius);
+
+        expect(corners).toHaveLength(4);
+
+        const [outerStart, outerEnd, innerEnd, innerStart] = corners;
+
+        expect(distanceFrom([0, 0], [outerStart[1], outerStart[2]])).toBeCloseTo(90, 9);
+        expect(distanceFrom([0, 0], [outerEnd[1], outerEnd[2]])).toBeCloseTo(90, 9);
+        expect(distanceFrom([0, 0], [innerEnd[1], innerEnd[2]])).toBeCloseTo(60, 9);
+        expect(distanceFrom([0, 0], [innerStart[1], innerStart[2]])).toBeCloseTo(60, 9);
+
+        expect(outerStart[2]).toBeCloseTo(borderRadius, 9);
+        expect(innerStart[2]).toBeCloseTo(borderRadius, 9);
+    });
+
+    test('Should offset the corner circles by the half gap when padded', () => {
+        const padWidth = 8;
+        const borderRadius = 10;
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: Math.PI / 2,
+            padWidth,
+            borderRadius,
+        });
+
+        const [start, edge] = commands;
+
+        expect(start[2]).toBeCloseTo(padWidth / 2, 9);
+        expect(edge[2]).toBeCloseTo(padWidth / 2, 9);
+
+        const [outerStart, outerEnd, innerEnd, innerStart] = arcCommands(commands).filter(([,,, radius]) => radius === borderRadius);
+
+        expect(outerStart[2]).toBeCloseTo(padWidth / 2 + borderRadius, 9);
+        expect(innerStart[2]).toBeCloseTo(padWidth / 2 + borderRadius, 9);
+        expect(outerEnd[1]).toBeCloseTo(padWidth / 2 + borderRadius, 9);
+        expect(innerEnd[1]).toBeCloseTo(padWidth / 2 + borderRadius, 9);
+    });
+
+    test('Should round two corners of an open wedge and keep the center sharp', () => {
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            startAngle: 0,
+            endAngle: Math.PI / 2,
+            borderRadius: 20,
+        });
+
+        expect(commands[0]).toEqual(['moveTo', 0, 0]);
+        expect(commands[commands.length - 2]).toEqual(['lineTo', 0, 0]);
+        expect(commands[commands.length - 1]).toEqual(['closePath']);
+        expect(arcCommands(commands).filter(([,,, radius]) => radius === 20)).toHaveLength(2);
+    });
+
+    test('Should clamp to half the band thickness, collapsing to a capsule', () => {
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 60,
+            startAngle: 0,
+            endAngle: Math.PI / 2,
+            borderRadius: 1000,
+        });
+
+        const corners = arcCommands(commands).filter(([,,, radius]) => radius === 20);
+
+        expect(corners).toHaveLength(4);
+
+        const [outerStart,,, innerStart] = corners;
+
+        expect(innerStart[1]).toBeCloseTo(outerStart[1], 9);
+        expect(innerStart[2]).toBeCloseTo(outerStart[2], 9);
+        expect(commands[0].slice(1)).toEqual(commands[1].slice(1));
+    });
+
+    test('Should clamp to half the outer arc length on a narrow sector', () => {
+        const radius = 100;
+        const span = 0.2;
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius,
+            innerRadius: 10,
+            startAngle: 0,
+            endAngle: span,
+            borderRadius: 1000,
+        });
+
+        const outerCorner = arcCommands(commands)[0];
+
+        expect(outerCorner[3]).toBeCloseTo(9.077139786423315, 9);
+        expect(outerCorner[3]).toBeLessThan(radius * span / 2);
+        expect(outerCorner[3]).toBeLessThan((radius - 10) / 2);
+    });
+
+    test('Should ignore a full-turn sweep', () => {
+        const options: Shape2DOptions<ArcState> = {
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: TAU,
+        };
+
+        expect(renderCommands({
+            ...options,
+            borderRadius: 20,
+        })).toEqual(renderCommands(options));
+    });
+
+    test('Should leave the path sharp when zero or absent', () => {
+        const sharp = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+        });
+
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            borderRadius: 0,
+        })).toEqual(sharp);
+
+        expect(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            borderRadius: -5,
+        })).toEqual(sharp);
+    });
+
+    test('Should apply padding before rounding, keeping the gap constant', () => {
+        const padWidth = 6;
+        const base = {
+            cx: 0,
+            cy: 0,
+            radius: 120,
+            innerRadius: 40,
+            padWidth,
+            borderRadius: 8,
+        };
+
+        const left = renderCommands({
+            ...base,
+            startAngle: 0.2,
+            endAngle: 1.2,
+        });
+
+        const right = renderCommands({
+            ...base,
+            startAngle: 1.2,
+            endAngle: 2.4,
+        });
+
+        const leftOuter = arcEndPoint(left[4] as [string, number, number, number, number, number]);
+        const leftInner: Point = [left[5][1] as number, left[5][2] as number];
+        const rightInner: Point = [right[0][1] as number, right[0][2] as number];
+        const rightOuter: Point = [right[1][1] as number, right[1][2] as number];
+
+        [0, 0.5, 1].forEach(position => {
+            expect(distanceToLine(pointAlong(leftInner, leftOuter, position), rightInner, rightOuter)).toBeCloseTo(padWidth, 9);
+        });
+    });
+
+});
+
+describe('Arc path validity', () => {
+
+    test('Should emit finite, non-inverted arcs across random sectors', () => {
+        const random = createRandom(20260804);
+
+        for (let index = 0; index < 400; index++) {
+            const radius = random() * 200;
+            const startAngle = (random() - 0.5) * TAU;
+            const options: Shape2DOptions<ArcState> = {
+                cx: (random() - 0.5) * 50,
+                cy: (random() - 0.5) * 50,
+                radius,
+                startAngle,
+                endAngle: startAngle + random() * TAU,
+                padWidth: random() < 0.5 ? random() * 30 : undefined,
+                padAngle: random() < 0.5 ? random() * 0.5 : undefined,
+                borderRadius: random() < 0.5 ? random() * 100 : undefined,
+            };
+
+            if (random() < 0.75) {
+                options.innerRadius = random() * radius;
+            }
+
+            const commands = renderCommands(options);
+
+            commands.flat().forEach(value => {
+                expect(typeof value === 'string' || typeof value === 'boolean' || Number.isFinite(value)).toBe(true);
+            });
+
+            arcCommands(commands).forEach(([, , , , from, to, counterclockwise]) => {
+                expect(counterclockwise ? from - to : to - from).toBeGreaterThanOrEqual(0);
+                expect(Math.abs(to - from)).toBeLessThanOrEqual(TAU + 1e-9);
+            });
+        }
+    });
+
+    test('Should keep every traced sub-command connected to the previous point', () => {
+        const commands = renderCommands({
+            cx: 12,
+            cy: -7,
+            radius: 90,
+            innerRadius: 35,
+            startAngle: 0.3,
+            endAngle: 2.1,
+            padWidth: 5,
+            borderRadius: 9,
+        });
+
+        let cursor: Point = [0, 0];
+
+        commands.forEach(command => {
+            const [type] = command;
+
+            if (type === 'closePath') {
+                return;
+            }
+
+            if (type !== 'arc') {
+                cursor = [command[1] as number, command[2] as number];
+                return;
+            }
+
+            const [, cx, cy, radius, from] = command as ArcCommand;
+
+            expect(distanceFrom(cursor, getThetaPoint(from, radius, cx, cy))).toBeLessThan(1e-9);
+
+            cursor = arcEndPoint(command as ArcCommand);
+        });
     });
 
 });

--- a/packages/core/test/elements/arc.test.ts
+++ b/packages/core/test/elements/arc.test.ts
@@ -120,6 +120,21 @@ function createRandom(seed: number) {
     };
 }
 
+/** Spans biased towards the half turn, where `sin(span / 2)` rounds to exactly 1 and the corner clamp divides by zero. */
+function randomSpan(random: () => number): number {
+    const roll = random();
+
+    if (roll < 0.15) {
+        return Math.PI - random() * 2e-8;
+    }
+
+    if (roll < 0.25) {
+        return Math.PI + (random() - 0.5) * 1e-7;
+    }
+
+    return random() * TAU;
+}
+
 describe('Arc', () => {
 
     test('Should create with state', () => {
@@ -445,18 +460,46 @@ describe('Arc padWidth', () => {
         expect(withBoth).toEqual(withWidthOnly);
     });
 
-    test('Should fall back to padAngle when padWidth is zero', () => {
-        const withZero = renderCommands({
+    test('Should fall back to padAngle only when padWidth is absent', () => {
+        const base = {
             cx: 0,
             cy: 0,
             radius: 100,
             startAngle: 0,
             endAngle: 1,
             padAngle: 0.4,
-            padWidth: 0,
-        });
+        };
 
-        expect(withZero).toEqual([['arc', 0, 0, 100, 0.2, 0.8]]);
+        expect(renderCommands(base)).toEqual([['arc', 0, 0, 100, 0.2, 0.8]]);
+        expect(renderCommands({
+            ...base,
+            padWidth: 0,
+        })).toEqual([['arc', 0, 0, 100, 0, 1]]);
+    });
+
+    test('Should stay continuous across the padWidth zero boundary when padAngle is also set', () => {
+        const base = {
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 50,
+            startAngle: 0,
+            endAngle: 1,
+            padAngle: 0.2,
+        };
+
+        const [zeroOuter] = arcCommands(renderCommands({
+            ...base,
+            padWidth: 0,
+        }));
+
+        const [epsilonOuter] = arcCommands(renderCommands({
+            ...base,
+            padWidth: 1e-9,
+        }));
+
+        expect(epsilonOuter[4]).toBeCloseTo(zeroOuter[4], 9);
+        expect(epsilonOuter[5]).toBeCloseTo(zeroOuter[5], 9);
     });
 
     test('Should collapse a sliver to its mid-angle without inverting', () => {
@@ -742,21 +785,28 @@ describe('Arc path validity', () => {
     test('Should emit finite, non-inverted arcs across random sectors', () => {
         const random = createRandom(20260804);
 
-        for (let index = 0; index < 400; index++) {
+        for (let index = 0; index < 600; index++) {
             const radius = random() * 200;
             const startAngle = (random() - 0.5) * TAU;
+            const padWidth = random() < 0.5 ? random() * 30 : undefined;
             const options: Shape2DOptions<ArcState> = {
                 cx: (random() - 0.5) * 50,
                 cy: (random() - 0.5) * 50,
                 radius,
                 startAngle,
-                endAngle: startAngle + random() * TAU,
-                padWidth: random() < 0.5 ? random() * 30 : undefined,
+                endAngle: startAngle + randomSpan(random),
+                padWidth,
                 padAngle: random() < 0.5 ? random() * 0.5 : undefined,
                 borderRadius: random() < 0.5 ? random() * 100 : undefined,
             };
 
-            if (random() < 0.75) {
+            const innerRoll = random();
+
+            if (innerRoll < 0.15) {
+                options.innerRadius = 0;
+            } else if (innerRoll < 0.3) {
+                options.innerRadius = (padWidth ?? 0) / 2;
+            } else if (innerRoll < 0.8) {
                 options.innerRadius = random() * radius;
             }
 
@@ -771,6 +821,37 @@ describe('Arc path validity', () => {
                 expect(Math.abs(to - from)).toBeLessThanOrEqual(TAU + 1e-9);
             });
         }
+    });
+
+    test('Should stay finite where the half-span sine rounds to exactly one', () => {
+        const endAngle = 0.49999999999999994 * TAU;
+
+        expect(Math.sin(endAngle / 2)).toBe(1);
+
+        const base = {
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            startAngle: 0,
+            endAngle,
+            borderRadius: 10,
+        };
+
+        [
+            {
+                ...base,
+                innerRadius: 0,
+            },
+            {
+                ...base,
+                innerRadius: 20,
+                padWidth: 40,
+            },
+        ].forEach(options => {
+            renderCommands(options).flat().forEach(value => {
+                expect(typeof value === 'string' || typeof value === 'boolean' || Number.isFinite(value)).toBe(true);
+            });
+        });
     });
 
     test('Should keep every traced sub-command connected to the previous point', () => {

--- a/packages/core/test/math/geometry.test.ts
+++ b/packages/core/test/math/geometry.test.ts
@@ -127,6 +127,11 @@ describe('Math', () => {
                 expect(getPadAngleAtRadius(10, 5)).toBe(Math.PI / 2);
                 expect(getPadAngleAtRadius(10, 1)).toBe(Math.PI / 2);
                 expect(getPadAngleAtRadius(10, 0)).toBe(Math.PI / 2);
+                expect(getPadAngleAtRadius(Infinity, 50)).toBe(Math.PI / 2);
+            });
+
+            test('Should return zero for an infinite radius', () => {
+                expect(getPadAngleAtRadius(10, Infinity)).toBe(0);
             });
 
             test('Should return zero for a gap or radius that cannot produce an inset', () => {

--- a/packages/core/test/math/geometry.test.ts
+++ b/packages/core/test/math/geometry.test.ts
@@ -12,6 +12,8 @@ import {
     arePointsEqual,
     Box,
     getContainingBox,
+    getPadAngleAtRadius,
+    getThetaPoint,
     isPointInBox,
     matrixIdentity,
     matrixRotate,
@@ -99,6 +101,40 @@ describe('Math', () => {
 
             test('Should return an empty box for an empty collection', () => {
                 expect(edgesOf(getContainingBox([], box => box as Box))).toEqual([0, 0, 0, 0]);
+            });
+
+        });
+
+        describe('getPadAngleAtRadius', () => {
+
+            test('Should return the arcsine of the half gap over the radius', () => {
+                expect(getPadAngleAtRadius(10, 100)).toBeCloseTo(Math.asin(0.05), 12);
+                expect(getPadAngleAtRadius(10, 25)).toBeCloseTo(Math.asin(0.2), 12);
+                expect(getPadAngleAtRadius(3, 6)).toBeCloseTo(Math.asin(0.25), 12);
+            });
+
+            test('Should leave the trimmed endpoint a half gap from the centreline at every radius', () => {
+                const padWidth = 7;
+
+                [4, 20, 90, 400].forEach(radius => {
+                    const [, y] = getThetaPoint(getPadAngleAtRadius(padWidth, radius), radius);
+
+                    expect(y).toBeCloseTo(padWidth / 2, 9);
+                });
+            });
+
+            test('Should saturate at a quarter turn once the radius sits inside the gap', () => {
+                expect(getPadAngleAtRadius(10, 5)).toBe(Math.PI / 2);
+                expect(getPadAngleAtRadius(10, 1)).toBe(Math.PI / 2);
+                expect(getPadAngleAtRadius(10, 0)).toBe(Math.PI / 2);
+            });
+
+            test('Should return zero for a gap or radius that cannot produce an inset', () => {
+                expect(getPadAngleAtRadius(0, 100)).toBe(0);
+                expect(getPadAngleAtRadius(-5, 100)).toBe(0);
+                expect(getPadAngleAtRadius(NaN, 100)).toBe(0);
+                expect(getPadAngleAtRadius(10, -1)).toBe(0);
+                expect(getPadAngleAtRadius(10, NaN)).toBe(0);
             });
 
         });

--- a/packages/svg/src/path.ts
+++ b/packages/svg/src/path.ts
@@ -8,6 +8,7 @@ import {
     getThetaPoint,
     normalizeBorderRadius,
     radiansToDegrees,
+    TAU,
 } from '@ripl/core';
 
 import type {
@@ -35,30 +36,63 @@ export class SVGPath extends ContextPath implements SVGContextElement {
         };
     }
 
+    private _hasSubpath = false;
+
     private _appendElementData(data: string) {
         this.definition.attributes.d = `${this.definition.attributes.d} ${data}`.trim();
+    }
+
+    /**
+     * Reaches `(x, y)` without breaking the current sub-path — an `L` while one is open, an `M`
+     * otherwise. Canvas joins an arc to the current point with an implicit line, where an `M` would
+     * open a second sub-path whose winding cancels the first under the `nonzero` fill rule.
+     */
+    private _continueSubpath(x: number, y: number): void {
+        if (this._hasSubpath) {
+            this.lineTo(x, y);
+            return;
+        }
+
+        this.moveTo(x, y);
     }
 
     /** Adds an arc centered at `(x, y)` with the given radius to the path. */
     public arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, counterclockwise?: boolean): void {
         const [x1, y1] = getThetaPoint(startAngle, radius, x, y);
-        const [x2, y2] = getThetaPoint(endAngle, radius, x, y);
-        const largeArcFlag = +(Math.abs(endAngle - startAngle) > Math.PI);
         const clockwiseFlag = +!counterclockwise;
 
-        this.moveTo(x1, y1);
-        this._appendElementData(`A ${radius} ${radius} 0 ${largeArcFlag} ${clockwiseFlag} ${x2},${y2}`);
+        this._continueSubpath(x1, y1);
+
+        // A single `A` back to its own start point is dropped by the renderer, so a full turn is halved.
+        if (Math.abs(endAngle - startAngle) >= TAU) {
+            const [ox, oy] = getThetaPoint(startAngle + Math.PI, radius, x, y);
+
+            this._appendElementData(`A ${radius} ${radius} 0 1 ${clockwiseFlag} ${ox},${oy}`);
+            this._appendElementData(`A ${radius} ${radius} 0 1 ${clockwiseFlag} ${x1},${y1}`);
+
+            return;
+        }
+
+        const [x2, y2] = getThetaPoint(endAngle, radius, x, y);
+
+        let sweep = counterclockwise
+            ? startAngle - endAngle
+            : endAngle - startAngle;
+
+        if (sweep < 0) sweep += TAU;
+
+        this._appendElementData(`A ${radius} ${radius} 0 ${+(sweep > Math.PI)} ${clockwiseFlag} ${x2},${y2}`);
     }
 
     /** Adds an arc connecting two tangents defined by the given points to the path. */
     public arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void {
-        this.moveTo(x1, y1);
+        this._continueSubpath(x1, y1);
         this._appendElementData(`A ${radius} ${radius} 0 0 1 ${x2},${y2}`);
     }
 
     /** Adds a full circle centered at `(x, y)` to the path. */
     public circle(x: number, y: number, radius: number): void {
-        this.moveTo(x + radius, y);
+        this._continueSubpath(x + radius, y);
         this._appendElementData(`a ${radius} ${radius} 0 1 0 ${radius * -2},0`);
         this._appendElementData(`a ${radius} ${radius} 0 1 0 ${radius * 2},0`);
     }
@@ -71,6 +105,7 @@ export class SVGPath extends ContextPath implements SVGContextElement {
     /** Closes the current sub-path with a straight line back to its start. */
     public closePath(): void {
         this._appendElementData('Z');
+        this._hasSubpath = false;
     }
 
     /** Adds an elliptical arc centered at `(x, y)` to the path. */
@@ -88,12 +123,12 @@ export class SVGPath extends ContextPath implements SVGContextElement {
             ];
         };
 
-        const isFull = Math.abs(endAngle - startAngle) >= Math.PI * 2;
+        const isFull = Math.abs(endAngle - startAngle) >= TAU;
 
         if (isFull) {
             const [mx, my] = pointOnEllipse(startAngle);
             const [ox, oy] = pointOnEllipse(startAngle + Math.PI);
-            this.moveTo(mx, my);
+            this._continueSubpath(mx, my);
             this._appendElementData(`A ${radiusX} ${radiusY} ${rotDeg} 1 ${+!counterclockwise} ${ox},${oy}`);
             this._appendElementData(`A ${radiusX} ${radiusY} ${rotDeg} 1 ${+!counterclockwise} ${mx},${my}`);
         } else {
@@ -103,10 +138,10 @@ export class SVGPath extends ContextPath implements SVGContextElement {
                 ? startAngle - endAngle
                 : endAngle - startAngle;
 
-            if (sweep < 0) sweep += Math.PI * 2;
+            if (sweep < 0) sweep += TAU;
             const largeArc = +(sweep > Math.PI);
 
-            this.moveTo(x1, y1);
+            this._continueSubpath(x1, y1);
             this._appendElementData(`A ${radiusX} ${radiusY} ${rotDeg} ${largeArc} ${+!counterclockwise} ${x2},${y2}`);
         }
     }
@@ -119,6 +154,7 @@ export class SVGPath extends ContextPath implements SVGContextElement {
     /** Moves the current point to `(x, y)` without adding a line. */
     public moveTo(x: number, y: number): void {
         this._appendElementData(`M ${x},${y}`);
+        this._hasSubpath = true;
     }
 
     /** Adds a quadratic Bézier curve to the path. */

--- a/packages/svg/test/index.test.ts
+++ b/packages/svg/test/index.test.ts
@@ -25,6 +25,8 @@ import {
 
 import {
     createGroup,
+    getThetaPoint,
+    TAU,
 } from '@ripl/core';
 
 describe('SVG', () => {
@@ -86,12 +88,53 @@ describe('SVG', () => {
             expect(path.definition.attributes.d).toContain('Q 10,20 30,40');
         });
 
-        test('arc should append M and A commands', () => {
+        test('arc should open a sub-path when none is open', () => {
             const path = new SVGPath();
             path.arc(50, 50, 25, 0, Math.PI);
             const d = path.definition.attributes.d;
-            expect(d).toContain('M');
-            expect(d).toContain('A');
+            expect(d).toMatch(/^M 75,50 A 25 25 0 0 1 25,/);
+        });
+
+        // An `M` mid-shape splits the annulus into two sub-paths whose windings cancel to a white void.
+        test('arc should continue an open sub-path instead of starting a new one', () => {
+            const path = new SVGPath();
+            path.moveTo(75, 50);
+            path.arc(50, 50, 25, 0, Math.PI);
+            path.lineTo(40, 50);
+            path.arc(50, 50, 10, Math.PI, 0, true);
+            path.closePath();
+            const d = path.definition.attributes.d;
+            expect((d.match(/M /g) || []).length).toBe(1);
+            expect(d.indexOf('M ')).toBe(0);
+        });
+
+        test('annular sector should trace as a single sub-path', () => {
+            const path = new SVGPath();
+            const [x1, y1] = getThetaPoint(0.2, 100, 130, 70);
+            const [x2, y2] = getThetaPoint(1.39, 50, 130, 70);
+
+            path.moveTo(x1, y1);
+            path.arc(130, 70, 100, 0.2, 1.39);
+            path.lineTo(x2, y2);
+            path.arc(130, 70, 50, 1.39, 0.2, true);
+            path.lineTo(x1, y1);
+
+            expect((path.definition.attributes.d.match(/M /g) || []).length).toBe(1);
+        });
+
+        test('arc spanning a full turn should produce two A commands', () => {
+            const path = new SVGPath();
+            path.arc(130, 70, 50, 0, TAU);
+            const d = path.definition.attributes.d;
+            expect((d.match(/A /g) || []).length).toBe(2);
+            expect(d).toBe('M 180,70 A 50 50 0 1 1 80,70 A 50 50 0 1 1 180,70');
+        });
+
+        // The flag must follow the directed sweep; an absolute angle difference reads this one as short.
+        test('counterclockwise arc sweeping past a half turn should set the large-arc flag', () => {
+            const path = new SVGPath();
+            path.arc(0, 0, 10, 0.1, 2, true);
+            expect(path.definition.attributes.d).toContain('A 10 10 0 1 0');
         });
 
         test('arcTo should append M and A commands', () => {


### PR DESCRIPTION
`ArcState.borderRadius` has been a declared option with a getter, a setter and a documented meaning since arcs were written. `Arc.render` never read it. Setting it did nothing at all — there is not an `arcTo`, `quadraticCurveTo` or `bezierCurveTo` anywhere in the file.

`padAngle` works, but it insets by a fixed *angle*, so the gap it opens between neighbouring segments is a wedge — wide at the outer radius, narrowing toward the centre. Measured on two adjacent sectors from r=40 to r=120 with `padAngle: 0.1`, the gap runs:

```
3.99, 5.99, 7.99, 9.98, 11.98      ← padAngle, widens 3× with radius
```

## The fix

**`padWidth`** is a new optional state property: a gap measured in logical pixels that stays constant at every radius. The inset applied at radius ρ is `θ(ρ) = asin(padWidth / 2ρ)`, so each straight edge lies on a line offset `padWidth / 2` from the radial centreline — which is what makes neighbouring edges parallel. The same two sectors with `padWidth: 6`:

```
6.000000000000005, 6.000000000000009, 6.000000000000017, 6.000000000000025, 6.000000000000031
```

Spread across the edge: 2.6e-14. That is measured by reconstructing both edges from the *emitted path commands*, not from the inputs, and it is pinned as a test.

**`borderRadius`** is now read, using d3's scalar `cornerRadius` model — corner circles tangent to both the radial edge and the arc, centred at `radius - rc` and `innerRadius + rc`. Four rounded corners for an annular sector, two for a wedge. Padding is applied first and rounding to the trimmed sector, matching d3 and keeping gaps constant under rounding.

A scalar was chosen over the Rect family's `number | [tl, tr, br, bl]` shape deliberately: a four-tuple has no meaningful corner order on an annular sector. That divergence is documented in `OPTIONS.md` and `shared-options.md`.

`padAngle` is untouched and takes effect only when `padWidth` is absent.

---

# Review round 2

## SVG arcs rendered with white voids — and the cause was not in this PR

Reported against the demo: segments appeared as disjoint crescents with straight-edged voids. Root cause found in `packages/svg/src/path.ts`, which called `moveTo()` before every `A` command:

```ts
this.moveTo(x1, y1);
this._appendElementData(`A ${radius} ${radius} 0 ${largeArcFlag} ${clockwiseFlag} ${x2},${y2}`);
```

In SVG, `M` **terminates the current sub-path and opens a new one**. Canvas's `arc()` instead appends an implicit `lineTo` to the arc's start and stays in the same sub-path. So an annular sector that Canvas draws as one sub-path, SVG split into **three** — and into **seven** once `borderRadius` added corner arcs. SVG closes each fragment with a chord when filling, so the clockwise outer fragment (winding +1) and the counterclockwise inner fragment (−1) cancelled under the `nonzero` rule. That is the void. The fill rule itself was never the problem; both backends use `nonzero`.

**This bug predates this PR.** `git diff origin/main...HEAD -- packages/svg/` was empty before this round; `path.ts` last changed in `5af6d68`/`594b45d`. Every arc-based chart has been rendering wrong in SVG on `main` — pie, polar-area, radial-bar, gauge, chord. It survived because a *full* donut (`0..τ`) happens to render correctly, and because the one existing SVG arc test asserted the bug as correct (`expect(d).toContain('M')`).

`SVGPath` now tracks whether a sub-path is open and emits `L` rather than `M` when one is, mirroring the `_openSubpath` pattern `packages/terminal/src/path.ts` already used. The same defect was found and fixed in `arcTo`, `circle` and `ellipse` — `rect`/`roundRect` correctly keep `moveTo`, since canvas's do start a new sub-path.

Two further defects in the same function, fixed while there:

- **A full circle silently disappeared.** `arc(cx, cy, r, 0, TAU)` painted **zero pixels** in SVG where canvas draws a circle. Note the endpoints are not exactly coincident — `sin(τ)` is `-2.45e-16`, so y differs by 1.2e-14 — Chromium drops the arc on an epsilon, so this was never a knife-edge float coincidence. Now emitted as two half-arcs, as `circle`/`ellipse` already did.
- **`largeArcFlag` ignored direction**, being computed from `Math.abs(endAngle - startAngle)`. `Arc` does not currently trip this, so this is hardening rather than a fixed defect.

**No change to `packages/core/src/elements/arc.ts` was needed** — the geometry was correct all along; only its SVG serialisation was wrong.

Verified by rendering in a real Chromium and counting painted pixels, not by reading code:

| case | before | after | expected |
|---|---|---|---|
| padded rounded donut segment | 2,818 px | **7,407 px** | analytic sector area ≈ 7,606 |
| open arc `0..τ`, r=50 | **0 px** | **8,004 px** | πr² = 7,854 |

The regression guard that should have existed now does: `packages/charts/test/visual/parity.ts` diffs the two backends for real but had no arc scene, so a new `arc-sector` case covers the exact failing geometry. It fails at **16.1% of the frame** without the fix and passes at zero after. The SVG unit test that pinned the bug is replaced by one asserting sub-path continuity — an annular sector must emit exactly one `M`.

## The arc demo now has Single and Stacked tabs

The demo drew three stacked arcs by default, which is a composed donut rather than a demonstration of one element. It is now three tabs, extending the `:::tabs` block the page already used and following the precedent in `docs/3d/essentials/camera.md`:

- **Single** (default) — one arc, with end angle, `innerRadius` and `borderRadius`.
- **Stacked** — three arcs, the same three controls plus `padWidth` and `padAngle`.
- **Code** — unchanged.

Each tab owns its own `<ripl-example>`, `useRiplExample` instance and refs. The tabs plugin renders panels with `v-if`, so an inactive tab is unmounted and remounts fresh — two independent instances is the correct shape, and staleness is structurally impossible since a tab's sliders live in the same unmounted subtree as its context.

The awkward `Pad Angle (set Pad Width to 0)` label is gone. Pad Width now precedes Pad Angle so the precedence reads top-down, and both labels describe the API rather than instructing the reader: `Pad Width (px, takes precedence)` / `Pad Angle (applies only at Pad Width 0)`.

---

## Verification

- `yarn test` — 193 files, **2460 passed, 2 skipped, 1 todo**. The 2 skips are the pre-existing `conformance.test.ts` jsdom cases.
- `tsc` clean; `eslint .` clean; TypeDoc `notDocumented` clean for `@ripl/core` and `@ripl/svg`.
- Playwright parity + hit suites: **8 passed**, including the new `arc-sector` scene. (`charts.spec.ts` snapshot failures in the sandbox are the known stale baselines — they fail on `main` here too, being rendered on a different Chromium.)
- The full `yarn workspace @ripl/website build` completes, so the restructured demo compiles.
- **Canvas rendering is untouched by the SVG fix**: the gallery renders byte-identically (`identical=26 changed=0`) to `main` and to this branch's previous tip, all rendered in the same environment.
- **`padAngle` output is byte-identical to `main`.** Verified independently of this branch's own tests by capturing emitted commands from a second worktree at the merge base and diffing **1680 configurations** (12 spans including negative, zero, sub-ulp, exactly π and beyond TAU × 7 radius pairs × 4 `padAngle` × 5 `borderRadius`). Exactly 92 differ, **all** with a positive `borderRadius`; zero otherwise.
- **Fidelity to d3 checked, not assumed.** The clamp formulas were derived independently then reduced algebraically to d3's; across 604 annular configurations the traced outline sits within **0.17px Hausdorff** of `d3-shape@3.2.0`. Geometric invariants over **5,799 cases**: zero violations.

## Earlier review findings, fixed in round 1

**A `0/0 → NaN` reaching path commands.** In the inner corner clamp, `Math.sin(span / 2)` rounds to *exactly* 1.0 once the span is within ~2.1e-8 of π, making `1 - sin(span/2)` exactly zero. Where the numerator is also zero the result was `NaN`, and the downstream guard still passed because it tested the *outer* radius:

```ts
{ radius: 100, innerRadius: 0, startAngle: 0,
  endAngle: 0.49999999999999994 * TAU, borderRadius: 10 }
// → ["moveTo",NaN,NaN] … ["arc",NaN,NaN,NaN,…]
```

`innerRadius: 0` is exactly the enter state `pie.ts`, `sunburst.ts` and `chord.ts` use, and `0.49999999999999994 * TAU` is what `(value / total) * TAU` yields when a ratio lands one ulp under 0.5 — so a ~50% slice with rounding set would hit it.

Worth noting **why the branch's own fuzz test missed it**: it asserted `Number.isFinite` but drew `innerRadius = random() * radius` (never exactly 0) and sampled spans uniformly, giving ~1e-8 odds of the window — it excluded the bug by construction. The generator now draws 15% of spans from inside the `sin === 1` window with `innerRadius: 0` as an explicit branch.

Also fixed: **`padWidth` precedence keys on presence, not truthiness** (previously `padWidth: 0` meant "unset", so animating `padWidth` 0 → n alongside `padAngle` snapped ~0.1 rad at the first frame); the **open-arc topology change is documented** (a non-zero `borderRadius` on an arc with no `innerRadius` converts a chord-closed segment into a wedge — a 6.3× filled-area jump at `borderRadius: 1e-12` — which also moves the `isPointInPath` hit region and makes the stroke draw two radial spokes); the `padWidth` docs no longer claim parallel edges unconditionally, since that property belongs to annular sectors; `getPadAngleAtRadius`'s JSDoc no longer claims a non-finite `padWidth` returns `0`; and `HALF_PI` moved to `math/constants.ts`.

## Breaking

**`Arc.borderRadius` changes from inert to functional.** Anyone already setting it sees nothing today and will see rounded corners after this. On an open arc it also changes the filled shape, hit region and stroke as described above. No chart in `packages/charts` and no website demo passes `borderRadius` to an arc — verified across all six `createArc` call sites — so nothing bundled changes.

**SVG arc output changes for every consumer**, since it was wrong. Charts rendered through `@ripl/svg` will look different — correct — where they previously showed voids or missing circles.

## Follow-ups

- `Arc._getLocalBoundingBox` under-reports for an arc that bulges past its endpoints: `{radius: 100, startAngle: -0.1, endAngle: 0.1}` gives a right edge of 99.50 instead of 100, because it samples only the centre and the two endpoints, never the axis crossings the sweep passes through. Pre-existing, unaffected either way here.
- Oversized `padAngle` collapses onto `endAngle` (`main`'s behaviour, preserved) while oversized `padWidth` collapses onto the mid-angle. `padWidth`'s is the better behaviour and d3's; the JSDoc states both rather than implying they match.