### PR TITLE
Build a 3D shape's hit path on demand instead of on every frame

### DIFF
--- a/docs/migrations/context-audit.md
+++ b/docs/migrations/context-audit.md
@@ -834,6 +834,18 @@ not a preference: `new WebGPUContext3D(…, { meta: { renderStrategy: 'cpu' } })
 shape into the CPU painter, which that class neither draws nor clears — a blank canvas plus a face
 buffer growing without bound. A `meta.renderStrategy` supplied by a caller is now ignored.
 
+### Performance
+
+**`Shape3D`'s hit path** — **behaviour**. Built on demand the first time `intersectsWith` needs it,
+instead of traced face by face on every render. `_renderCPU` and `_renderGPU` called
+`context.createPath` and then one `moveTo`, N-1 `lineTo` and one `closePath` per face, every frame,
+whether or not anything ever hit-tested the shape: on a 9 000-face mesh that is a fresh `Path2D`
+and ~45 000 native calls per frame, thrown away unread. The projection loop is unchanged — it is
+still what produces `_depth`, and so `zIndex` — and now writes the projected screen-space points
+into a `Float32Array` reused across frames. `intersectsWith` answers identically, `pointerEvents`
+semantics and the never-rendered bounding-box fallback included; the path is a pure function of the
+projected points, so no output changes.
+
 ### Known gaps (decided, not fixed)
 
 **No back-face culling on the CPU path.** Every face of a closed shape is transformed, shaded,

--- a/packages/3d/src/core/shape.ts
+++ b/packages/3d/src/core/shape.ts
@@ -163,6 +163,14 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
 
     private _depth = 0;
     private _getCachedFaces: CachedFunction<() => Face3D[]>;
+    private _hitFaceCount = 0;
+    private _hitFaceOffsets = new Uint32Array(0);
+
+    // Reused across frames and overwritten in place, so a frame no one hit-tests allocates nothing.
+    private _hitPoints = new Float32Array(0);
+
+    // Not `_hitFaceCount > 0`: a rendered shape with no faces hit-tests as an empty path, not a box.
+    private _hasHitGeometry = false;
 
     /** The X position of the shape's origin in world space. */
     public get x() {
@@ -348,7 +356,9 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
             const baseRGBA = parseColor(baseFillStyle);
             const matrix = this.getModelMatrix();
 
+            // The projection moves every frame, so any built path is dropped and rebuilt on demand.
             this.hitPath = undefined;
+            this._hasHitGeometry = false;
 
             if (context.renderStrategy !== 'gpu') {
                 return this._renderCPU(context, faces, baseRGBA, baseFillStyle, matrix);
@@ -370,13 +380,16 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
     // any shape that is not a closed, consistently wound solid. The cost is that every face of a
     // closed shape is filled, and with `fill` alpha below 1 the hidden ones bleed through.
     private _renderCPU(context: Context3D, faces: Face3D[], baseRGBA: ColorRGBA | undefined, baseFillStyle: string, matrix: Matrix4): void {
-        const hitPath = context.createPath(`${this.id}:hit`);
         const normalizedLight = vec3Normalize(context.getLightDirectionForRender());
 
         // One capture per shape: the flush groups faces by state identity, so sharing it is load-bearing.
         const state = context.captureFaceState(this.getWorldTransform());
 
+        this._resetHitGeometry(faces);
+
         let nearestDepth = Infinity;
+        let hitCursor = 0;
+        let hitFace = 0;
 
         for (const face of faces) {
             const transformed = this.transformVertices(face.vertices, matrix);
@@ -399,17 +412,20 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
                 state,
             });
 
-            this._traceFaceHitPath(hitPath, points);
+            hitCursor = this._writeFaceHitPoints(hitFace++, hitCursor, points);
         }
 
-        this.hitPath = hitPath;
+        this._hasHitGeometry = true;
         this._depth = isFinite(nearestDepth) ? nearestDepth : 0;
     }
 
+    // Redundant-looking on a backend that holds the geometry, but it is the only source of `_depth`.
     private _renderGPU(context: Context3D, faces: Face3D[], matrix: Matrix4): void {
-        const hitPath = context.createPath(`${this.id}:hit`);
+        this._resetHitGeometry(faces);
 
         let nearestDepth = Infinity;
+        let hitCursor = 0;
+        let hitFace = 0;
 
         for (const face of faces) {
             const transformed = this.transformVertices(face.vertices, matrix);
@@ -417,25 +433,79 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
 
             nearestDepth = Math.min(nearestDepth, numberSum(points, p => p[2]) / points.length);
 
-            this._traceFaceHitPath(hitPath, points);
+            hitCursor = this._writeFaceHitPoints(hitFace++, hitCursor, points);
         }
 
-        this.hitPath = hitPath;
+        this._hasHitGeometry = true;
         this._depth = isFinite(nearestDepth) ? nearestDepth : 0;
     }
 
-    private _traceFaceHitPath(hitPath: ContextPath, points: ProjectedPoint[]): void {
-        hitPath.moveTo(points[0][0], points[0][1]);
+    private _resetHitGeometry(faces: Face3D[]): void {
+        const coordinateCount = countFaceVertices(faces) * 2;
 
-        for (let idx = 1; idx < points.length; idx++) {
-            hitPath.lineTo(points[idx][0], points[idx][1]);
+        if (this._hitPoints.length < coordinateCount) {
+            this._hitPoints = new Float32Array(coordinateCount);
+        }
+
+        if (this._hitFaceOffsets.length < faces.length + 1) {
+            this._hitFaceOffsets = new Uint32Array(faces.length + 1);
+        }
+
+        this._hitFaceCount = faces.length;
+    }
+
+    private _writeFaceHitPoints(faceIndex: number, offset: number, points: ProjectedPoint[]): number {
+        const buffer = this._hitPoints;
+
+        let cursor = offset;
+
+        for (const point of points) {
+            buffer[cursor++] = point[0];
+            buffer[cursor++] = point[1];
+        }
+
+        this._hitFaceOffsets[faceIndex] = offset;
+        this._hitFaceOffsets[faceIndex + 1] = cursor;
+
+        return cursor;
+    }
+
+    private _getHitPath(): ContextPath | undefined {
+        if (!this._hasHitGeometry || !this.context) {
+            return undefined;
+        }
+
+        return this.hitPath ??= this._buildHitPath(this.context);
+    }
+
+    private _buildHitPath(context: Context): ContextPath {
+        const hitPath = context.createPath(`${this.id}:hit`);
+        const offsets = this._hitFaceOffsets;
+
+        for (let idx = 0; idx < this._hitFaceCount; idx++) {
+            this._traceFaceHitPath(hitPath, offsets[idx], offsets[idx + 1]);
+        }
+
+        return hitPath;
+    }
+
+    private _traceFaceHitPath(hitPath: ContextPath, start: number, end: number): void {
+        const points = this._hitPoints;
+
+        hitPath.moveTo(points[start], points[start + 1]);
+
+        for (let idx = start + 2; idx < end; idx += 2) {
+            hitPath.lineTo(points[idx], points[idx + 1]);
         }
 
         hitPath.closePath();
     }
 
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
-        if (!this.context || !this.hitPath) {
+        const context = this.context;
+        const hitPath = this._getHitPath();
+
+        if (!context || !hitPath) {
             return super.intersectsWith(x, y, options);
         }
 
@@ -443,9 +513,9 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
             isPointer = false,
         } = options || {};
 
-        const isAnyIntersecting = () => !!(this.hitPath && this.context) && (
-            this.context.isPointInStroke(this.hitPath, x, y) ||
-            this.context.isPointInPath(this.hitPath, x, y)
+        const isAnyIntersecting = () => (
+            context.isPointInStroke(hitPath, x, y) ||
+            context.isPointInPath(hitPath, x, y)
         );
 
         if (!isPointer) {
@@ -455,7 +525,7 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
         const hitTest = POINTER_EVENT_HIT_TESTS[this.pointerEvents];
 
         return hitTest
-            ? hitTest(this.context, this.hitPath, x, y)
+            ? hitTest(context, hitPath, x, y)
             : isAnyIntersecting();
     }
 
@@ -482,14 +552,18 @@ function computeTriangleNormal(a: Vector3, b: Vector3, c: Vector3): Vector3 {
     return [nx / len, ny / len, nz / len];
 }
 
-function triangulateFacesFlat(faces: Face3D[], color: ColorRGBA): Float32Array {
-    let vertexCount = 0;
+function countFaceVertices(faces: Face3D[]): number {
+    let count = 0;
 
     for (const face of faces) {
-        vertexCount += face.vertices.length;
+        count += face.vertices.length;
     }
 
-    const data = new Float32Array(vertexCount * 10);
+    return count;
+}
+
+function triangulateFacesFlat(faces: Face3D[], color: ColorRGBA): Float32Array {
+    const data = new Float32Array(countFaceVertices(faces) * 10);
     const cr = color[0] / 255;
     const cg = color[1] / 255;
     const cb = color[2] / 255;

--- a/packages/3d/test/core/hit-path.bench.ts
+++ b/packages/3d/test/core/hit-path.bench.ts
@@ -1,0 +1,250 @@
+import {
+    bench,
+    describe,
+} from 'vitest';
+
+import {
+    mat4LookAt,
+    mat4Multiply,
+    mat4Perspective,
+    projectPoint,
+} from '../../src';
+
+import type {
+    Face3D,
+    ProjectedPoint,
+} from '../../src';
+
+import type {
+    ContextPath,
+} from '@ripl/core';
+
+// Run with `yarn test:bench` (never in CI); jsdom's `Path2D` is a no-op so these are a lower bound.
+
+// Sink read by every arm so the JIT cannot dead-code-eliminate the trace or the buffer writes.
+let blackhole = 0;
+
+// Shared via the prototype so `createNoopPath` allocates one object per call, like `new Path2D()`.
+const noopPathMethods = {
+    moveTo(x: number, y: number) {
+        blackhole += x + y;
+    },
+    lineTo(x: number, y: number) {
+        blackhole += x + y;
+    },
+    closePath() {},
+};
+
+/** A path whose methods consume coordinates into a sink (mirrors a polyfilled Path2D's shape). */
+function createNoopPath(): ContextPath {
+    return Object.create(noopPathMethods) as ContextPath;
+}
+
+const VIEWPORT = {
+    width: 1200,
+    height: 800,
+};
+
+const viewProjection = mat4Multiply(
+    mat4Perspective(Math.PI / 3, VIEWPORT.width / VIEWPORT.height, 0.1, 1000),
+    mat4LookAt([0, 3, 8], [0, 0, 0], [0, 1, 0])
+);
+
+/** A grid of quads, the shape a surface plot or a subdivided mesh actually produces. */
+function createQuadMesh(faceCount: number): Face3D[] {
+    const segments = Math.ceil(Math.sqrt(faceCount));
+    const step = 4 / segments;
+    const faces: Face3D[] = [];
+
+    for (let row = 0; row < segments && faces.length < faceCount; row++) {
+        for (let col = 0; col < segments && faces.length < faceCount; col++) {
+            const x = -2 + col * step;
+            const z = -2 + row * step;
+
+            faces.push({
+                vertices: [
+                    [x, Math.sin(x + z), z],
+                    [x + step, Math.sin(x + step + z), z],
+                    [x + step, Math.sin(x + step + z + step), z + step],
+                    [x, Math.sin(x + z + step), z + step],
+                ],
+            });
+        }
+    }
+
+    return faces;
+}
+
+function projectFace(face: Face3D): ProjectedPoint[] {
+    return face.vertices.map(vertex => projectPoint(vertex, viewProjection, VIEWPORT));
+}
+
+/** The pre-change frame: one fresh path per shape, traced face by face whether or not it is used. */
+function renderEager(faces: Face3D[]): void {
+    const hitPath = createNoopPath();
+
+    let nearestDepth = Infinity;
+
+    for (const face of faces) {
+        const points = projectFace(face);
+
+        nearestDepth = Math.min(nearestDepth, points[0][2]);
+        hitPath.moveTo(points[0][0], points[0][1]);
+
+        for (let idx = 1; idx < points.length; idx++) {
+            hitPath.lineTo(points[idx][0], points[idx][1]);
+        }
+
+        hitPath.closePath();
+    }
+
+    blackhole += nearestDepth;
+}
+
+/** The post-change frame: the same projection loop, writing screen-space points into a reused buffer. */
+function renderLazy(faces: Face3D[], points: Float32Array, offsets: Uint32Array): void {
+    let nearestDepth = Infinity;
+    let cursor = 0;
+
+    for (let face = 0; face < faces.length; face++) {
+        const projected = projectFace(faces[face]);
+
+        nearestDepth = Math.min(nearestDepth, projected[0][2]);
+        offsets[face] = cursor;
+
+        for (const point of projected) {
+            points[cursor++] = point[0];
+            points[cursor++] = point[1];
+        }
+
+        offsets[face + 1] = cursor;
+    }
+
+    blackhole += nearestDepth;
+}
+
+/** What a live hover costs on top of a lazy frame: one path built from the buffer, once. */
+function buildHitPath(faceCount: number, points: Float32Array, offsets: Uint32Array): void {
+    const hitPath = createNoopPath();
+
+    for (let face = 0; face < faceCount; face++) {
+        const start = offsets[face];
+        const end = offsets[face + 1];
+
+        hitPath.moveTo(points[start], points[start + 1]);
+
+        for (let idx = start + 2; idx < end; idx += 2) {
+            hitPath.lineTo(points[idx], points[idx + 1]);
+        }
+
+        hitPath.closePath();
+    }
+}
+
+function createBuffers(faces: Face3D[]) {
+    let vertexCount = 0;
+
+    for (const face of faces) {
+        vertexCount += face.vertices.length;
+    }
+
+    return {
+        points: new Float32Array(vertexCount * 2),
+        offsets: new Uint32Array(faces.length + 1),
+    };
+}
+
+/** The same work with the shared projection hoisted out, so the delta is the hit path alone. */
+function describeTraceOnly(faceCount: number): void {
+    describe(`${faceCount} faces / frame — hit path only`, () => {
+        const faces = createQuadMesh(faceCount);
+        const { points, offsets } = createBuffers(faces);
+        const projected = faces.map(projectFace);
+
+        bench('eager (trace a fresh path every frame)', () => {
+            const hitPath = createNoopPath();
+
+            for (const face of projected) {
+                hitPath.moveTo(face[0][0], face[0][1]);
+
+                for (let idx = 1; idx < face.length; idx++) {
+                    hitPath.lineTo(face[idx][0], face[idx][1]);
+                }
+
+                hitPath.closePath();
+            }
+
+            if (blackhole === Infinity) {
+                throw new Error('unreachable');
+            }
+        });
+
+        bench('lazy (write the reused buffer)', () => {
+            let cursor = 0;
+
+            for (let face = 0; face < projected.length; face++) {
+                offsets[face] = cursor;
+
+                for (const point of projected[face]) {
+                    points[cursor++] = point[0];
+                    points[cursor++] = point[1];
+                }
+
+                offsets[face + 1] = cursor;
+            }
+
+            blackhole += cursor;
+
+            if (blackhole === Infinity) {
+                throw new Error('unreachable');
+            }
+        });
+    });
+}
+
+// The shared projection loop allocates five arrays per face, so this scenario is GC-bound and
+// needs a long warmup before the hit-path delta shows through at all.
+const FRAME_BENCH_OPTIONS = {
+    time: 3000,
+    warmupTime: 1000,
+};
+
+function describeFaceCount(faceCount: number): void {
+    describe(`${faceCount} faces / frame`, () => {
+        const faces = createQuadMesh(faceCount);
+        const { points, offsets } = createBuffers(faces);
+
+        bench('eager (trace a fresh path every frame)', () => {
+            renderEager(faces);
+
+            if (blackhole === Infinity) {
+                throw new Error('unreachable');
+            }
+        }, FRAME_BENCH_OPTIONS);
+
+        bench('lazy (nothing hit-tests)', () => {
+            renderLazy(faces, points, offsets);
+
+            if (blackhole === Infinity) {
+                throw new Error('unreachable');
+            }
+        }, FRAME_BENCH_OPTIONS);
+
+        bench('lazy (a live hover builds the path once)', () => {
+            renderLazy(faces, points, offsets);
+            buildHitPath(faces.length, points, offsets);
+
+            if (blackhole === Infinity) {
+                throw new Error('unreachable');
+            }
+        }, FRAME_BENCH_OPTIONS);
+    });
+}
+
+describeFaceCount(1000);
+describeFaceCount(5000);
+describeFaceCount(10000);
+
+describeTraceOnly(1000);
+describeTraceOnly(5000);
+describeTraceOnly(10000);

--- a/packages/3d/test/shape.test.ts
+++ b/packages/3d/test/shape.test.ts
@@ -30,6 +30,10 @@ import {
     createScene,
 } from '@ripl/core';
 
+import type {
+    ContextPath,
+} from '@ripl/core';
+
 import {
     createContext as createCanvasContext,
 } from '@ripl/canvas';
@@ -259,6 +263,240 @@ describe('Shape3D', () => {
             }).render();
 
             expect(slab.zIndex).toBeGreaterThan(chip.zIndex);
+        });
+
+    });
+
+    describe('Hit testing', () => {
+
+        type Polygon = [number, number][];
+
+        function isPointInPolygon(polygon: Polygon, x: number, y: number): boolean {
+            let inside = false;
+            let previous = polygon.length - 1;
+
+            for (let idx = 0; idx < polygon.length; idx++) {
+                const [xi, yi] = polygon[idx];
+                const [xj, yj] = polygon[previous];
+
+                if ((yi > y) !== (yj > y) && x < (xj - xi) * (y - yi) / (yj - yi) + xi) {
+                    inside = !inside;
+                }
+
+                previous = idx;
+            }
+
+            return inside;
+        }
+
+        // jsdom's Path2D records nothing, so the traced faces are captured and tested here instead.
+        function mockPolygonHitTesting(context: CanvasContext3D) {
+            const traces = new WeakMap<ContextPath, Polygon[]>();
+            const createPath = context.createPath.bind(context);
+
+            const spy = vi.spyOn(context, 'createPath').mockImplementation(id => {
+                const path = createPath(id);
+                const polygons: Polygon[] = [];
+
+                traces.set(path, polygons);
+
+                path.moveTo = (px, py) => {
+                    polygons.push([[px, py]]);
+                };
+
+                path.lineTo = (px, py) => {
+                    polygons[polygons.length - 1].push([px, py]);
+                };
+
+                return path;
+            });
+
+            vi.spyOn(context, 'isPointInPath').mockImplementation((path, px, py) => {
+                return (traces.get(path) ?? []).some(polygon => isPointInPolygon(polygon, px, py));
+            });
+
+            vi.spyOn(context, 'isPointInStroke').mockImplementation(() => false);
+
+            return spy;
+        }
+
+        function firstFaceCentroid(): [number, number] {
+            const { points } = faceFills()[0];
+
+            return [
+                points.reduce((total, point) => total + point[0], 0) / points.length,
+                points.reduce((total, point) => total + point[1], 0) / points.length,
+            ];
+        }
+
+        function hitPathCalls(spy: ReturnType<typeof mockPolygonHitTesting>, id: string): number {
+            return spy.mock.calls.filter(([pathId]) => pathId === `${id}:hit`).length;
+        }
+
+        // The trace cost ~5 native calls per face per frame and was thrown away whenever, as here,
+        // nothing hit-tested the shape.
+        test('Should not build a hit path while rendering', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            const createPath = vi.spyOn(context, 'createPath');
+
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            expect(createPath).not.toHaveBeenCalledWith(`${cube.id}:hit`);
+        });
+
+        test('Should hit a point inside a projected face', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            const [x, y] = firstFaceCentroid();
+
+            expect(cube.intersectsWith(x, y)).toBe(true);
+        });
+
+        test('Should miss a point outside every projected face', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            expect(cube.intersectsWith(-1000, -1000)).toBe(false);
+        });
+
+        test('Should hit a point inside a projected face under a pointer test', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            const [x, y] = firstFaceCentroid();
+
+            expect(cube.intersectsWith(x, y, { isPointer: true })).toBe(true);
+        });
+
+        test('Should miss a point outside every projected face under a pointer test', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            expect(cube.intersectsWith(-1000, -1000, { isPointer: true })).toBe(false);
+        });
+
+        test('Should build the hit path once however many times a frame is tested', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            const createPath = mockPolygonHitTesting(context);
+
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            const [x, y] = firstFaceCentroid();
+
+            cube.intersectsWith(x, y);
+            cube.intersectsWith(x, y);
+            cube.intersectsWith(-1000, -1000, { isPointer: true });
+            cube.intersectsWith(x, y, { isPointer: true });
+
+            expect(hitPathCalls(createPath, cube.id)).toBe(1);
+        });
+
+        test('Should rebuild the hit path after the next render', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            const createPath = mockPolygonHitTesting(context);
+            const scene = createScene(context, {
+                children: [cube],
+            });
+
+            scene.render();
+
+            const [x, y] = firstFaceCentroid();
+
+            expect(cube.intersectsWith(x, y)).toBe(true);
+
+            context.setCamera([50, 0, 5], [50, 0, 0], [0, 1, 0]);
+            scene.render();
+
+            expect(cube.intersectsWith(x, y)).toBe(false);
+            expect(hitPathCalls(createPath, cube.id)).toBe(2);
+        });
+
+        // `Element.intersectsWith` ignores `options`, so a fallback under `isPointer` would make a
+        // shape opted out of pointer events more hittable, not less.
+        test('Should refuse a pointer test on a shape with pointerEvents none', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+                pointerEvents: 'none',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            const [x, y] = firstFaceCentroid();
+
+            expect(cube.intersectsWith(x, y, { isPointer: true })).toBe(false);
+            expect(cube.intersectsWith(x, y)).toBe(true);
+        });
+
+        test('Should fall back to the bounding box before the shape has rendered', () => {
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            mockPolygonHitTesting(context);
+            createScene(context, {
+                children: [cube],
+            });
+
+            expect(cube.intersectsWith(200, 150)).toBe(false);
         });
 
     });


### PR DESCRIPTION
## The problem

`Shape3D._renderCPU` and `_renderGPU` each created a `ContextPath` and traced every face into it, unconditionally, every frame:

```ts
const hitPath = context.createPath(`${this.id}:hit`);
// ...per face:
this._traceFaceHitPath(hitPath, points);
```

`createPath` is not pooled — `packages/canvas/src/mixins.ts` returns `new CanvasPath(id)`, which allocates a native `Path2D` — and each face costs one `moveTo`, N-1 `lineTo` and one `closePath`, every one a JS-to-native call with no batching. For a quad that is five native calls per face per frame. At 9,000 faces that is ~45,000 native calls and a fresh `Path2D` every frame, entirely wasted whenever nothing hit-tests the shape.

Nothing in this repo hit-tests a `Shape3D` today. Two supporting details: the `id` argument buys nothing here (paths are not cached or pooled by id; it is the SVG vdom diff key and a debugging aid), and on WebGPU the trace is pure overhead against an offscreen hit canvas that never paints.

## The fix, and why this shape

The obvious fix is to skip the trace when nothing listens, mirroring what `Context.hitTest` already does — it filters `renderedElements.filter(el => el.has(event))` before ever calling `intersectsWith`. **That was rejected.** `apps/website/src/docs/core/essentials/shape.md` documents `intersectsWith` as pixel-accurate:

> Shapes provide pixel-accurate hit testing through the `intersectsWith` method. Instead of using a simple bounding box check (like the base `Element`), shapes test whether a point is inside the actual path geometry

and demonstrates calling it with no listener attached. A listener gate silently downgrades that to a bounding-box test. Three further hazards: `Element.intersectsWith` ignores its `options` argument entirely, so the box fallback would make a `pointerEvents: 'none'` shape *more* hittable; `Element.on` invalidates the tracked-element memo but schedules no repaint, so a shape gaining a listener between frames would hit-test against a stale AABB; and it widens the reach of the camera-dependent bounding-box defect already recorded in `docs/audits/3d-webgpu.md`.

So the geometry is retained and the path is built on demand instead:

- The per-face projection loop is **kept**. It is also the only source of `nearestDepth` → `_depth` → `zIndex`, which `Group.render` and `Scene._collectInstructions` sort on and which the existing picking-depth test pins. In `_renderGPU` that loop exists *solely* for depth and the hit path, so deleting it looks safe and is not.
- Projected screen-space points are written into a reused `Float32Array` plus a `Uint32Array` face-offset index, grown only when the face count outgrows them and overwritten in place. That is strictly less GC pressure than before: a per-frame `Path2D` is replaced by one buffer written in place.
- `_getHitPath()` builds the path from that buffer on first use and memoizes into the existing `protected hitPath`. `render()` keeps its `this.hitPath = undefined` line, which now means "the buffer moved, rebuild on next demand".
- `intersectsWith` keeps its exact structure and ordering, including the `pointerEvents` dispatch relative to the no-path fallback. Only *when* the path is built changed.

This is never worse than tracing eagerly: nobody hit-testing pays nothing, an orbiting camera with a still pointer pays nothing, and a live hover pays once per pointer frame instead of once per render frame.

`hitPath` is `protected`, `_renderCPU`/`_renderGPU` are `private`, and nothing outside `packages/3d/src/core/shape.ts` references either — no subclass, no test, no devtools, not `@ripl/webgpu`. The change surface is fully internal.

## Verification

`packages/3d` had no coverage of `Shape3D` hit testing at all, so this adds the first: 9 tests in a new `Hit testing` block (12 → 21 in that file).

The `createPath` pin fails at the branch point. Stashing **only** `packages/3d/src/core/shape.ts` (a plain `git stash` removes the new tests too, so the run would trivially pass and prove nothing):

```
FAIL  packages/3d/test/shape.test.ts > Shape3D > Hit testing > Should not build a hit path while rendering
AssertionError: expected "createPath" to not be called with arguments: [ 'cube:058e5002:hit' ]
Number of calls: 1
      Tests  1 failed | 20 passed (21)
```

and with the fix, `21 passed (21)`. This was reproduced independently of the agent that wrote it.

Honestly: only that one test is fail-first. The parity, build-once, `pointerEvents: 'none'` and never-rendered-fallback tests pass on both sides — that is their job, they pin behavior that must not move. Because jsdom's `Path2D` records nothing and the mock canvas's `isPointInPath` hard-returns `false`, the parity tests install a local harness that captures traced faces off `createPath` and runs a real point-in-polygon test.

Gates: `yarn lint`, `yarn typecheck`, `yarn typecheck:dist` clean; `yarn test` 193 files / 2433 passed; coverage statements 89.15% / branches 76.93% / functions 82.61% / lines 89.47%, all clear of the ratchet; TypeDoc `notDocumented` on `@ripl/3d` reports zero.

Benchmark (`packages/3d/test/core/hit-path.bench.ts`, the package's first). jsdom's `Path2D` is a no-op, so these are a lower bound:

| faces | eager | lazy | delta | scenario |
|---|---|---|---|---|
| 1,000 | 2,026 hz | 2,178 hz | +7.5% | full frame |
| 5,000 | 400 hz | 461 hz | +15% | full frame |
| 10,000 | 261 hz | 296 hz | +13% | full frame |
| 1,000 | 23,813 hz | 50,558 hz | 2.12x | hit-path work only |
| 5,000 | 4,405 hz | 8,852 hz | 2.01x | hit-path work only |
| 10,000 | 2,078 hz | 3,972 hz | 1.91x | hit-path work only |

The full-frame arms share an allocation-heavy projection loop that dilutes the delta and leaves them GC-bound; they varied run to run. The isolated arms are stable at 0.3-0.7% rme and are the honest size of the work removed. A "live hover builds the path once" arm measures level with the old eager path (10,000 faces: 231 hz vs 261 hz), confirming the change is not materially worse for a hit-tested scene.

Two things that could not be verified here: everything ran on Node 22.22.2 because no nvm is present in this container (`.nvmrc` pins 24.18.1, which CI uses); and `yarn build` does not work from a git worktree here, because lerna/nx resolved the workspace root to the shared checkout, so `tsdown` was run per package with an explicit PATH followed by `tsc -p tsconfig.dist.json`. That is a faithful equivalent of `yarn build && yarn typecheck:dist` but is not literally those commands.

## Breaking

None. `intersectsWith` returns the same answers, honors `pointerEvents` identically, and falls back the same way for a shape that has never rendered.

One edge-case difference worth recording: a face with zero vertices previously threw during render (`points[0][0]` on an empty array) and now produces a degenerate subpath and a `NaN` depth. No built-in shape emits such a face; it is reachable only from a custom `computeFaces()`. Arguably an improvement, since killing the rAF loop on one malformed face is the failure mode audit finding 3D-1 exists to prevent.

## Follow-ups deliberately left undone

- Camera-versioned caching of the built path across frames. A real further win for a hit-tested scene with a still camera, and `Context3D.updateViewProjectionMatrix` is the single choke point where a version counter would go, but it touches `Context3D` as well and belongs in its own change.
- The `pointerEvents: 'none'` fast path, which would change programmatic `intersectsWith` for the same reason the listener gate was rejected.
- Anything else in `_renderGPU`, whose projection loop is otherwise redundant on a backend that already holds the geometry.

---
_Generated by [Claude Code](https://claude.ai/code/session_012N5g87JbHQtVW3sAmmyrmf)_