### PR TITLE
Describe drag deltas as the step, not the total

### DIFF
--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -100,7 +100,7 @@ export interface ContextEventMap extends EventMap {
         /** Y coordinate at which the drag started, in surface pixel space. */
         y: number;
     };
-    /** Emitted continuously during a drag, carrying the current position, drag start, and delta from the start. */
+    /** Emitted continuously during a drag, carrying the current position, drag start, and the movement since the previous event. */
     drag: {
         /** Current X coordinate of the pointer, in surface pixel space. */
         x: number;
@@ -110,12 +110,12 @@ export interface ContextEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in surface pixel space. */
         startY: number;
-        /** Horizontal distance moved since the drag started, in pixels. */
+        /** Horizontal distance moved since the previous drag event, in pixels. */
         deltaX: number;
-        /** Vertical distance moved since the drag started, in pixels. */
+        /** Vertical distance moved since the previous drag event, in pixels. */
         deltaY: number;
     };
-    /** Emitted when a drag gesture ends, carrying the final position, drag start, and total delta. */
+    /** Emitted when a drag gesture ends, carrying the final position, drag start, and the movement since the previous event. */
     dragend: {
         /** Final X coordinate of the pointer, in surface pixel space. */
         x: number;
@@ -125,9 +125,9 @@ export interface ContextEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in surface pixel space. */
         startY: number;
-        /** Total horizontal distance moved over the drag, in pixels. */
+        /** Horizontal distance moved since the previous drag event, in pixels. */
         deltaX: number;
-        /** Total vertical distance moved over the drag, in pixels. */
+        /** Vertical distance moved since the previous drag event, in pixels. */
         deltaY: number;
     };
 }

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -130,7 +130,7 @@ export interface ElementEventMap extends EventMap {
         /** Y coordinate at which the drag started, in element-local space. */
         y: number;
     };
-    /** Emitted continuously while dragging the element, carrying the current position, drag start, and delta from the start. */
+    /** Emitted continuously while dragging the element, carrying the current position, drag start, and the movement since the previous event. */
     drag: {
         /** Current X coordinate of the pointer, in element-local space. */
         x: number;
@@ -140,12 +140,12 @@ export interface ElementEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in element-local space. */
         startY: number;
-        /** Horizontal distance moved since the drag started, in pixels. */
+        /** Horizontal distance moved since the previous drag event, in pixels. */
         deltaX: number;
-        /** Vertical distance moved since the drag started, in pixels. */
+        /** Vertical distance moved since the previous drag event, in pixels. */
         deltaY: number;
     };
-    /** Emitted when a drag gesture on the element ends, carrying the final position, drag start, and total delta. */
+    /** Emitted when a drag gesture on the element ends, carrying the final position, drag start, and the movement since the previous event. */
     dragend: {
         /** Final X coordinate of the pointer, in element-local space. */
         x: number;
@@ -155,9 +155,9 @@ export interface ElementEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in element-local space. */
         startY: number;
-        /** Total horizontal distance moved over the drag, in pixels. */
+        /** Horizontal distance moved since the previous drag event, in pixels. */
         deltaX: number;
-        /** Total vertical distance moved over the drag, in pixels. */
+        /** Vertical distance moved since the previous drag event, in pixels. */
         deltaY: number;
     };
     /** Emitted when the element is destroyed; carries no payload. */

--- a/packages/dom/test/context.test.ts
+++ b/packages/dom/test/context.test.ts
@@ -396,6 +396,51 @@ describe('DOMContext pointer state machine', () => {
         expect(typesOf(element)).toEqual(['dragstart', 'drag', 'dragend']);
     });
 
+    // The payload reports the step, not the accumulated total; the docs said "since the drag
+    // started" and a consumer following them would have written `x = startX + deltaX`.
+    test('Should report drag deltas relative to the previous event', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mousemove', 140, 140);
+        mouse(context, 'mousemove', 160, 160);
+
+        const drags = element.events.filter(event => event.type === 'drag');
+
+        expect(drags[0].data).toMatchObject({
+            deltaX: 130,
+            deltaY: 130,
+        });
+
+        expect(drags[1].data).toMatchObject({
+            deltaX: 20,
+            deltaY: 20,
+        });
+    });
+
+    test('Should report the dragend delta relative to the previous event', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mousemove', 140, 140);
+        mouse(context, 'mouseup', 160, 160);
+
+        const dragend = element.events.find(event => event.type === 'dragend');
+
+        expect(dragend?.data).toMatchObject({
+            startX: 10,
+            deltaX: 20,
+        });
+    });
+
     test('Should not resume a stranded drag once the button is released', () => {
         const context = create();
         const element = createMockElement('a', DRAG_EVENTS);


### PR DESCRIPTION
## The problem

`ElementEventMap` and `ContextEventMap` both documented the drag payload's delta as cumulative:

```ts
/** Emitted continuously while dragging the element, carrying the current position, drag start, and delta from the start. */
drag: {
    /** Horizontal distance moved since the drag started, in pixels. */
    deltaX: number;
```

and `dragend` as "total delta" / "Total horizontal distance moved over the drag".

`DOMContext` computes both as the step, not the total:

```ts
const deltaX = rx - state.dragPrevX;
const deltaY = ry - state.dragPrevY;

state.dragPrevX = rx;
state.dragPrevY = ry;
```

`dragPrevX` is seeded to the drag start when the gesture begins and then advanced on **every** event, so each payload carries the movement since the previous event. `dragend` (`packages/dom/src/context.ts:289`) does the same.

The wording matters because it inverts the correct usage. A consumer following the docs writes `x = startX + deltaX`, which lags by one event and accumulates wrongly; the incremental value wants `x += deltaX`. Both readings look plausible against a payload that also carries `startX`/`startY`, so nothing about the shape of the data corrects the mistake.

This surfaced while writing a Bézier control-point editor for the docs playground, where the two readings produce visibly different drag behavior.

## The fix

Corrects twelve doc sites across the two event maps: the `drag` and `dragend` summaries and the four delta properties in each of `packages/core/src/core/element.ts` and `packages/core/src/context/types.ts`. No runtime change.

Adds two tests to `packages/dom/test/context.test.ts` pinning the semantics so the docs and the implementation cannot drift apart again. They use the existing mock-element harness and assert on the payload directly:

- `drag` over three moves reports `deltaX: 130` then `deltaX: 20` — a cumulative implementation would report 150 on the second
- `dragend` reports `deltaX: 20` alongside `startX: 10`, pinning both fields at once so the distinction between them is explicit

## Verification

`yarn lint` and `yarn typecheck` clean. `packages/dom` + `packages/core` at 1,205 passed / 2 skipped, including the two new tests.

Stated plainly: these tests pass before and after, because this is a documentation fix and the runtime behavior was always correct. They exist to record the contract the corrected wording now describes. A cumulative implementation fails them.

## Breaking

None. Documentation and tests only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012N5g87JbHQtVW3sAmmyrmf)_