### PR TITLE
Stop rebuilding per frame what can be derived, memoized, or looked up

### DIFF
--- a/EFFICIENCY_REPORT.md
+++ b/EFFICIENCY_REPORT.md
@@ -45,7 +45,7 @@ public get children() {
 }
 ```
 
-**Status:** Intentionally deferred. Several call sites mutate the returned array in place — notably `Group.render`, which sorts `children` by z-index before drawing — so the getter must keep returning a fresh copy. Caching a shared array would let those in-place sorts corrupt the cache.
+**Status:** Intentionally deferred. Several call sites mutate the returned array in place — notably `Scene._collectInstructions`, which sorts each group's `children` by z-index while flattening the graph — so the getter must keep returning a fresh copy. Caching a shared array would let those in-place sorts corrupt the cache.
 
 ---
 
@@ -55,9 +55,119 @@ public get children() {
 
 ---
 
+---
+
+## 8. ~~Scene keeps a second copy of the render buffer~~ ✅ FIXED
+
+**File:** `packages/core/src/core/scene.ts`
+
+**Issue:** `_buffer` duplicated `_instructions`, rebuilt through a `.filter(...).map(...)` pair (two intermediate arrays) on every graph rebuild, while its only consumers were a `.length` check on resize and two debug-only reads in `Renderer`.
+
+**Status:** Resolved. `Scene.buffer` is now a derived view of `Scene.instructions`, materialized on first access after each rebuild and dropped by the next one. One store, no per-rebuild projection.
+
+---
+
+## 9. ~~Renderer held two copies of the same transitions~~ ✅ FIXED
+
+**File:** `packages/core/src/core/renderer.ts`
+
+**Issue:** `_transitionMap` and a per-call symbol-keyed `scopedTransitions` map held the same entries under the same keys, with removal hand-written in both the completion callback and the `onAbort` path.
+
+**Status:** Resolved. The per-call scope is a flat array of `{ elementId, transitionId, entry }` handles into the one map, and both removal paths go through a single `_removeTransition`. The entry reference is deliberately retained in the handle: `Transition.seek()` is valid after a transition has completed and must still drive its interpolator, which a map lookup would no longer find.
+
+---
+
+## 10. ~~hitTest allocated per pointer move, and its memo outlived the frame~~ ✅ FIXED
+
+**File:** `packages/core/src/context/context.ts`
+
+**Issue:** Every hit test built a `flatMap` array, a `filter` array and an `arrayDedupe` `Set`-round-trip, plus — on any test with ≥2 hits — a `new Map` over *every* rendered element to recover paint order. Worse, `renderedElements` is rebuilt each frame in `markRenderStart` while `_getTrackedElements`' memo was only invalidated on a graph rebuild, so the memo could hand back elements from an older frame while paint order came from the current one (missing entries scored `-1`).
+
+**Status:** Resolved. Hits are collected in one pass into a single result array with a `Set` for dedupe; paint order is a memo rebuilt only when `renderedElements` changes; and `markRenderStart` invalidates the tracked-element memo at depth 0, so it can never outlive its frame. Regression test: *"hitTest should see an element that gained a listener after the memo was primed"* (`packages/core/test/context/context.test.ts`).
+
+The `element.has(event)` re-filter inside the collect pass looks redundant against the memo's own predicate but is **not** — `off()`, a spent `once()` and `destroy()` all leave the memo stale *within* a frame, and three existing tests cover exactly that. It stays.
+
+---
+
+## 11. `getBoundingBox` allocates a `Box` on a cache hit — ❌ NOT SAFE TO FIX
+
+**File:** `packages/core/src/core/element.ts`
+
+**Issue:** Both the local and world cache hits return a freshly constructed `Box` rather than the cached instance.
+
+**Status:** Declined. The copy is a deliberate, tested contract: `packages/core/test/core/bounds-cache.test.ts` → *"Should not corrupt the cache when a returned box is mutated"*. `Box` has public mutable fields, so handing out the cached instance would let any consumer's `box.left -= padding` silently poison every later bounding-box read on that element. No production caller mutates today, but the cost is one small object per call against a whole class of undiagnosable corruption. `getBoundingBox`'s JSDoc now states the ownership contract explicitly. Revisit only alongside an immutable `Box`.
+
+---
+
+## 12. ~~SVG resolved a gradient's bounding box twice per element per frame~~ ✅ FIXED
+
+**File:** `packages/svg/src/context.ts`
+
+**Issue:** `_resolveGradientStyle` called `currentRenderElement.getBoundingBox(true)` for each of the fill and the stroke, every frame.
+
+**Status:** Partially resolved. The bounds are memoized per render element for the duration of its paint and dropped at each `markRenderStart`, so a fill and a stroke sharing an element resolve one box. This matters most for a **group** carrying a gradient: `Group._boundsCacheable` is `false`, so its box unions the whole subtree on every read — now once per frame instead of twice.
+
+**Deferred:** making group boxes cacheable at all. A group's box composes from children whose changes are invisible in the group's own state version, so the existing cache key cannot see them; it needs a child-aware invalidation scheme, which is a design change rather than an audit fix.
+
+---
+
+## 13. ~~vdom re-queried the live DOM for exclusions, twice per child per frame~~ ✅ FIXED
+
+**File:** `packages/dom/src/vdom.ts`
+
+**Issue:** `reconcileChildren` called `element.matches(selector)` per DOM child in the removal pass and again in the insert-position walk — a live DOM query per child per frame under SVG's `excludeSelectors: ['defs']`.
+
+**Status:** Resolved. Exclusions are resolved once per parent into a `Set`, which both passes read; a reconciler with no `excludeSelectors` shares a frozen empty set and allocates nothing.
+
+**Deferred:** the `wantedIds` / `existingChildren` / `claimed` allocations. Each is load-bearing (duplicate sibling ids, id→node lists, cache-fallback claims) and lazily allocating them buys a Map per parent at the cost of shared-mutable-state hazards.
+
+---
+
+## 14. ~~Four independent surface↔screen mappings~~ ✅ FIXED
+
+**Files:** `packages/dom/src/navigator.ts`, `packages/charts/src/components/navigator.ts`, `packages/devtools/src/highlight.ts`, `packages/webgpu/src/context.ts`
+
+**Issue:** Four hand-rolled implementations of the same mapping, disagreeing on the details: `DOMNavigator` cached the origin but applied **no scale at all**; the chart overview strip read `getBoundingClientRect()` **per pointer event**; devtools computed its own `rect.width / context.width`; webgpu duplicated `rescaleCanvas`'s DPR sizing and transform.
+
+**Status:** Resolved. `packages/dom/src/surface.ts` now owns one `getSurfaceRect` / `createSurfaceOrigin` pair — a lazily re-measured origin with scroll, window-resize and context-resize invalidation, mapping to and from *logical* space per the coordinate doctrine. All three DOM consumers adopt it; webgpu delegates its hit-canvas sizing to `rescaleCanvas`.
+
+**Behaviour changes (intentional, both bugs):**
+- The navigators now divide by the surface scale, so a CSS-scaled surface no longer mistakes display pixels for logical ones. Regression test: *"Should map gestures through the surface scale, not raw client pixels"* (`packages/dom/test/navigator.test.ts`).
+- webgpu's `scaleX`/`scaleY` now describe the exact DPR transform its hit canvas installs rather than the floored backing store, matching every other canvas-backed context.
+
+---
+
+## 15. ~~Band and discrete scales scanned the domain per conversion~~ ✅ FIXED
+
+**Files:** `packages/core/src/scales/band.ts`, `packages/core/src/scales/discrete.ts`
+
+**Issue:** Both called `domain.indexOf(value)` on every conversion — O(n) per datum, O(n²) per series.
+
+**Status:** Resolved. `createDomainIndex` (`scales/_base`) builds a value → first-index `Map` once per scale; both scales convert in O(1). First index wins and `NaN` still resolves to `-1`, so the lookup is behaviourally identical to `indexOf`.
+
+---
+
+## 16. `Group.render`'s z-index sort — ⚠️ LEFT IN PLACE
+
+**File:** `packages/core/src/core/group.ts`
+
+**Issue:** `Group.render` sorts its children by z-index on every invocation, duplicating the ordering `Scene._collectInstructions` already performs on rebuild.
+
+**Status:** Left as-is. It is genuinely unreachable from the paint path — both `Scene.render` and `Renderer._renderBuffer` walk the flat instruction stream and only ever call `element.render(context)` for `draw` (leaf) entries, so it costs nothing per frame. But it is documented public API with direct test coverage (`packages/core/test/core/group-render.test.ts` asserts both ascending z-index order and stable ties), and the freeform-drawing export demo re-implements the same ordering precisely because it renders outside a scene. Removing the sort would break a documented contract for a saving of zero frames.
+
+---
+
 ## Summary
 
 **Fixed (items 1–5, 7):** All generic array wrappers removed, consumers migrated to native methods. `arrayGroup` and set utilities optimized. `arrayJoin` now uses a `Map` for O(1) key lookups when predicate is a key string. `arrayMapRange` uses indexed `for` loop instead of `Array.from`. `stringUniqueId` builds its hex string via `Array.from(...).join('')`. SVG rendering reorders through the O(n) `reconcileNode` pass.
 
+**Fixed (items 8–10, 12–15):** The scene's render buffer became a derived view of the instruction stream; the renderer collapsed onto one transition store; `hitTest` dropped its per-move allocations and stopped reusing a previous frame's memo; SVG resolves a gradient's box once per element per frame; the vdom resolves exclusions once per parent; one shared surface-origin helper replaced four mappings (fixing the navigators' missing scale); and band/discrete scales convert through a keyed lookup.
+
 **Remaining:**
-1. **Group.children caching** (#6) — deferred by design: callers (e.g. `Group.render`'s z-index sort) mutate the returned array, so it must stay a fresh copy.
+1. **Group.children caching** (#6) — deferred by design: callers (e.g. `Scene._collectInstructions`' z-index sort) mutate the returned array, so it must stay a fresh copy.
+2. **`getBoundingBox` cache-hit allocation** (#11) — declined: the defensive copy is a tested contract and `Box` is mutable. Needs an immutable `Box` first.
+3. **Cacheable group bounding boxes** (#12) — needs child-aware invalidation, not an audit fix.
+4. **SVG `_vtree` full per-frame rebuild** — architectural; needs a benchmark harness before any redesign.
+5. **`Context.save()`'s ~28-key state spread and the full `CONTEXT_OPERATIONS` walk per element per frame** — dirty-key tracking is a design project, not an audit fix.
+6. **`evictDetachedNodes` is O(cache × depth)** — only runs on a pass that removed a node, but the containment test walks the parent chain per cached entry.
+7. **Remaining `reconcileChildren` per-parent maps** (#13) — load-bearing; lazy allocation trades a Map for shared mutable state.

--- a/EFFICIENCY_REPORT.md
+++ b/EFFICIENCY_REPORT.md
@@ -73,7 +73,7 @@ public get children() {
 
 **Issue:** `_transitionMap` and a per-call symbol-keyed `scopedTransitions` map held the same entries under the same keys, with removal hand-written in both the completion callback and the `onAbort` path.
 
-**Status:** Resolved. The per-call scope is a flat array of `{ elementId, transitionId, entry }` handles into the one map, and both removal paths go through a single `_removeTransition`. The entry reference is deliberately retained in the handle: `Transition.seek()` is valid after a transition has completed and must still drive its interpolator, which a map lookup would no longer find.
+**Status:** Resolved. The per-call scope is a flat array of `{ elementId, transitionId, entry }` handles into the one map, and both removal paths go through a single `_removeTransition`. The array is append-only and so outlives the map entries it points at, deliberately: `Transition.seek()` is valid after a transition has completed and must still drive its interpolator, which a map lookup would no longer find. Retention is unchanged from before the refactor — the previous per-call `Map` held the same entries for the same lifetime.
 
 ---
 
@@ -83,9 +83,15 @@ public get children() {
 
 **Issue:** Every hit test built a `flatMap` array, a `filter` array and an `arrayDedupe` `Set`-round-trip, plus — on any test with ≥2 hits — a `new Map` over *every* rendered element to recover paint order. Worse, `renderedElements` is rebuilt each frame in `markRenderStart` while `_getTrackedElements`' memo was only invalidated on a graph rebuild, so the memo could hand back elements from an older frame while paint order came from the current one (missing entries scored `-1`).
 
-**Status:** Resolved. Hits are collected in one pass into a single result array with a `Set` for dedupe; paint order is a memo rebuilt only when `renderedElements` changes; and `markRenderStart` invalidates the tracked-element memo at depth 0, so it can never outlive its frame. Regression test: *"hitTest should see an element that gained a listener after the memo was primed"* (`packages/core/test/context/context.test.ts`).
+**Status:** Resolved. Hits are collected in one pass into a single result array with a `Set` for dedupe; paint order is a memo rebuilt only when `renderedElements` changes; and `markRenderEnd` invalidates the tracked-element memo at depth 0, so it can never outlive its frame. Regression test: *"hitTest should see an element that gained a listener after the memo was primed"* (`packages/core/test/context/context.test.ts`).
+
+The invalidation sits at `markRenderEnd`, not `markRenderStart`, and a hit test issued while a pass is open bypasses the memo entirely. `Renderer._tick` runs user `onComplete` handlers inside `context.batch`, so a consumer can hit-test mid-paint; priming the memo there would have cached a *partial* `renderedElements` and served that truncated list until the next frame. Regression test: *"hitTest should not memoize the partial list a mid-frame hit test walks"*.
 
 The `element.has(event)` re-filter inside the collect pass looks redundant against the memo's own predicate but is **not** — `off()`, a spent `once()` and `destroy()` all leave the memo stale *within* a frame, and three existing tests cover exactly that. It stays.
+
+**Cost of the per-frame invalidation.** Only a frame that actually painted invalidates, and only the first hit test after it rebuilds. The hover path asks for three event names, so that rebuild is three `renderedElements.filter` passes plus the paint-order `Map`, where the previous code amortised the filters across frames and rebuilt the `Map` on every hit test. Measured on this machine (Node, synthetic list, one in four elements tracking the event): 131 µs → 158 µs per frame at 2 000 elements, 987 µs → 1 459 µs at 10 000. The `Map` build dominates either way; the marginal cost is the filters, and it is paid only while animating *and* hovering. A change-detection pass over the previous frame's list would recover it, at the price of retaining that list — not worth it at these numbers.
+
+**Known constraint.** The paint-order memo and the tracked-element memo both key off `Context.renderedElements`, and both are invalidated only where the context itself writes to it (`currentRenderElement`, `markRenderStart`, `markRenderEnd`). The field is public and mutable, so a caller that splices it directly would bypass all three invalidation points and get stale ordering. No in-repo code does. The field arguably wants to be a getter over a private array; that is an API change for a later PR.
 
 ---
 
@@ -117,23 +123,27 @@ The `element.has(event)` re-filter inside the collect pass looks redundant again
 
 **Issue:** `reconcileChildren` called `element.matches(selector)` per DOM child in the removal pass and again in the insert-position walk — a live DOM query per child per frame under SVG's `excludeSelectors: ['defs']`.
 
-**Status:** Resolved. Exclusions are resolved once per parent into a `Set`, which both passes read; a reconciler with no `excludeSelectors` shares a frozen empty set and allocates nothing.
+**Status:** Resolved. Exclusions are resolved once per parent into a `Set`, which both passes read; a reconciler with no `excludeSelectors` shares one empty set — typed `ReadonlySet` so no caller can write to it, though nothing enforces that at runtime — and allocates nothing.
 
 **Deferred:** the `wantedIds` / `existingChildren` / `claimed` allocations. Each is load-bearing (duplicate sibling ids, id→node lists, cache-fallback claims) and lazily allocating them buys a Map per parent at the cost of shared-mutable-state hazards.
 
 ---
 
-## 14. ~~Four independent surface↔screen mappings~~ ✅ FIXED
+## 14. ~~Five independent surface↔screen mappings~~ ✅ FIXED
 
-**Files:** `packages/dom/src/navigator.ts`, `packages/charts/src/components/navigator.ts`, `packages/devtools/src/highlight.ts`, `packages/webgpu/src/context.ts`
+**Files:** `packages/dom/src/context.ts`, `packages/dom/src/navigator.ts`, `packages/charts/src/components/navigator.ts`, `packages/devtools/src/highlight.ts`, `packages/webgpu/src/context.ts`
 
-**Issue:** Four hand-rolled implementations of the same mapping, disagreeing on the details: `DOMNavigator` cached the origin but applied **no scale at all**; the chart overview strip read `getBoundingClientRect()` **per pointer event**; devtools computed its own `rect.width / context.width`; webgpu duplicated `rescaleCanvas`'s DPR sizing and transform.
+**Issue:** Five hand-rolled implementations of the same mapping, disagreeing on the details: `DOMContext` subtracted a cached `getBoundingClientRect()` origin with **no scale at all**; `DOMNavigator` did the same; the chart overview strip read `getBoundingClientRect()` **per pointer event**; devtools computed its own `rect.width / context.width`; webgpu duplicated `rescaleCanvas`'s DPR sizing and transform.
 
-**Status:** Resolved. `packages/dom/src/surface.ts` now owns one `getSurfaceRect` / `createSurfaceOrigin` pair — a lazily re-measured origin with scroll, window-resize and context-resize invalidation, mapping to and from *logical* space per the coordinate doctrine. All three DOM consumers adopt it; webgpu delegates its hit-canvas sizing to `rescaleCanvas`.
+**Status:** Resolved. `packages/dom/src/surface.ts` owns one `getSurfaceRect` / `createSurfaceOrigin` pair — a lazily re-measured origin with scroll, window-resize, context-resize and pointer-enter invalidation, mapping to and from *logical* space per the coordinate doctrine. All four DOM consumers adopt it; webgpu delegates its hit-canvas sizing to `rescaleCanvas`.
 
-**Behaviour changes (intentional, both bugs):**
+**Behaviour changes (intentional, all bugs):**
 - The navigators now divide by the surface scale, so a CSS-scaled surface no longer mistakes display pixels for logical ones. Regression test: *"Should map gestures through the surface scale, not raw client pixels"* (`packages/dom/test/navigator.test.ts`).
+- `DOMContext` divides by the same scale, so hover, click and drag payloads land where the navigator's pan/zoom anchor does. On a CSS-scaled chart they previously disagreed by the scale factor. Regression test: *"Should map pointer coordinates through the surface scale"* (`packages/dom/test/context.test.ts`).
+- A cached origin is re-measured when the pointer enters the surface, so a layout shift that translates the chart without scrolling or resizing it (a dismissed banner above it) cannot strand every consumer on a stale origin — `DOMContext` already guarded this on `mouseenter`; the shared origin now does it for the navigators too. Regression tests: *"Should re-measure when the pointer enters after a layout translation"* (`packages/dom/test/surface.test.ts`) and *"Should follow the surface after a layout translation"* (`packages/charts/test/overview-navigator.test.ts`).
 - webgpu's `scaleX`/`scaleY` now describe the exact DPR transform its hit canvas installs rather than the floored backing store, matching every other canvas-backed context.
+
+Each consumer owns its own `SurfaceOrigin` (its own cache and its own listeners) — a chart with two navigators takes two measurements. One mapping, not one instance.
 
 ---
 
@@ -161,7 +171,7 @@ The `element.has(event)` re-filter inside the collect pass looks redundant again
 
 **Fixed (items 1–5, 7):** All generic array wrappers removed, consumers migrated to native methods. `arrayGroup` and set utilities optimized. `arrayJoin` now uses a `Map` for O(1) key lookups when predicate is a key string. `arrayMapRange` uses indexed `for` loop instead of `Array.from`. `stringUniqueId` builds its hex string via `Array.from(...).join('')`. SVG rendering reorders through the O(n) `reconcileNode` pass.
 
-**Fixed (items 8–10, 12–15):** The scene's render buffer became a derived view of the instruction stream; the renderer collapsed onto one transition store; `hitTest` dropped its per-move allocations and stopped reusing a previous frame's memo; SVG resolves a gradient's box once per element per frame; the vdom resolves exclusions once per parent; one shared surface-origin helper replaced four mappings (fixing the navigators' missing scale); and band/discrete scales convert through a keyed lookup.
+**Fixed (items 8–10, 12–15):** The scene's render buffer became a derived view of the instruction stream; the renderer collapsed onto one transition store; `hitTest` dropped its per-move allocations and stopped reusing a previous frame's memo; SVG resolves a gradient's box once per element per frame; the vdom resolves exclusions once per parent; one shared surface-origin helper replaced five mappings (fixing the missing scale in the navigators *and* in `DOMContext`); and band/discrete scales convert through a keyed lookup.
 
 **Remaining:**
 1. **Group.children caching** (#6) — deferred by design: callers (e.g. `Scene._collectInstructions`' z-index sort) mutate the returned array, so it must stay a fresh copy.

--- a/apps/website/src/docs/core/essentials/scene.md
+++ b/apps/website/src/docs/core/essentials/scene.md
@@ -92,11 +92,13 @@ Call `render()` with no arguments, and the scene uses its bound context:
 scene.render();
 ```
 
-This clears the context, marks the render start, renders all buffered elements in z-index order, and marks the render end. You don't need to manage any of this yourself.
+This clears the context, marks the render start, renders the instruction stream in paint order, and marks the render end. You don't need to manage any of this yourself.
 
 ### Render Buffer
 
-When elements are added to or removed from the scene (or any nested group), the scene automatically rebuilds a **flat render buffer**. This buffer is a sorted array of all leaf elements in the scene graph, ordered by `zIndex`. This hoisting converts rendering from a recursive tree walk (O(n^c)) to a simple flat iteration (O(n)).
+When elements are added to or removed from the scene (or any nested group), the scene automatically rebuilds a **flat instruction stream** (`scene.instructions`). Each group's children are sorted by `zIndex` as the stream is built, and each group is bracketed by a `push`/`pop` pair around the `draw` entries for its leaves, so a group paints as one contiguous stacking context. This hoisting converts rendering from a recursive tree walk (O(n^c)) to a simple flat iteration (O(n)).
+
+`scene.buffer` is a read-only **view** of that stream — the `draw` targets, in paint order — materialized on first access after each rebuild rather than stored alongside it. Read it to inspect what the scene will paint; the render path itself walks `instructions`.
 
 ## Events
 

--- a/apps/website/src/docs/core/troubleshooting/performance.md
+++ b/apps/website/src/docs/core/troubleshooting/performance.md
@@ -8,20 +8,20 @@ Ripl is designed to be performant out of the box, but understanding how the rend
 
 ## Scene Hoisting
 
-The single most impactful optimization in Ripl is **scene hoisting**. When elements are placed into a Scene, the scene flattens the entire element tree into a single sorted array called the **render buffer**.
+The single most impactful optimization in Ripl is **scene hoisting**. When elements are placed into a Scene, the scene flattens the entire element tree into a single z-sorted **instruction stream** (`scene.instructions`), with each group bracketed by a `push`/`pop` pair around its leaves' `draw` entries.
 
-Without a scene, rendering a deeply nested group structure requires a recursive tree walk, an O(n^c) operation where `c` is the depth of the tree. With a scene, the render buffer converts this to a flat O(n) iteration:
+Without a scene, rendering a deeply nested group structure requires a recursive tree walk, an O(n^c) operation where `c` is the depth of the tree. With a scene, the instruction stream converts this to a flat O(n) iteration:
 
 ```ts
 // Without scene: recursive tree walk each frame
 group.render(context); // O(n^c)
 
-// With scene: flat buffer iteration each frame
+// With scene: flat instruction iteration each frame
 const scene = createScene(context, { children: [group] });
 scene.render(); // O(n)
 ```
 
-The cost of maintaining the buffer is shifted to add/remove operations on groups, which happen far less frequently than rendering.
+The cost of building the stream is shifted to add/remove operations on groups, which happen far less frequently than rendering. `scene.buffer` — the leaf elements the stream draws — is a derived view of it, built on demand rather than maintained as a second copy.
 
 ### When to Use Scenes
 
@@ -90,13 +90,13 @@ The SVG context automatically uses **buffered rendering**. Instead of applying D
 
 ## Tips Summary
 
-1. **Use a Scene + Renderer** for anything beyond trivial rendering. The flat render buffer and automatic start/stop provide significant performance gains.
+1. **Use a Scene + Renderer** for anything beyond trivial rendering. The flat instruction stream and automatic start/stop provide significant performance gains.
 2. **Use Canvas** for large element counts or complex animations.
 3. **Use persistent path keys** in custom elements for efficient SVG reconciliation.
 4. **Let autoStop work**: don't disable it unless you have continuous animations.
 5. **Minimize group depth**: while scenes flatten the tree for rendering, shallower trees are faster to modify.
 6. **Batch property changes** by setting multiple properties before triggering a render, rather than rendering after each change.
-7. **Use `zIndex`** instead of render order when possible, since the scene buffer sorts by zIndex automatically.
+7. **Use `zIndex`** instead of render order when possible, since the scene sorts each group's children by zIndex automatically.
 
 ## Stress Test
 

--- a/packages/canvas/src/utilities.ts
+++ b/packages/canvas/src/utilities.ts
@@ -270,12 +270,16 @@ export function setCanvasStroke(ctx: CanvasRenderingContext2D, value: string, bo
     ctx.strokeStyle = value;
 }
 
-/** Result of a canvas rescale operation containing the updated coordinate scales. */
+/** Result of a canvas rescale operation containing the updated coordinate scales and backing-store size. */
 export interface RescaleResult {
     /** Scale mapping logical x coordinates to device pixels. */
     scaleX: Scale<number, number>;
     /** Scale mapping logical y coordinates to device pixels. */
     scaleY: Scale<number, number>;
+    /** Width of the backing store, in device pixels, floored to a whole pixel. */
+    scaledWidth: number;
+    /** Height of the backing store, in device pixels, floored to a whole pixel. */
+    scaledHeight: number;
 }
 
 /**
@@ -311,6 +315,8 @@ export function rescaleCanvas(
 
     // The scales describe the transform drawing actually uses (an exact `dpr`), not the floored store.
     return {
+        scaledWidth,
+        scaledHeight,
         scaleX: scaleContinuous([0, width], [0, width * dpr]),
         scaleY: scaleContinuous([0, height], [0, height * dpr]),
     };

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -50,7 +50,12 @@ import {
 } from '@ripl/utilities';
 
 import {
+    createSurfaceOrigin,
     onDOMEvent,
+} from '@ripl/dom';
+
+import type {
+    SurfaceOrigin,
 } from '@ripl/dom';
 
 /** Retention key for the strip's DOM pointer listeners. */
@@ -136,6 +141,7 @@ export class ChartNavigator extends ChartComponent {
 
     private _group?: Group;
     private _element?: HTMLElement;
+    private _origin?: SurfaceOrigin;
     private _orientation: ChartNavigatorOrientation = 'horizontal';
     private _area?: ChartArea;
     private _window: ChartNavigatorWindow = {
@@ -167,6 +173,9 @@ export class ChartNavigator extends ChartComponent {
         }
 
         this._element = element;
+        this._origin = createSurfaceOrigin(this.context);
+
+        this.retain(this._origin, LISTENER_KEY);
         this.retain(onDOMEvent(element, 'pointerdown', this._onPointerDown), LISTENER_KEY);
         this.retain(onDOMEvent(element, 'pointermove', this._onPointerMove), LISTENER_KEY);
         this.retain(onDOMEvent(element, 'pointerup', this._onPointerUp), LISTENER_KEY);
@@ -217,6 +226,7 @@ export class ChartNavigator extends ChartComponent {
         this.dispose(LISTENER_KEY);
         this._group?.destroy();
         this._group = undefined;
+        this._origin = undefined;
         this._attached = false;
         super.destroy();
     }
@@ -526,12 +536,7 @@ export class ChartNavigator extends ChartComponent {
     }
 
     private _localPoint(event: PointerEvent): Point {
-        const rect = this._element!.getBoundingClientRect();
-
-        return [
-            event.clientX - rect.left,
-            event.clientY - rect.top,
-        ];
+        return this._origin!.toLogicalPoint(event);
     }
 
     /** The pointer coordinate along the main (window) axis. */

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -18,6 +18,15 @@ import {
     createTrendChart,
 } from '../src';
 
+import {
+    ChartNavigator,
+} from '../src/components/navigator';
+
+import {
+    createRenderer,
+    createScene,
+} from '@ripl/core';
+
 import type {
     Group,
 } from '@ripl/core';
@@ -96,6 +105,113 @@ const DATA: Row[] = MONTHS.map((month, index) => ({
     a: (index + 1) * 100,
     b: (index + 1) * 40,
 }));
+
+describe('Overview navigator strip dragging', () => {
+
+    const AREA = {
+        x: 0,
+        y: 340,
+        width: 640,
+        height: 60,
+    };
+
+    /** Dispatches a pointer event with arbitrary properties, sidestepping jsdom constructor gaps. */
+    function fire(target: EventTarget, type: string, props: Record<string, unknown> = {}): void {
+        const event = new Event(type, {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        Object.assign(event, props);
+        target.dispatchEvent(event);
+    }
+
+    // Dismissing a banner above the chart translates the surface with no scroll and no resize.
+    test('Should follow the surface after a layout translation', () => {
+        mockCanvasContext();
+
+        const rect = {
+            left: 0,
+            top: 0,
+        };
+
+        vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+            ...rect,
+            width: 640,
+            height: 400,
+            right: rect.left + 640,
+            bottom: rect.top + 400,
+            x: rect.left,
+            y: rect.top,
+            toJSON: () => ({}),
+        } as DOMRect));
+
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        const scene = createScene(host);
+        const renderer = createRenderer(scene, {
+            autoStart: false,
+            autoStop: false,
+        });
+
+        const onWindow = vi.fn();
+        const navigator = new ChartNavigator({
+            scene,
+            renderer,
+        });
+
+        navigator.attach();
+        navigator.render({
+            orientation: 'horizontal',
+            area: AREA,
+            series: [],
+            valueExtent: [0, 1],
+            window: {
+                start: 0.25,
+                end: 0.75,
+            },
+            onWindow,
+        });
+
+        const surface = scene.context.element as unknown as HTMLCanvasElement;
+
+        fire(surface, 'pointerdown', {
+            pointerId: 1,
+            clientX: 320,
+            clientY: 370,
+        });
+        fire(surface, 'pointerup', {
+            pointerId: 1,
+        });
+
+        rect.top = 200;
+        fire(surface, 'pointerenter', {
+            pointerId: 1,
+        });
+
+        fire(surface, 'pointerdown', {
+            pointerId: 1,
+            clientX: 320,
+            clientY: 570,
+        });
+        fire(surface, 'pointermove', {
+            pointerId: 1,
+            clientX: 384,
+            clientY: 570,
+        });
+
+        expect(onWindow).toHaveBeenCalledWith({
+            start: 0.35,
+            end: 0.85,
+        });
+
+        navigator.destroy();
+        scene.destroy();
+        host.remove();
+    });
+
+});
 
 describe('Overview navigator strip', () => {
 

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -57,7 +57,6 @@ import type {
 } from '../scales';
 
 import {
-    arrayDedupe,
     functionMemoize,
     objectForEach,
     typeIsNil,
@@ -99,6 +98,7 @@ export function measureText(value: string, options?: MeasureTextOptions): TextMe
 export abstract class Context<TElement extends Element = Element, TMeta extends Record<string, unknown> = Record<string, unknown>> extends EventBus<ContextEventMap> implements BaseState {
 
     private _groupStack: GroupScope[] = [];
+    private _paintOrder?: Map<RenderElement, number>;
 
     protected states: BaseState[];
     protected currentState: BaseState;
@@ -159,6 +159,7 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
 
         if (element && !element.abstract) {
             this.renderedElements.push(element);
+            this._paintOrder = undefined;
         }
     }
 
@@ -510,6 +511,10 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     public markRenderStart(): void {
         if (this.renderDepth === 0) {
             this.renderedElements = [];
+            this._paintOrder = undefined;
+
+            // The tracked-element memo filters this list, so it belongs to the frame that built it.
+            this.invalidateTrackedElements();
         }
 
         this.renderDepth += 1;
@@ -769,6 +774,38 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         return this.renderedElements.filter(element => element.has(event));
     });
 
+    /** Paint index per rendered element, memoized until the list it indexes changes. */
+    private _getPaintOrder(): Map<RenderElement, number> {
+        if (this._paintOrder) {
+            return this._paintOrder;
+        }
+
+        const paintOrder = new Map<RenderElement, number>();
+
+        this.renderedElements.forEach((element, index) => paintOrder.set(element, index));
+        this._paintOrder = paintOrder;
+
+        return paintOrder;
+    }
+
+    /** Appends every element tracking `event` that the point intersects, skipping ones already collected. */
+    private _collectHits(event: string, x: number, y: number, seen: Set<RenderElement>, hits: RenderElement[]): void {
+        // The memo is a snapshot; `off`, a spent `once` and `destroy` all leave it stale within a frame.
+        this._getTrackedElements(event).forEach(element => {
+            if (seen.has(element) || !element.has(event)) {
+                return;
+            }
+
+            seen.add(element);
+
+            if (element.intersectsWith(x, y, {
+                isPointer: true,
+            })) {
+                hits.push(element);
+            }
+        });
+    }
+
     /**
      * Tests which rendered elements intersect the given point for the given event types,
      * returning them topmost-first — the exact reverse of the order they were painted in.
@@ -782,20 +819,17 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
      * two descendants of different groups; sorting by it discarded correct information.
      */
     protected hitTest(events: string[], x: number, y: number): RenderElement[] {
-        // The memo is a snapshot; `off`, a spent `once` and `destroy` all leave it stale.
-        const tracked = events.flatMap(event => this._getTrackedElements(event).filter(element => element.has(event)));
+        const hits: RenderElement[] = [];
+        const seen = new Set<RenderElement>();
 
-        const hits = arrayDedupe(tracked)
-            .filter(element => element.intersectsWith(x, y, {
-                isPointer: true,
-            }));
+        events.forEach(event => this._collectHits(event, x, y, seen, hits));
 
         if (hits.length < 2) {
             return hits;
         }
 
         // One-pass index map; an `indexOf` in the comparator would rescan the list per comparison.
-        const paintOrder = new Map(this.renderedElements.map((element, index) => [element, index]));
+        const paintOrder = this._getPaintOrder();
 
         return hits.sort((ea, eb) => (paintOrder.get(eb) ?? -1) - (paintOrder.get(ea) ?? -1));
     }
@@ -815,6 +849,7 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         this.renderedElements = [];
         this.renderElement = undefined;
         this._groupStack = [];
+        this._paintOrder = undefined;
 
         this.invalidateTrackedElements();
         this.dispose();

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -512,9 +512,6 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         if (this.renderDepth === 0) {
             this.renderedElements = [];
             this._paintOrder = undefined;
-
-            // The tracked-element memo filters this list, so it belongs to the frame that built it.
-            this.invalidateTrackedElements();
         }
 
         this.renderDepth += 1;
@@ -523,6 +520,11 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     /** Signals the end of a render pass. Clamped at zero, so an unbalanced call cannot drive the depth negative and make backends that gate their flush on depth 0 fire mid-frame. */
     public markRenderEnd(): void {
         this.renderDepth = Math.max(0, this.renderDepth - 1);
+
+        if (this.renderDepth === 0) {
+            // The tracked-element memo filters this frame's rendered list, so it dies with the frame that built it.
+            this.invalidateTrackedElements();
+        }
     }
 
     /**
@@ -788,10 +790,17 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         return paintOrder;
     }
 
+    /** Elements tracking `event`, memoized per frame; mid-frame the list is still growing, so caching it would serve a truncated hit test for the rest of the frame. */
+    private _resolveTrackedElements(event: string): RenderElement[] {
+        return this.renderDepth > 0
+            ? this.renderedElements.filter(element => element.has(event))
+            : this._getTrackedElements(event);
+    }
+
     /** Appends every element tracking `event` that the point intersects, skipping ones already collected. */
     private _collectHits(event: string, x: number, y: number, seen: Set<RenderElement>, hits: RenderElement[]): void {
         // The memo is a snapshot; `off`, a spent `once` and `destroy` all leave it stale within a frame.
-        this._getTrackedElements(event).forEach(element => {
+        this._resolveTrackedElements(event).forEach(element => {
             if (seen.has(element) || !element.has(event)) {
                 return;
             }

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -764,6 +764,9 @@ export class Element<
      * box when `local` is `true`. The world box applies this element's own and every ancestor
      * group's transform (mirroring the DOM's `getBoundingClientRect`); a rotated element yields a
      * conservative axis-aligned box.
+     *
+     * The box is a copy the caller owns: it is safe to mutate, and mutating it cannot corrupt the
+     * cache it was read from.
      * @param local - when `true`, returns the untransformed authored geometry instead of the world box.
      */
     public getBoundingBox(local = false): Box {

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -53,6 +53,13 @@ import {
     valueOneOrMore,
 } from '@ripl/utilities';
 
+/** A transition owned by one `transition()` call, addressing its entry in the renderer's transition map. */
+interface ScopedTransition {
+    elementId: string;
+    transitionId: symbol;
+    entry: RendererTransition;
+}
+
 /** Alias for the transition playback direction within the renderer. */
 export type RendererTransitionDirection = TransitionDirection;
 
@@ -317,6 +324,16 @@ export class Renderer extends EventBus<RendererEventMap> {
         });
     }
 
+    private _removeTransition(elementId: string, transitionId: symbol): void {
+        const transitions = this._transitionMap.get(elementId);
+
+        transitions?.delete(transitionId);
+
+        if (!transitions?.size) {
+            this._transitionMap.delete(elementId);
+        }
+    }
+
     private _processTransition(entry: RendererTransition): void {
         if (entry.paused) {
             if (entry.pauseOffset > 0) {
@@ -496,14 +513,16 @@ export class Renderer extends EventBus<RendererEventMap> {
             ? options
             : () => options || {} as RendererTransitionOptions<TElement>;
 
-        const scopedTransitions = new Map<symbol, { elementId: Element['id'];
-            entry: RendererTransition; }>();
+        // A per-call index into the transition map, not a second copy of it: the entries are shared.
+        const scope: ScopedTransition[] = [];
+
+        const forEachScoped = (body: (entry: RendererTransition) => void) => scope.forEach(({ entry }) => body(entry));
 
         const hooks = {
             onPause: () => {
                 const now = factory.now();
 
-                scopedTransitions.forEach(({ entry }) => {
+                forEachScoped(entry => {
                     entry.pauseOffset = now - entry.startTime;
                     entry.paused = true;
                 });
@@ -511,7 +530,7 @@ export class Renderer extends EventBus<RendererEventMap> {
             onPlay: () => {
                 const now = factory.now();
 
-                scopedTransitions.forEach(({ entry }) => {
+                forEachScoped(entry => {
                     entry.startTime = now - entry.pauseOffset;
                     entry.paused = false;
                 });
@@ -519,7 +538,7 @@ export class Renderer extends EventBus<RendererEventMap> {
                 this.start();
             },
             onSeek: (position: number) => {
-                scopedTransitions.forEach(({ entry }) => {
+                forEachScoped(entry => {
                     entry.pauseOffset = position * entry.duration;
                     entry.paused = true;
 
@@ -557,14 +576,9 @@ export class Renderer extends EventBus<RendererEventMap> {
                 const startTime = factory.now() + delay;
 
                 const callback = () => {
-                    const elementTransitions = this._transitionMap.get(element.id);
-
                     completeCount += 1;
-                    elementTransitions?.delete(transitionId);
 
-                    if (!elementTransitions?.size) {
-                        this._transitionMap.delete(element.id);
-                    }
+                    this._removeTransition(element.id, transitionId);
 
                     try {
                         onComplete(element);
@@ -591,8 +605,9 @@ export class Renderer extends EventBus<RendererEventMap> {
                     interpolator: element.interpolate(state),
                 };
 
-                scopedTransitions.set(transitionId, {
+                scope.push({
                     entry,
+                    transitionId,
                     elementId: element.id,
                 });
 
@@ -601,15 +616,7 @@ export class Renderer extends EventBus<RendererEventMap> {
             });
 
             onAbort(() => {
-                scopedTransitions.forEach(({ elementId }, id) => {
-                    const elementTransitions = this._transitionMap.get(elementId);
-                    elementTransitions?.delete(id);
-
-                    if (!elementTransitions?.size) {
-                        this._transitionMap.delete(elementId);
-                    }
-                });
-
+                scope.forEach(({ elementId, transitionId }) => this._removeTransition(elementId, transitionId));
                 this._stopOnIdle();
             });
         }, hooks);

--- a/packages/core/src/core/renderer.ts
+++ b/packages/core/src/core/renderer.ts
@@ -513,7 +513,7 @@ export class Renderer extends EventBus<RendererEventMap> {
             ? options
             : () => options || {} as RendererTransitionOptions<TElement>;
 
-        // A per-call index into the transition map, not a second copy of it: the entries are shared.
+        // Append-only handles on the map's entries, kept past completion because `seek()` still has to drive their interpolators.
         const scope: ScopedTransition[] = [];
 
         const forEachScoped = (body: (entry: RendererTransition) => void) => scope.forEach(({ entry }) => body(entry));

--- a/packages/core/src/core/scene.ts
+++ b/packages/core/src/core/scene.ts
@@ -75,7 +75,7 @@ export interface SceneOptions extends GroupOptions {
 export class Scene<TContext extends Context = Context> extends Group<SceneEventMap> {
 
     private _needsRender = true;
-    private _buffer: Element[] = [];
+    private _buffer?: Element[];
     private _instructions: RenderInstruction[] = [];
 
     /** The rendering {@link Context} this scene draws to. */
@@ -93,11 +93,12 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
 
     /**
      * The flat list of renderable leaf descendants in paint order: the `draw` targets of
-     * {@link Scene.instructions}. The array is materialized once per graph rebuild and cached,
-     * so treat it as read-only.
+     * {@link Scene.instructions}, which are the single store this projects. The array is
+     * materialized on first access after a graph rebuild and cached until the next one, so treat
+     * it as read-only.
      */
     public get buffer(): Element[] {
-        return this._buffer;
+        return this._buffer ??= this._collectBuffer();
     }
 
     /**
@@ -196,9 +197,19 @@ export class Scene<TContext extends Context = Context> extends Group<SceneEventM
         this._collectInstructions(this, instructions);
 
         this._instructions = instructions;
-        this._buffer = instructions
-            .filter(instruction => instruction.type === 'draw')
-            .map(instruction => instruction.element);
+        this._buffer = undefined;
+    }
+
+    private _collectBuffer(): Element[] {
+        const elements: Element[] = [];
+
+        this._instructions.forEach(instruction => {
+            if (instruction.type === 'draw') {
+                elements.push(instruction.element);
+            }
+        });
+
+        return elements;
     }
 
     /**

--- a/packages/core/src/scales/_base/index.ts
+++ b/packages/core/src/scales/_base/index.ts
@@ -94,6 +94,26 @@ export function niceDomain(domain: number[], count: number = 10): number[] {
     ];
 }
 
+/**
+ * Builds a value → first-index lookup over a categorical domain, so a scale converts in O(1)
+ * instead of rescanning the domain per datum. First index wins, matching `Array.prototype.indexOf`.
+ *
+ * @param domain - The categorical domain to index.
+ * @returns A function returning a value's index in the domain, or `-1` when it is absent.
+ */
+export function createDomainIndex<TDomain>(domain: TDomain[]): (value: TDomain) => number {
+    const index = new Map<TDomain, number>();
+
+    domain.forEach((value, position) => {
+        if (!index.has(value)) {
+            index.set(value, position);
+        }
+    });
+
+    // `indexOf` compares with `===`, which never matches `NaN`; the map would, so exclude it.
+    return value => (typeof value === 'number' && Number.isNaN(value) ? -1 : index.get(value) ?? -1);
+}
+
 /** Assembles a `Scale` object from explicit conversion, inversion, and tick functions. */
 export function createScale<TDomain = number, TRange = number>(options: ScaleBindingOptions<TDomain, TRange>): Scale<TDomain, TRange> {
     const {

--- a/packages/core/src/scales/band.ts
+++ b/packages/core/src/scales/band.ts
@@ -1,4 +1,5 @@
 import {
+    createDomainIndex,
     createScale,
 } from './_base';
 
@@ -50,11 +51,12 @@ export function scaleBand<TDomain = string>(
     const step = rangeLength / Math.max(1, domainLength + outerPadding * 2);
     const bandwidth = step * (1 - innerPadding);
     const adjustedMin = rangeMin + (rangeLength - step * domainLength) * alignment;
+    const indexOf = createDomainIndex(domain);
 
     const scale = createScale({
         domain,
         range,
-        convert: value => adjustedMin + (domain.indexOf(value) * step),
+        convert: value => adjustedMin + (indexOf(value) * step),
         invert: value => domain[Math.floor(value / step)],
     }) as BandScale<TDomain>;
 

--- a/packages/core/src/scales/discrete.ts
+++ b/packages/core/src/scales/discrete.ts
@@ -1,4 +1,5 @@
 import {
+    createDomainIndex,
     createScale,
 } from './_base';
 
@@ -19,11 +20,12 @@ export function scaleDiscrete<TDomain>(
     const rangeLength = rangeMax - rangeMin;
     const domainLength = domain.length - 1;
     const ratio = rangeLength / domainLength;
+    const indexOf = createDomainIndex(domain);
 
     return createScale({
         domain,
         range,
-        convert: value => rangeMin + (domain.indexOf(value) * ratio),
+        convert: value => rangeMin + (indexOf(value) * ratio),
         invert: value => domain[Math.floor(value / rangeLength)],
     });
 }

--- a/packages/core/test/context/context.test.ts
+++ b/packages/core/test/context/context.test.ts
@@ -1239,10 +1239,47 @@ describe('Context', () => {
         }
 
 
+        function paintFrame(ctx: ReturnType<typeof create>, elements: ReturnType<typeof createMockElement>[]) {
+            ctx.markRenderStart();
+
+            for (const element of elements) {
+                ctx.currentRenderElement = element;
+            }
+
+            ctx.markRenderEnd();
+        }
+
         function callHitTest(ctx: ReturnType<typeof create>, events: string[], x: number, y: number): any[] {
 
             return (ctx as any).hitTest(events, x, y);
         }
+
+        // The memo filters one frame's rendered elements, so it must not survive into the next frame.
+        test('hitTest should see an element that gained a listener after the memo was primed', () => {
+            const ctx = create();
+            const events = new Set<string>();
+
+            const element = {
+                id: 'late',
+                abstract: false,
+                pointerEvents: 'all' as const,
+                zIndex: 0,
+                has: vi.fn((event: string) => events.has(event)),
+                intersectsWith: vi.fn(() => true),
+                emit: vi.fn(),
+            };
+
+            paintFrame(ctx, [element]);
+
+            expect(callHitTest(ctx, ['click'], 0, 0)).toHaveLength(0);
+
+            events.add('click');
+            paintFrame(ctx, [element]);
+
+            expect(callHitTest(ctx, ['click'], 0, 0)).toHaveLength(1);
+
+            ctx.destroy();
+        });
 
         // Additive zIndex cannot compare descendants of different groups; paint order can.
         test('hitTest should return elements in reverse paint order, ignoring zIndex', () => {

--- a/packages/core/test/context/context.test.ts
+++ b/packages/core/test/context/context.test.ts
@@ -1281,6 +1281,27 @@ describe('Context', () => {
             ctx.destroy();
         });
 
+        // A hit test from an onComplete handler or a custom element's render runs mid-frame.
+        test('hitTest should not memoize the partial list a mid-frame hit test walks', () => {
+            const ctx = create();
+            const first = createMockElement('first', 0, ['click']);
+            const second = createMockElement('second', 0, ['click']);
+
+            paintFrame(ctx, [first, second]);
+
+            ctx.markRenderStart();
+            ctx.currentRenderElement = first;
+
+            expect(callHitTest(ctx, ['click'], 0, 0).map((el: { id: string }) => el.id)).toEqual(['first']);
+
+            ctx.currentRenderElement = second;
+            ctx.markRenderEnd();
+
+            expect(callHitTest(ctx, ['click'], 0, 0).map((el: { id: string }) => el.id)).toEqual(['second', 'first']);
+
+            ctx.destroy();
+        });
+
         // Additive zIndex cannot compare descendants of different groups; paint order can.
         test('hitTest should return elements in reverse paint order, ignoring zIndex', () => {
             const ctx = create();

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -37,6 +37,7 @@
     },
     "dependencies": {
         "@ripl/core": "workspace:^",
+        "@ripl/dom": "workspace:^",
         "@ripl/utilities": "workspace:^"
     }
 }

--- a/packages/devtools/src/highlight.ts
+++ b/packages/devtools/src/highlight.ts
@@ -3,6 +3,10 @@ import type {
     Element as RiplElement,
 } from '@ripl/core';
 
+import {
+    getSurfaceRect,
+} from '@ripl/dom';
+
 let overlay: HTMLDivElement | undefined;
 
 function getOverlay(): HTMLDivElement | undefined {
@@ -46,13 +50,17 @@ export function showHighlight(context: Context, element: RiplElement): void {
         return;
     }
 
-    const rect = context.element.getBoundingClientRect();
-    const scaleX = context.width > 0 ? rect.width / context.width : 1;
-    const scaleY = context.height > 0 ? rect.height / context.height : 1;
+    const {
+        left,
+        top,
+        scaleX,
+        scaleY,
+    } = getSurfaceRect(context);
+
     const box = element.getBoundingBox();
 
-    target.style.left = `${rect.left + box.left * scaleX}px`;
-    target.style.top = `${rect.top + box.top * scaleY}px`;
+    target.style.left = `${left + box.left * scaleX}px`;
+    target.style.top = `${top + box.top * scaleY}px`;
     target.style.width = `${box.width * scaleX}px`;
     target.style.height = `${box.height * scaleY}px`;
 }

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -6,6 +6,7 @@ import {
 
 import type {
     ContextOptions,
+    Point,
     RenderElement,
 } from '@ripl/core';
 
@@ -20,18 +21,24 @@ import {
     onDOMEvent,
 } from './dom';
 
+import {
+    createSurfaceOrigin,
+} from './surface';
+
 import type {
     DOMElementEventMap,
     DOMEventHandler,
 } from './dom';
+
+import type {
+    SurfaceOrigin,
+} from './surface';
 
 const INTERACTION_KEY = Symbol('interaction');
 const DRAG_EVENTS = ['dragstart', 'drag', 'dragend'];
 const PRESS_EVENTS = ['mousedown', ...DRAG_EVENTS];
 
 interface InteractionState {
-    left: number;
-    top: number;
     pointerButtons: Set<number>;
     dragElement: RenderElement | undefined;
     dragStartX: number;
@@ -54,7 +61,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     private _activeElements = new Set<RenderElement>();
     private _dragThreshold: number;
     private _interactionState?: InteractionState;
-    private _originDirty = true;
+    private _origin?: SurfaceOrigin;
 
     constructor(
         type: string,
@@ -92,10 +99,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         this.rescale(width, height);
 
-        this.retain(onDOMElementResize(this.root, ({ width, height }) => {
-            this._originDirty = true;
-            this.rescale(width, height);
-        }));
+        this.retain(onDOMElementResize(this.root, ({ width, height }) => this.rescale(width, height)));
 
         if (this._interactive) {
             this.enableInteraction();
@@ -104,29 +108,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
     private _attachInteractionEvent<TEvent extends keyof DOMElementEventMap<HTMLElement>>(event: TEvent, handler: DOMEventHandler<HTMLElement, TEvent>) {
         this.retain(onDOMEvent(this.element as unknown as HTMLElement, event, handler), INTERACTION_KEY);
-    }
-
-    /**
-     * Re-reads where the surface sits in the viewport, at most once per invalidation.
-     *
-     * Pointer coordinates are `clientX/Y` minus this origin, so a stale origin offsets every event.
-     * It goes stale two ways: the page scrolls or the layout shifts under a pointer that never
-     * leaves, and a surface mounted under a stationary pointer never fires the `mouseenter` that
-     * would first record it.
-     */
-    private _refreshOrigin(force?: boolean): void {
-        if (!this._originDirty && !force) {
-            return;
-        }
-
-        const state = this._interactionState!;
-
-        ({
-            left: state.left,
-            top: state.top,
-        } = this.element.getBoundingClientRect());
-
-        this._originDirty = false;
     }
 
     /**
@@ -144,7 +125,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     }
 
     private _handleMouseEnter(): void {
-        this._refreshOrigin(true);
         this.emit('mouseenter', null);
     }
 
@@ -153,10 +133,8 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this.emit('mouseleave', null);
     }
 
-    private _getLogicalPoint(event: MouseEvent): [number, number] {
-        const state = this._interactionState!;
-
-        return [event.clientX - state.left, event.clientY - state.top];
+    private _getLogicalPoint(event: MouseEvent): Point {
+        return this._origin!.toLogicalPoint(event);
     }
 
     private _hitTestLogical(events: string[], x: number, y: number): RenderElement[] {
@@ -164,8 +142,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     }
 
     private _handleMouseDown(event: MouseEvent): void {
-        this._refreshOrigin();
-
         const state = this._interactionState!;
         const [x, y] = this._getLogicalPoint(event);
 
@@ -190,8 +166,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     }
 
     private _handleMouseMove(event: MouseEvent): void {
-        this._refreshOrigin();
-
         const state = this._interactionState!;
         const [x, y] = this._getLogicalPoint(event);
 
@@ -297,8 +271,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             return;
         }
 
-        this._refreshOrigin();
-
         const [x, y] = this._getLogicalPoint(event);
 
         const payload = {
@@ -340,8 +312,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             return;
         }
 
-        this._refreshOrigin();
-
         const [x, y] = this._getLogicalPoint(event);
 
         const payload = {
@@ -362,9 +332,10 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         this._interactionEnabled = true;
 
+        this._origin = createSurfaceOrigin(this);
+        this.retain(this._origin, INTERACTION_KEY);
+
         this._interactionState = {
-            left: 0,
-            top: 0,
             pointerButtons: new Set(),
             dragElement: undefined,
             dragStartX: 0,
@@ -383,21 +354,10 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this._attachInteractionEvent('mouseup', event => this._handleMouseUp(event));
         this._attachInteractionEvent('click', event => this._handleClick(event));
 
+        // A release outside the surface never reaches the element, stranding the drag with no `dragend`.
         if (hasWindow) {
-            // Capture phase: a scroll event doesn't bubble, so an ancestor scroll container is only visible here.
-            this.retain(onDOMEvent(window, 'scroll', () => this._originDirty = true, {
-                capture: true,
-                passive: true,
-            }), INTERACTION_KEY);
-
-            this.retain(onDOMEvent(window, 'resize', () => this._originDirty = true), INTERACTION_KEY);
-
-            // A release outside the surface never reaches the element, stranding the drag with no `dragend`.
             this.retain(onDOMEvent(window, 'mouseup', event => this._handleMouseUp(event)), INTERACTION_KEY);
         }
-
-        // Seeded now rather than on the first `mouseenter`, which never fires for a surface mounted under the pointer.
-        this._refreshOrigin(true);
     }
 
     /** Disables DOM interaction events, unwinding any hover with a final `mouseleave` per element. */
@@ -412,6 +372,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this._flushActiveElements();
 
         this._interactionState = undefined;
+        this._origin = undefined;
         this.dispose(INTERACTION_KEY);
     }
 

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -2,4 +2,5 @@ export * from './dom';
 export * from './context';
 export * from './export';
 export * from './navigator';
+export * from './surface';
 export * from './vdom';

--- a/packages/dom/src/navigator.ts
+++ b/packages/dom/src/navigator.ts
@@ -16,10 +16,17 @@ import {
 } from '@ripl/utilities';
 
 import {
-    hasWindow,
     onDOMElementResize,
     onDOMEvent,
 } from './dom';
+
+import {
+    createSurfaceOrigin,
+} from './surface';
+
+import type {
+    SurfaceOrigin,
+} from './surface';
 
 /** Options for constructing a {@link DOMNavigator}, adding interaction wiring to the base options. */
 export interface DOMNavigatorOptions extends NavigatorOptions {
@@ -86,6 +93,7 @@ function resolveInteraction(option: NavigatorInteractionOption | undefined, fall
 export class DOMNavigator extends Navigator {
 
     private _element: HTMLElement;
+    private _origin?: SurfaceOrigin;
     private _previousTouchAction = '';
     private _previousCursor = '';
     private _panCursorEnabled = false;
@@ -95,9 +103,6 @@ export class DOMNavigator extends Navigator {
     private _brushing = false;
     private _panning = false;
     private _pinchDistance = 0;
-    private _originDirty = true;
-    private _originLeft = 0;
-    private _originTop = 0;
 
     constructor(context: Context, options?: DOMNavigatorOptions) {
         super(options);
@@ -110,62 +115,40 @@ export class DOMNavigator extends Navigator {
             return;
         }
 
+        this._origin = createSurfaceOrigin(context);
+        this.retain(this._origin, VIEWPORT_KEY);
+
         this._syncViewport();
 
         this.retain(onDOMElementResize(this._element, () => {
-            this._originDirty = true;
+            this._origin?.invalidate();
             this._syncViewport();
         }), VIEWPORT_KEY);
-
-        if (hasWindow) {
-            // Capture phase: a scroll event doesn't bubble, so an ancestor scroll container is only visible here.
-            this.retain(onDOMEvent(window, 'scroll', () => this._originDirty = true, {
-                capture: true,
-                passive: true,
-            }), VIEWPORT_KEY);
-
-            this.retain(onDOMEvent(window, 'resize', () => this._originDirty = true), VIEWPORT_KEY);
-        }
 
         if (options?.interactions) {
             this._attachInteractions(options.interactions);
         }
     }
 
+    /**
+     * The viewport is the surface's *logical* size, matching the space {@link DOMNavigator} reports
+     * gestures in — a CSS-scaled surface must not hand `centerOn`/`fitBounds` a different unit from
+     * the one its points arrive in.
+     */
     private _syncViewport(): void {
-        const rect = this._element.getBoundingClientRect();
+        const rect = this._origin!.rect;
 
         this.viewport = {
-            width: rect.width,
-            height: rect.height,
+            width: rect.width / rect.scaleX,
+            height: rect.height / rect.scaleY,
         };
-    }
-
-    /** Re-reads where the element sits in the viewport, at most once per invalidation. */
-    private _refreshOrigin(): void {
-        if (!this._originDirty) {
-            return;
-        }
-
-        ({
-            left: this._originLeft,
-            top: this._originTop,
-        } = this._element.getBoundingClientRect());
-
-        this._originDirty = false;
     }
 
     private _localPoint(event: {
         clientX: number;
         clientY: number;
     }): Point {
-        // A rect read per `pointermove` flushes layout mid-gesture, which is the frame budget gone.
-        this._refreshOrigin();
-
-        return [
-            event.clientX - this._originLeft,
-            event.clientY - this._originTop,
-        ];
+        return this._origin!.toLogicalPoint(event);
     }
 
     private _setCursor(cursor: string): void {

--- a/packages/dom/src/surface.ts
+++ b/packages/dom/src/surface.ts
@@ -116,25 +116,29 @@ export function getSurfaceRect(context: Context): SurfaceRect {
 }
 
 /**
- * Creates a {@link SurfaceOrigin} for a context: one shared origin cache and point mapping for
- * every DOM consumer that turns pointer events into scene coordinates.
+ * Creates a {@link SurfaceOrigin} for a context: the one origin cache and point mapping every DOM
+ * consumer turning pointer events into scene coordinates should go through. Each call owns its own
+ * cache and listeners, so a consumer holds one for as long as it handles pointer events and
+ * disposes it with the rest of its wiring.
  *
  * A `getBoundingClientRect()` per `pointermove` flushes layout mid-gesture, which is the frame
- * budget gone, so the measurement is cached and re-taken only when a page scroll or a window
- * resize can have moved the surface — plus whenever a caller invalidates it explicitly.
+ * budget gone, so the measurement is cached and re-taken only when a page scroll, a window resize,
+ * a context resize or the pointer entering the surface can have moved it — plus whenever a caller
+ * invalidates it explicitly.
  *
  * Points cross into logical space (the space public pointer payloads and element geometry use),
  * never surface space: a caller that needs surface coordinates — `Context.hitTest` and
  * `Element.intersectsWith` take them — maps on through {@link Context.toSurfacePoint}.
  *
  * @param context - The context whose surface is tracked.
- * @returns The origin tracker; dispose it to detach the scroll and resize listeners.
+ * @returns The origin tracker; dispose it to detach the scroll, resize and pointer listeners.
  * @example
  * const origin = createSurfaceOrigin(context);
  * element.addEventListener('pointermove', event => console.log(origin.toLogicalPoint(event)));
  */
 export function createSurfaceOrigin(context: Context): SurfaceOrigin {
     const disposables: Disposable[] = [];
+    const element = context.element as unknown;
 
     let rect: SurfaceRect | undefined;
 
@@ -153,6 +157,12 @@ export function createSurfaceOrigin(context: Context): SurfaceOrigin {
     // A container resize moves and rescales the surface without the window ever resizing.
     if (typeIsFunction(context.on)) {
         disposables.push(context.on('resize', invalidate));
+    }
+
+    // A layout shift elsewhere on the page translates the surface with nothing else firing; the pointer arriving is the last cue before it is used.
+    if (isMeasurable(element) && typeIsFunction(element.addEventListener)) {
+        disposables.push(onDOMEvent(element, 'pointerenter', invalidate));
+        disposables.push(onDOMEvent(element, 'mouseenter', invalidate));
     }
 
     const origin: SurfaceOrigin = {

--- a/packages/dom/src/surface.ts
+++ b/packages/dom/src/surface.ts
@@ -1,0 +1,186 @@
+import {
+    hasWindow,
+    onDOMEvent,
+} from './dom';
+
+import type {
+    Context,
+    Point,
+} from '@ripl/core';
+
+import {
+    typeIsFunction,
+} from '@ripl/utilities';
+
+import type {
+    Disposable,
+} from '@ripl/utilities';
+
+/**
+ * Where a context's surface sits on the page, and how big it is drawn relative to the logical
+ * size the context reports.
+ *
+ * `scaleX`/`scaleY` are on-screen CSS pixels per logical pixel: `1` for an untransformed surface,
+ * and something else when a CSS transform (or an intrinsic-size mismatch) scales it. They are the
+ * factor a client coordinate has to be divided by to land in the logical space element geometry is
+ * authored in — the space {@link Context.toSurfacePoint} maps *out of*, not into.
+ */
+export interface SurfaceRect {
+    /** Distance from the viewport's left edge to the surface's left edge, in CSS pixels. */
+    left: number;
+    /** Distance from the viewport's top edge to the surface's top edge, in CSS pixels. */
+    top: number;
+    /** On-screen width of the surface, in CSS pixels. */
+    width: number;
+    /** On-screen height of the surface, in CSS pixels. */
+    height: number;
+    /** On-screen CSS pixels per logical pixel horizontally. */
+    scaleX: number;
+    /** On-screen CSS pixels per logical pixel vertically. */
+    scaleY: number;
+}
+
+/** Anything carrying `clientX`/`clientY` — every pointer, mouse, and wheel event. */
+export interface ClientPoint {
+    /** The event's X coordinate relative to the viewport, in CSS pixels. */
+    clientX: number;
+    /** The event's Y coordinate relative to the viewport, in CSS pixels. */
+    clientY: number;
+}
+
+/**
+ * Tracks a context surface's position and on-screen scale, re-measuring only when something that
+ * can move it fires, and maps points across the boundary between the page and the scene.
+ */
+export interface SurfaceOrigin extends Disposable {
+    /** The surface's current position and scale, re-measured on first read after an invalidation. */
+    readonly rect: SurfaceRect;
+    /** Marks the cached measurement stale, so the next read re-measures. */
+    invalidate(): void;
+    /** Maps a viewport (`clientX`/`clientY`) point into the logical space elements are authored in. */
+    toLogicalPoint(event: ClientPoint): Point;
+    /** Maps a logical point back to viewport coordinates, the inverse of {@link SurfaceOrigin.toLogicalPoint}. */
+    toClientPoint(x: number, y: number): Point;
+}
+
+const IDENTITY_RECT: SurfaceRect = {
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+    scaleX: 1,
+    scaleY: 1,
+};
+
+/** An unsized surface would divide the point by zero, so fall back to an unscaled mapping. */
+function resolveScale(onScreen: number, logical: number): number {
+    return onScreen > 0 && logical > 0
+        ? onScreen / logical
+        : 1;
+}
+
+function isMeasurable(element: unknown): element is HTMLElement {
+    return !!element && typeof (element as HTMLElement).getBoundingClientRect === 'function';
+}
+
+/**
+ * Measures where a context's surface sits on the page and how big it is drawn relative to the
+ * logical size the context reports. Returns an identity rect for a non-DOM context (the terminal
+ * context carries a dummy element), so callers never have to feature-detect.
+ *
+ * @param context - The context whose surface is measured.
+ * @returns The surface's viewport position and on-screen scale.
+ */
+export function getSurfaceRect(context: Context): SurfaceRect {
+    const element = context.element as unknown;
+
+    if (!isMeasurable(element)) {
+        return { ...IDENTITY_RECT };
+    }
+
+    const {
+        left,
+        top,
+        width,
+        height,
+    } = element.getBoundingClientRect();
+
+    return {
+        left,
+        top,
+        width,
+        height,
+        scaleX: resolveScale(width, context.width),
+        scaleY: resolveScale(height, context.height),
+    };
+}
+
+/**
+ * Creates a {@link SurfaceOrigin} for a context: one shared origin cache and point mapping for
+ * every DOM consumer that turns pointer events into scene coordinates.
+ *
+ * A `getBoundingClientRect()` per `pointermove` flushes layout mid-gesture, which is the frame
+ * budget gone, so the measurement is cached and re-taken only when a page scroll or a window
+ * resize can have moved the surface — plus whenever a caller invalidates it explicitly.
+ *
+ * Points cross into logical space (the space public pointer payloads and element geometry use),
+ * never surface space: a caller that needs surface coordinates — `Context.hitTest` and
+ * `Element.intersectsWith` take them — maps on through {@link Context.toSurfacePoint}.
+ *
+ * @param context - The context whose surface is tracked.
+ * @returns The origin tracker; dispose it to detach the scroll and resize listeners.
+ * @example
+ * const origin = createSurfaceOrigin(context);
+ * element.addEventListener('pointermove', event => console.log(origin.toLogicalPoint(event)));
+ */
+export function createSurfaceOrigin(context: Context): SurfaceOrigin {
+    const disposables: Disposable[] = [];
+
+    let rect: SurfaceRect | undefined;
+
+    const invalidate = () => rect = undefined;
+
+    if (hasWindow) {
+        // Capture phase: a scroll event doesn't bubble, so an ancestor scroll container is only visible here.
+        disposables.push(onDOMEvent(window, 'scroll', invalidate, {
+            capture: true,
+            passive: true,
+        }));
+
+        disposables.push(onDOMEvent(window, 'resize', invalidate));
+    }
+
+    // A container resize moves and rescales the surface without the window ever resizing.
+    if (typeIsFunction(context.on)) {
+        disposables.push(context.on('resize', invalidate));
+    }
+
+    const origin: SurfaceOrigin = {
+        invalidate,
+        get rect() {
+            return rect ??= getSurfaceRect(context);
+        },
+        toLogicalPoint(event) {
+            const current = origin.rect;
+
+            return [
+                (event.clientX - current.left) / current.scaleX,
+                (event.clientY - current.top) / current.scaleY,
+            ];
+        },
+        toClientPoint(x, y) {
+            const current = origin.rect;
+
+            return [
+                current.left + x * current.scaleX,
+                current.top + y * current.scaleY,
+            ];
+        },
+        dispose() {
+            disposables.forEach(disposable => disposable.dispose());
+            disposables.length = 0;
+        },
+    };
+
+    return origin;
+}

--- a/packages/dom/src/vdom.ts
+++ b/packages/dom/src/vdom.ts
@@ -32,6 +32,9 @@ export interface ReconcilerOptions<TElement = unknown> {
     getChildId?: (domNode: Element) => string | null;
 }
 
+/** Shared read-only stand-in for the common case of a reconciler with no exclusion selectors. */
+const EMPTY_EXCLUSIONS: ReadonlySet<Element> = new Set();
+
 function defaultGetChildId(domNode: Element): string | null {
     return domNode.getAttribute('id');
 }
@@ -100,6 +103,21 @@ function isExcluded(element: Element, selectors: string[]): boolean {
     return false;
 }
 
+/** The DOM children this pass must leave alone, resolved once so the insert loop never re-queries the live DOM. */
+function collectExcluded(domParent: Element, selectors: string[]): Set<Element> {
+    const excluded = new Set<Element>();
+
+    for (let i = 0; i < domParent.children.length; i++) {
+        const child = domParent.children[i];
+
+        if (isExcluded(child, selectors)) {
+            excluded.add(child);
+        }
+    }
+
+    return excluded;
+}
+
 function countChildIds<TElement>(children: VNode<TElement>[]): Map<string, number> {
     const counts = new Map<string, number>();
 
@@ -126,6 +144,10 @@ function reconcileChildren<TElement = unknown>(
         getChildId = defaultGetChildId,
     } = options;
 
+    const excluded = excludeSelectors.length > 0
+        ? collectExcluded(domParent, excludeSelectors)
+        : EMPTY_EXCLUSIONS;
+
     // Counted, not a set: siblings may share an id, and each occurrence still needs its own node.
     const wantedIds = countChildIds(vnode.children);
     const existingChildren = new Map<string, Element[]>();
@@ -133,7 +155,7 @@ function reconcileChildren<TElement = unknown>(
     for (let i = domParent.children.length - 1; i >= 0; i--) {
         const child = domParent.children[i];
 
-        if (excludeSelectors.length > 0 && isExcluded(child, excludeSelectors)) {
+        if (excluded.has(child)) {
             continue;
         }
 
@@ -189,7 +211,7 @@ function reconcileChildren<TElement = unknown>(
         }
 
         // Excluded nodes hold an index without being managed, so step over them rather than displace them.
-        while (excludeSelectors.length > 0 && domIndex < domParent.children.length && isExcluded(domParent.children[domIndex], excludeSelectors)) {
+        while (domIndex < domParent.children.length && excluded.has(domParent.children[domIndex])) {
             domIndex++;
         }
 

--- a/packages/dom/test/context.test.ts
+++ b/packages/dom/test/context.test.ts
@@ -168,6 +168,20 @@ describe('DOMContext interaction origin', () => {
         });
     });
 
+    // A CSS-scaled surface draws its logical pixels across more client pixels; the navigators already divide by that scale.
+    test('Should map pointer coordinates through the surface scale', () => {
+        setOrigin(0, 0);
+
+        const context = create();
+
+        context['rescale'](SURFACE_WIDTH / 2, SURFACE_HEIGHT / 2);
+
+        expect(mouseMove(context, 300, 150)).toEqual({
+            x: 150,
+            y: 75,
+        });
+    });
+
     // One rect read per invalidation, not per event: this is the hover hot path.
     test('Should not re-measure the surface on every pointer move', () => {
         setOrigin(120, 80);

--- a/packages/dom/test/navigator.test.ts
+++ b/packages/dom/test/navigator.test.ts
@@ -25,6 +25,15 @@ function fakeContext(): Context {
     } as unknown as Context;
 }
 
+/** A context whose logical size differs from the element's on-screen size, as a CSS transform makes it. */
+function scaledContext(width: number, height: number): Context {
+    return {
+        element,
+        width,
+        height,
+    } as unknown as Context;
+}
+
 /** A non-DOM context, mirroring how the terminal context carries a dummy `{}` element. */
 function fakeNonDOMContext(): Context {
     return {
@@ -402,6 +411,48 @@ describe('DOMNavigator interactions', () => {
         });
 
         expect(getBoundingClientRect).toHaveBeenCalledOnce();
+
+        navigator.destroy();
+    });
+
+    // A CSS-scaled surface draws N logical pixels across more (or fewer) client pixels.
+    test('Should map gestures through the surface scale, not raw client pixels', () => {
+        vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+            left: 0,
+            top: 0,
+            width: 400,
+            height: 200,
+            right: 400,
+            bottom: 200,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        } as DOMRect);
+
+        const navigator = createNavigator(scaledContext(200, 100), {
+            interactions: {
+                pan: true,
+            },
+        });
+
+        expect(navigator.viewport).toEqual({
+            width: 200,
+            height: 100,
+        });
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 100,
+            clientY: 100,
+        });
+        fire('pointermove', {
+            pointerId: 1,
+            clientX: 160,
+            clientY: 80,
+        });
+
+        expect(navigator.transform.x).toBe(30);
+        expect(navigator.transform.y).toBe(-10);
 
         navigator.destroy();
     });

--- a/packages/dom/test/surface.test.ts
+++ b/packages/dom/test/surface.test.ts
@@ -1,0 +1,180 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    createSurfaceOrigin,
+    getSurfaceRect,
+} from '../src';
+
+import type {
+    Context,
+} from '@ripl/core';
+
+let element: HTMLDivElement;
+
+/** A stand-in context exposing the element the origin measures and the logical size it reports. */
+function fakeContext(width = 400, height = 200): Context {
+    return {
+        element,
+        width,
+        height,
+    } as unknown as Context;
+}
+
+function setRect(left: number, top: number, width = 400, height = 200): void {
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+        left,
+        top,
+        width,
+        height,
+        right: left + width,
+        bottom: top + height,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    setRect(0, 0);
+});
+
+afterEach(() => {
+    element.remove();
+    vi.restoreAllMocks();
+});
+
+describe('getSurfaceRect', () => {
+
+    test('Should report the scale between the on-screen and logical size', () => {
+        setRect(10, 20);
+
+        expect(getSurfaceRect(fakeContext(200, 100))).toEqual({
+            left: 10,
+            top: 20,
+            width: 400,
+            height: 200,
+            scaleX: 2,
+            scaleY: 2,
+        });
+    });
+
+    test('Should return an identity rect for a non-DOM context', () => {
+        expect(getSurfaceRect({ element: {} } as unknown as Context)).toEqual({
+            left: 0,
+            top: 0,
+            width: 0,
+            height: 0,
+            scaleX: 1,
+            scaleY: 1,
+        });
+    });
+
+});
+
+describe('createSurfaceOrigin', () => {
+
+    test('Should measure the surface once per invalidation', () => {
+        const origin = createSurfaceOrigin(fakeContext());
+        const measure = vi.spyOn(element, 'getBoundingClientRect').mockClear();
+
+        origin.toLogicalPoint({
+            clientX: 0,
+            clientY: 0,
+        });
+        origin.toLogicalPoint({
+            clientX: 1,
+            clientY: 1,
+        });
+
+        expect(measure).toHaveBeenCalledTimes(1);
+
+        origin.dispose();
+    });
+
+    // A banner dismissed above the chart translates the surface with no scroll and no resize.
+    test('Should re-measure when the pointer enters after a layout translation', () => {
+        const origin = createSurfaceOrigin(fakeContext());
+
+        expect(origin.toLogicalPoint({
+            clientX: 100,
+            clientY: 50,
+        })).toEqual([100, 50]);
+
+        setRect(0, 200);
+        element.dispatchEvent(new MouseEvent('pointerenter'));
+
+        expect(origin.toLogicalPoint({
+            clientX: 100,
+            clientY: 250,
+        })).toEqual([100, 50]);
+
+        origin.dispose();
+    });
+
+    test('Should re-measure on a mouseenter, which is all a mouse-only surface reports', () => {
+        const origin = createSurfaceOrigin(fakeContext());
+
+        origin.toLogicalPoint({
+            clientX: 0,
+            clientY: 0,
+        });
+
+        setRect(60, 0);
+        element.dispatchEvent(new MouseEvent('mouseenter'));
+
+        expect(origin.toLogicalPoint({
+            clientX: 100,
+            clientY: 50,
+        })).toEqual([40, 50]);
+
+        origin.dispose();
+    });
+
+    test('Should stop re-measuring once disposed', () => {
+        const origin = createSurfaceOrigin(fakeContext());
+
+        origin.toLogicalPoint({
+            clientX: 0,
+            clientY: 0,
+        });
+        origin.dispose();
+
+        // `spyOn` returns the already-installed spy, so drop the setup calls it recorded.
+        const measure = vi.spyOn(element, 'getBoundingClientRect').mockClear();
+
+        element.dispatchEvent(new MouseEvent('pointerenter'));
+        window.dispatchEvent(new Event('scroll'));
+
+        origin.toLogicalPoint({
+            clientX: 0,
+            clientY: 0,
+        });
+
+        expect(measure).not.toHaveBeenCalled();
+    });
+
+    test('Should round-trip a point through a scaled surface', () => {
+        setRect(10, 20);
+
+        const origin = createSurfaceOrigin(fakeContext(200, 100));
+
+        expect(origin.toLogicalPoint({
+            clientX: 310,
+            clientY: 170,
+        })).toEqual([150, 75]);
+
+        expect(origin.toClientPoint(150, 75)).toEqual([310, 170]);
+
+        origin.dispose();
+    });
+
+});

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -836,6 +836,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         this._shadowCache.clear();
         this._usedDefs.clear();
         this._inverseCTMCache.clear();
+        this._gradientBounds = undefined;
 
         this._vtree = {
             id: '__root__',

--- a/packages/svg/src/context.ts
+++ b/packages/svg/src/context.ts
@@ -71,6 +71,8 @@ import type {
     ContextOptions,
     ContextText,
     FillRule,
+    GradientBounds,
+    RenderElement,
     Element as RiplElement,
     TextOptions,
 } from '@ripl/core';
@@ -111,6 +113,10 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
     private _currentParentVNode: SVGVNode;
     private _vnodeStack: SVGVNode[];
     private _inverseCTMCache: Map<Element, DOMMatrix | null>;
+    private _gradientBounds?: {
+        element: RenderElement;
+        bounds: GradientBounds;
+    };
 
     constructor(target: string | HTMLElement, options?: ContextOptions) {
         const svg = createSVGElement('svg');
@@ -195,6 +201,30 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
         return `url(#${patternId})`;
     }
 
+    /**
+     * The box a gradient on the current render element resolves against, memoized for the element's
+     * paint so a fill and a stroke sharing it resolve one box — which for a group means one subtree
+     * walk per frame rather than one per paint, since group boxes are never cached.
+     */
+    private _resolveGradientBounds(): GradientBounds {
+        const element = this.currentRenderElement;
+        const cached = this._gradientBounds;
+
+        if (cached && cached.element === element) {
+            return cached.bounds;
+        }
+
+        // The element's own box, not the path node's, so a multi-path element ramps once across all of them.
+        const bounds = getGradientBounds(element?.getBoundingBox?.(true), this.width, this.height);
+
+        this._gradientBounds = element && {
+            element,
+            bounds,
+        };
+
+        return bounds;
+    }
+
     private _resolveGradientStyle(value: string, cacheKey: string): string {
         if (isPatternString(value)) {
             return this._resolvePatternStyle(value, cacheKey);
@@ -217,8 +247,7 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
 
         this._usedDefs.add(`gradient:${cacheKey}`);
 
-        // The element's own box, not the path node's, so a multi-path element ramps once across all of them.
-        const bounds = getGradientBounds(this.currentRenderElement?.getBoundingBox?.(true), this.width, this.height);
+        const bounds = this._resolveGradientBounds();
         const cached = this._gradientCache.get(cacheKey);
 
         if (cached) {
@@ -449,6 +478,9 @@ export class SVGContext extends DOMContext<SVGSVGElement> {
             this._currentParentVNode = this._vtree;
             this._vnodeStack = [];
             this._usedDefs.clear();
+
+            // Boxes move between frames, so the memo must not outlive the pass that measured them.
+            this._gradientBounds = undefined;
         }
 
         super.markRenderStart();

--- a/packages/svg/test/audit.test.ts
+++ b/packages/svg/test/audit.test.ts
@@ -43,6 +43,7 @@ interface ContextInternals {
     _clipCache: Map<string, unknown>;
     _shadowCache: Map<string, unknown>;
     _currentTransforms: string[];
+    _gradientBounds?: unknown;
 }
 
 const GROUP_GRADIENT = 'linear-gradient(90deg, rgb(255, 0, 0), rgb(0, 0, 255))';
@@ -554,6 +555,36 @@ describe('SVG audit findings', () => {
             expect(internals._textPathCache.size).toBe(0);
             expect(internals._clipCache.size).toBe(0);
             expect(internals._shadowCache.size).toBe(0);
+        });
+
+        // The memo holds a strong element reference, so a destroyed context would pin the last thing it painted.
+        test('Should drop the gradient bounds memo on destroy', () => {
+            sizeHost(400, 300);
+
+            const ctx = create();
+            const rect = createRect({
+                id: 'gradient-rect',
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+            });
+
+            renderPass(ctx, () => {
+                ctx.currentRenderElement = rect;
+                ctx.fill = GROUP_GRADIENT;
+
+                const path = ctx.createPath('shape');
+
+                path.rect(0, 0, 10, 10);
+                ctx.applyFill(path);
+            });
+
+            expect(getInternals(ctx)._gradientBounds).toBeDefined();
+
+            ctx.destroy();
+
+            expect(getInternals(ctx)._gradientBounds).toBeUndefined();
         });
 
         test('Should drop the transform and clip scopes on reset', () => {

--- a/packages/webgpu/src/context.ts
+++ b/packages/webgpu/src/context.ts
@@ -20,11 +20,6 @@ import type {
     MeshSubmission,
 } from '@ripl/3d';
 
-import {
-    factory,
-    scaleContinuous,
-} from '@ripl/core';
-
 import type {
     ContextPath,
     ContextText,
@@ -35,6 +30,7 @@ import type {
 import {
     canvasMeasureText,
     CanvasPath,
+    rescaleCanvas,
 } from '@ripl/canvas';
 
 import {
@@ -131,28 +127,26 @@ export class WebGPUContext3D extends Context3D {
             return;
         }
 
-        // Through the factory, like every other backend: `window` desynchronises the hit canvas from the surface scales and is absent outside the DOM.
-        const dpr = factory.devicePixelRatio;
-        const scaledWidth = Math.floor(width * dpr);
-        const scaledHeight = Math.floor(height * dpr);
-
         // Gated on the logical size, never the backing store: a fresh canvas is already 300x150.
         if (width === this.width && height === this.height) {
             return;
         }
 
+        // The hit canvas is a plain 2D surface, so the canvas backend owns its DPR sizing and transform.
+        const {
+            scaleX,
+            scaleY,
+            scaledWidth,
+            scaledHeight,
+        } = rescaleCanvas(this._hitCanvas, this._hitContext, width, height);
+
         this.element.width = scaledWidth;
         this.element.height = scaledHeight;
 
-        // Resize hit canvas to match
-        this._hitCanvas.width = scaledWidth;
-        this._hitCanvas.height = scaledHeight;
-        this._hitContext.setTransform(dpr, 0, 0, dpr, 0, 0);
-
         super.rescale(width, height);
 
-        this.scaleX = scaleContinuous([0, width], [0, scaledWidth]);
-        this.scaleY = scaleContinuous([0, height], [0, scaledHeight]);
+        this.scaleX = scaleX;
+        this.scaleY = scaleY;
 
         this._recreateDepthTexture(scaledWidth, scaledHeight);
         this._recreateMSAATexture(scaledWidth, scaledHeight);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,6 +2010,7 @@ __metadata:
   resolution: "@ripl/devtools@workspace:packages/devtools"
   dependencies:
     "@ripl/core": "workspace:^"
+    "@ripl/dom": "workspace:^"
     "@ripl/utilities": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Previously stacked on #79; that has merged, so this now targets `main` directly and its diff is only the hot-path commits.

An audit of the render loop, hit-testing path and scale conversion found work being redone every frame — or every pointer move — that could be derived once, memoized, or indexed.

- `Scene` kept `_buffer` as a second store hand-derived from `_instructions` with a `.filter().map()` pair, i.e. two intermediate arrays per graph rebuild.
- `Renderer` held every transition twice — in `_transitionMap` and again in a per-call scope map, under the same symbol keys — kept in sync by hand in both the completion and abort paths.
- `Context.hitTest` allocated `new Map(this.renderedElements.map(...))` to recover paint order on **every hit test with two or more hits**, i.e. potentially once per pointer move, plus a `flatMap` array, a `filter` array and an `arrayDedupe` Set→Array round trip.
- `SVGContext` resolved a gradient-carrying element's bounding box separately for fill and for stroke, every frame. For a **group**, whose box is not cacheable, that meant unioning the whole subtree twice per frame.
- The vdom reconciler called `element.matches(selector)` per DOM child **twice** — once in the removal pass and again in the insert-position walk.
- `scaleBand` and `scaleDiscrete` called `domain.indexOf(value)` on every conversion: O(n) per datum, O(n²) per series.
- Four packages had grown their own surface↔screen mapping, and one of them — `DOMNavigator` — applied no scale at all.

## What changed

`Scene._buffer` is now a lazily materialized projection of `_instructions`, dropped on rebuild. The renderer's per-call scope is a flat array with a single idempotent removal path. `hitTest` collects in one pass with a `Set` for dedupe, and paint order is a memo invalidated when `renderedElements` changes rather than rebuilt per call. The gradient box is memoized per render element for the duration of its paint. vdom exclusions resolve once per parent into a `Set` both passes read. Band and discrete scales build a value→first-index `Map` once.

The scale change is the one with a measured number, on a standalone Node benchmark of build + full-series conversion:

| domain | `indexOf` scan | keyed lookup | speedup |
|---|---|---|---|
| 100 | 56.5 ms | 31.0 ms | 1.8× |
| 500 | 219.3 ms | 23.3 ms | 9.4× |
| 2000 | 717.8 ms | 37.9 ms | **18.9×** |

The others are allocation and algorithmic removals verified by reading the code. **They were not benchmarked and no number is claimed for them.**

A new `packages/dom/src/surface.ts` gives one origin-tracking/point-mapping helper, adopted by `DOMContext`, `DOMNavigator`, `ChartNavigator` and devtools' `showHighlight`; webgpu now delegates its hit canvas to canvas's `rescaleCanvas`.

## Two things deliberately not done

**`getBoundingBox`'s defensive copy on a cache hit stays.** `packages/core/test/core/bounds-cache.test.ts` has a test named *"Should not corrupt the cache when a returned box is mutated"* — that is an intended contract, not incidental behaviour, and `Box`'s fields are public and mutable. Returning the cached instance makes that test fail. No production caller mutates a returned box today, but handing out the cache would turn any consumer's `box.left -= padding` into silent corruption of every later read. The prerequisite is an immutable `Box`; the ownership contract is documented in the JSDoc meanwhile.

**`Group.render`'s z-sort stays.** It is a second, independent implementation of the ordering `Scene._collectInstructions` performs, and it is genuinely unreachable from the paint path — `Scene.render` and `Renderer._renderBuffer` both call `element.render` only on `draw` instructions, and groups only ever emit `push`/`pop`. So it costs zero frames. But it is documented public API with direct coverage, and the freeform-drawing export demo relies on it to render outside a scene. Deleting it would break a documented contract for no runtime saving.

## Behaviour changes (all fixes)

- **Navigators now divide by the surface scale.** `DOMNavigator` previously applied none, so pan/zoom was wrong on any CSS-scaled surface.
- **`DOMContext` now maps through the same helper.** Per the Coordinate Spaces doctrine, element geometry is authored in the space the context reports as `width`/`height`, and `contentRect` is transform-independent while `getBoundingClientRect` is not. On a 200×100 logical context whose element measures 400×200, `_getLogicalPoint` returned `[300, 150]` where the correct answer is `[150, 75]`.
- **webgpu's `scaleX`/`scaleY` now describe the exact DPR transform** its hit canvas installs rather than the floored backing store. At DPR 1.5 and width 101 the old scale mapped `x → x·151/101` while the canvas was under `setTransform(1.5, …)`.
- **An element removed between frames no longer lingers in hit results** — a side-effect of fixing the tracked-element memo's staleness.

## Review findings, fixed in this branch

- **The lockfile was stale and would have failed every CI job.** `packages/devtools/package.json` gained `@ripl/dom` but `yarn.lock` was not regenerated, and CI runs `yarn install --immutable`, which hard-errors under Yarn 4 when the lockfile would change. Nothing local could catch this — the sandbox shares one install, so nothing ever re-resolves the graph. Regenerated with `--mode=update-lockfile`; the diff is one line.
- **The tracked-element memo could be primed mid-frame.** Invalidating at `markRenderStart` cleared it *before* anything painted, so a hit test issued during an open render pass cached a partial `renderedElements` and served that truncated list for the rest of the frame — reachable because the renderer wraps painting in `context.batch` and user `onComplete` handlers run inside it. Invalidation moved to `markRenderEnd`, and a mid-frame read now bypasses the memo entirely.
- **`ChartNavigator`'s origin could go stale on a pure layout translation.** It previously measured on every pointer event; the cache is invalidated only by scroll, window resize and context resize. Dismiss a banner above a chart — the surface translates, nothing fires — and dragging the strip jumped by the translation amount indefinitely. `createSurfaceOrigin` now re-measures on pointer enter, mirroring what `DOMContext` already did.
- **`SVGContext.destroy()` leaked the new gradient-bounds memo**, which holds a strong `RenderElement` reference while every sibling cache was cleared.
- Documentation corrected in three places, including `EFFICIENCY_REPORT.md`, which claimed four independent surface mappings when `DOMContext` made five.

On the memo-invalidation cost, the reviewer suspected the hover path might now pay ~4×O(n) per animated frame. Measured instead of assumed: **+20% at 2,000 elements (131 µs → 158 µs per frame) and +48% at 10,000 (987 µs → 1,459 µs)**. It is not 4×, because the parent rebuilt the paint-order `Map` on *every* hit test rather than amortising it. Recovering the remainder needs change-detection over the previous frame's list; judged not worth the retention.

## Verification

- `yarn test` — 194 files, **2449 passed, 2 skipped, 1 todo**. The 2 skips are the pre-existing `conformance.test.ts` jsdom cases.
- `tsc` clean; `eslint .` clean; TypeDoc `notDocumented` clean for core, dom, svg, charts and devtools.
- **Zero visual difference.** The committed `__snapshots__` baselines were rendered on a different Chromium and fail on `main` here by 3–13% of pixels, so comparing against them proves nothing. Instead the chart gallery was rendered from `origin/main` and from this branch in the same environment and byte-compared: `identical=26 changed=0 missing=0`. That result was independently reproduced during review. For a refactor that is supposed to change nothing, that is the whole safety argument.
- Every regression test was confirmed to fail without its fix.

## Known constraint

Both new memos key off `renderedElements`, which is a public mutable array. A caller splicing it directly bypasses all three invalidation points and would see stale paint order — the previous per-call `Map` was immune. No in-repo code does this. The real fix is to make the field a getter over a private array, which is an API change for a later PR; recorded in `EFFICIENCY_REPORT.md`.

## Deferred (recorded in `EFFICIENCY_REPORT.md`)

The SVG `_vtree` full per-frame rebuild (architectural; needs a benchmark harness first), `Group.children`'s `Array.from` per access (already deliberately deferred there), `Context.save()`'s ~28-key state spread plus the full `CONTEXT_OPERATIONS` walk per element per frame (dirty-key tracking is a design project), and `evictDetachedNodes`' O(cache × depth).