### PR TITLE
Draw radial segments as solid fills with a constant-width gap, and let small arcs be hovered

### DIFF
--- a/apps/website/scripts/check-config-coverage.mjs
+++ b/apps/website/scripts/check-config-coverage.mjs
@@ -340,7 +340,7 @@ function main() {
 
             const exclusions = CHART_EXCLUSIONS[page] ?? {};
             const required = [...new Set([...shape.options, ...shape.series])]
-                .filter(option => !excludedBy.has(option) && !(option in exclusions));
+                .filter(option => !excludedBy.has(option) && !Object.hasOwn(exclusions, option));
 
             const missing = required.filter(option => !covered.has(option));
 

--- a/apps/website/scripts/check-config-coverage.mjs
+++ b/apps/website/scripts/check-config-coverage.mjs
@@ -124,6 +124,13 @@ const CHART_EXCLUSIONS = {
     scatter: {
         overview: 'the scrub strip is category-axis only; scatter has a continuous x, so it draws none',
     },
+    // The panel drives `padWidth`, which wins wherever it is set, so a `padAngle` control would be inert.
+    'polar-area': {
+        padAngle: 'deprecated in favour of `padWidth`, which the panel controls',
+    },
+    chord: {
+        padAngle: 'deprecated in favour of `padWidth`, which the panel controls',
+    },
 };
 
 /** Reads the `option="…"` attributes inside a chunk of template markup. */

--- a/apps/website/src/charts/arc-diagram.md
+++ b/apps/website/src/charts/arc-diagram.md
@@ -1,6 +1,6 @@
 # Arc Diagram
 
-The **Arc Diagram** is a cartesian axis whose points are nodes, connected by semicircular arcs whose thickness encodes the strength of each relationship. Keeping nodes on one axis makes it easy to spot clusters and bridges, which makes this a clean way to show connections in an ordered set (character co-occurrence, module dependencies, adjacency). The axis can run horizontally or vertically, and nodes can be sized by their connection count.
+The **Arc Diagram** is a cartesian axis whose points are nodes, connected by semicircular arcs whose thickness encodes the strength of each relationship. Keeping nodes on one axis makes it easy to spot clusters and bridges, which makes this a clean way to show connections in an ordered set (character co-occurrence, module dependencies, adjacency). The axis can run horizontally or vertically, and nodes can be sized by their connection count. Arcs are hit-tested on their stroke, so a small link nested under a large one is still hoverable.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -1,6 +1,6 @@
 # Chord Chart
 
-The **Chord Chart** visualizes relationships between groups using arcs and ribbons arranged in a circle. Each group is represented by an arc segment, and ribbons connect groups to show the magnitude of flow between them. The chart features a sequential entry animation (arcs first, then ribbons), an optional legend, and configurable colors and arc gaps. Outer arcs are filled with their solid group color and separated by a constant-width gap (`padWidth`); hovering one dims the other arcs and every ribbon it is not attached to.
+The **Chord Chart** visualizes relationships between groups using arcs and ribbons arranged in a circle. Each group is represented by an arc segment, and ribbons connect groups to show the magnitude of flow between them. The chart features a sequential entry animation (arcs first, then ribbons), an optional legend, and configurable colors and arc gaps. Outer arcs are filled with a translucent tint of their group color and separated by a constant-width gap (`padWidth`); hovering one dims the other arcs and every ribbon it is not attached to.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -1,6 +1,6 @@
 # Chord Chart
 
-The **Chord Chart** visualizes relationships between groups using arcs and ribbons arranged in a circle. Each group is represented by an arc segment, and ribbons connect groups to show the magnitude of flow between them. The chart features a sequential entry animation (arcs first, then ribbons), an optional legend, and configurable colors and pad angles.
+The **Chord Chart** visualizes relationships between groups using arcs and ribbons arranged in a circle. Each group is represented by an arc segment, and ribbons connect groups to show the magnitude of flow between them. The chart features a sequential entry animation (arcs first, then ribbons), an optional legend, and configurable colors and arc gaps. Outer arcs are filled with their solid group color and separated by a constant-width gap (`padWidth`); hovering one dims the other arcs and every ribbon it is not attached to.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
@@ -15,8 +15,8 @@ The **Chord Chart** visualizes relationships between groups using arcs and ribbo
     </template>
     <template #config>
         <RiplChartConfig :config="config" extra-title="Groups" :extras-reset="reset">
-            <RiplField label="Pad angle" option="padAngle">
-                <RiplInputRange v-model="extras.padAngle" :min="0" :max="0.2" :step="0.01" />
+            <RiplField label="Arc gap" option="padWidth">
+                <RiplInputRange v-model="extras.padWidth" :min="0" :max="12" :step="1" />
             </RiplField>
             <template #colors>
                 <RiplField
@@ -60,7 +60,7 @@ import {
 const LABELS = ['Engineering', 'Design', 'Marketing', 'Sales'];
 
 const { extras, reset } = useChartExtras({
-    padAngle: 0.04,
+    padWidth: 2,
     palette: LABELS.map((_, index) => paletteColor(index)),
 });
 
@@ -91,7 +91,7 @@ let matrix = generateMatrix();
 function buildOptions() {
     return {
         palette: extras.palette,
-        padAngle: extras.padAngle,
+        padWidth: extras.padWidth,
         ...buildCommonOptions(config),
     };
 }
@@ -165,7 +165,10 @@ createChordChart('#container', {
     matrix,
     // One color per group, positional.
     palette: ['#7cacf8', '#6dd5b1', '#b197fc', '#f7c97e'],
-    // Gap between adjacent group arcs, in radians.
+    // Gap between adjacent group arcs, in pixels — a constant width whatever the radius.
+    padWidth: 2,
+    // Deprecated: an angular gap, in radians, taken out of the ring before the arcs are sized.
+    // Ignored while `padWidth` is set.
     padAngle: 0.04,
     legend: { position: 'right' },
     format: 'number',

--- a/apps/website/src/charts/pie.md
+++ b/apps/website/src/charts/pie.md
@@ -1,6 +1,6 @@
 # Pie Chart
 
-The **Pie Chart** illustrates numerical proportions as angular slices of a circle. It supports animated entry, exit, and reorder transitions when data changes, and can switch to a donut layout by setting an `innerRadius`. Slices are filled with their solid series color and separated by a constant-width gap (`padWidth`). Hover any slice to see a tooltip and dim the rest, and adjust the inner radius in the demo below.
+The **Pie Chart** illustrates numerical proportions as angular slices of a circle. It supports animated entry, exit, and reorder transitions when data changes, and can switch to a donut layout by setting an `innerRadius`. Slices are filled with a translucent tint of their series color and separated by a constant-width gap (`padWidth`) that holds its width right to the center. Hover any slice to see a tooltip and dim the rest, and adjust the inner radius in the demo below.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
@@ -256,7 +256,7 @@ createPieChart('#container', {
     // Non-zero turns the pie into a donut. A value of 1 or less is a fraction of the outer
     // radius; anything larger is read as absolute pixels.
     innerRadius: 60,
-    // Segments are filled solid and separated by a gap of this constant width, in pixels.
+    // Segments are separated by a gap of this constant width, in pixels.
     padWidth: 2,
     labels: 'outside',
     legend: { position: 'right' },

--- a/apps/website/src/charts/pie.md
+++ b/apps/website/src/charts/pie.md
@@ -1,6 +1,6 @@
 # Pie Chart
 
-The **Pie Chart** illustrates numerical proportions as angular slices of a circle. It supports animated entry, exit, and reorder transitions when data changes, and can switch to a donut layout by setting an `innerRadius`. Hover any slice to see a tooltip, and adjust the inner radius in the demo below.
+The **Pie Chart** illustrates numerical proportions as angular slices of a circle. It supports animated entry, exit, and reorder transitions when data changes, and can switch to a donut layout by setting an `innerRadius`. Slices are filled with their solid series color and separated by a constant-width gap (`padWidth`). Hover any slice to see a tooltip and dim the rest, and adjust the inner radius in the demo below.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
@@ -19,6 +19,9 @@ The **Pie Chart** illustrates numerical proportions as angular slices of a circl
         <RiplChartConfig :config="config" extra-title="Pie" :extras-reset="reset">
             <RiplField label="Inner radius" option="innerRadius">
                 <RiplInputRange v-model="extras.innerRadius" :min="0" :max="0.9" :step="0.05" />
+            </RiplField>
+            <RiplField label="Segment gap" option="padWidth">
+                <RiplInputRange v-model="extras.padWidth" :min="0" :max="10" :step="1" />
             </RiplField>
             <RiplField label="Labels" option="labels">
                 <RiplSelect v-model="extras.labels">
@@ -63,6 +66,7 @@ const COUNTRIES = [
 
 const { extras, reset } = useChartExtras({
     innerRadius: 0,
+    padWidth: 2,
     labels: 'off' as 'off' | 'inside' | 'outside',
 });
 
@@ -98,6 +102,7 @@ let data = COUNTRIES.map(label => getDataItem(label));
 function buildOptions() {
     return {
         innerRadius: extras.innerRadius,
+        padWidth: extras.padWidth,
         labels: labelsOption(),
         ...buildCommonOptions(config),
     };
@@ -251,6 +256,8 @@ createPieChart('#container', {
     // Non-zero turns the pie into a donut. A value of 1 or less is a fraction of the outer
     // radius; anything larger is read as absolute pixels.
     innerRadius: 60,
+    // Segments are filled solid and separated by a gap of this constant width, in pixels.
+    padWidth: 2,
     labels: 'outside',
     legend: { position: 'right' },
     format: 'percentage',

--- a/apps/website/src/charts/polar-area.md
+++ b/apps/website/src/charts/polar-area.md
@@ -1,6 +1,6 @@
 # Polar Area Chart
 
-The **Polar Area Chart** renders equal-angle segments whose radius encodes the value, making it easy to compare magnitudes across categories. Unlike a pie chart (where angle encodes value), all slices share the same angle; only the radius varies. The chart includes animated axis rings, radial lines, labels that enter on first render and transition smoothly on data updates, and an optional legend (shown by default).
+The **Polar Area Chart** renders equal-angle segments whose radius encodes the value, making it easy to compare magnitudes across categories. Unlike a pie chart (where angle encodes value), all slices share the same angle; only the radius varies. The chart includes animated axis rings, radial lines, labels that enter on first render and transition smoothly on data updates, and an optional legend (shown by default). Segments are filled with their solid series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
@@ -23,8 +23,8 @@ The **Polar Area Chart** renders equal-angle segments whose radius encodes the v
             <RiplField label="Max radius" option="maxRadiusRatio">
                 <RiplInputRange v-model="extras.maxRadiusRatio" :min="0.2" :max="0.5" :step="0.05" />
             </RiplField>
-            <RiplField label="Segment gap" option="padAngle">
-                <RiplInputRange v-model="extras.padAngle" :min="0" :max="0.1" :step="0.01" />
+            <RiplField label="Segment gap" option="padWidth">
+                <RiplInputRange v-model="extras.padWidth" :min="0" :max="10" :step="1" />
             </RiplField>
             <RiplField label="Grid rings" option="levels">
                 <RiplInputRange v-model="extras.levels" :min="2" :max="8" :step="1" />
@@ -69,7 +69,7 @@ const LABELS = ['Speed', 'Strength', 'Defense', 'Magic', 'Luck', 'Agility', 'Sta
 const { extras, reset } = useChartExtras({
     innerRadius: 0.15,
     maxRadiusRatio: 0.45,
-    padAngle: 0.02,
+    padWidth: 2,
     levels: 4,
     labels: 'off' as 'off' | 'inside' | 'outside',
 });
@@ -107,7 +107,7 @@ function buildOptions() {
     return {
         innerRadius: extras.innerRadius,
         maxRadiusRatio: extras.maxRadiusRatio,
-        padAngle: extras.padAngle,
+        padWidth: extras.padWidth,
         levels: extras.levels,
         labels: labelsOption(),
         ...buildCommonOptions(config),
@@ -253,7 +253,9 @@ createPolarAreaChart('#container', {
     // How far the longest segment reaches, as a fraction of the chart size. 0.5 touches the
     // edge, so this is the outer bound (0–0.5).
     maxRadiusRatio: 0.45,
-    // Gap between adjacent segments, in radians.
+    // Gap between adjacent segments, in pixels — a constant width whatever the radius.
+    padWidth: 2,
+    // Deprecated: an angular gap, in radians, that widens with radius. Ignored while `padWidth` is set.
     padAngle: 0.02,
     // Concentric grid rings.
     levels: 4,

--- a/apps/website/src/charts/polar-area.md
+++ b/apps/website/src/charts/polar-area.md
@@ -1,6 +1,6 @@
 # Polar Area Chart
 
-The **Polar Area Chart** renders equal-angle segments whose radius encodes the value, making it easy to compare magnitudes across categories. Unlike a pie chart (where angle encodes value), all slices share the same angle; only the radius varies. The chart includes animated axis rings, radial lines, labels that enter on first render and transition smoothly on data updates, and an optional legend (shown by default). Segments are filled with their solid series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
+The **Polar Area Chart** renders equal-angle segments whose radius encodes the value, making it easy to compare magnitudes across categories. Unlike a pie chart (where angle encodes value), all slices share the same angle; only the radius varies. The chart includes animated axis rings, radial lines, labels that enter on first render and transition smoothly on data updates, and an optional legend (shown by default). Segments are filled with a translucent tint of their series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/apps/website/src/charts/radial-bar.md
+++ b/apps/website/src/charts/radial-bar.md
@@ -1,6 +1,6 @@
 # Radial Bar Chart
 
-The **Radial Bar Chart** lays each category out as a concentric ring whose arc length encodes its value. This circular take on the bar chart reads well for a handful of comparable metrics or progress-style values. Each ring has a faint track behind a colored value arc that sweeps clockwise from the top.
+The **Radial Bar Chart** lays each category out as a concentric ring whose arc length encodes its value. This circular take on the bar chart reads well for a handful of comparable metrics or progress-style values. Each ring has a faint track behind a colored value arc that sweeps clockwise from the top. Value arcs are hit-tested on their stroke, so every ring is hoverable rather than only the outermost.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/apps/website/src/charts/scatter.md
+++ b/apps/website/src/charts/scatter.md
@@ -32,7 +32,7 @@ The **Scatter Chart** (also known as a bubble chart when using variable sizes) p
                 <RiplInputRange
                     v-model="extras.maxRadius"
                     :min="5"
-                    :max="40"
+                    :max="30"
                     :step="1"
                 />
             </RiplField>
@@ -106,7 +106,7 @@ const seriesMeta = [
 const { extras, reset } = useChartExtras({
     sizeBy: true,
     minRadius: 5,
-    maxRadius: 25,
+    maxRadius: 15,
     markerSymbol: 'circle' as 'mixed' | 'circle' | 'square' | 'diamond' | 'triangle',
     multiAxis: true,
 });
@@ -343,7 +343,7 @@ createScatterChart('#container', {
             yBy: 'profit',
             sizeBy: 'volume',
             minRadius: 5,
-            maxRadius: 25,
+            maxRadius: 15,
         },
     ],
 });

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -1,6 +1,6 @@
 # Sunburst Chart
 
-The **Sunburst Chart** displays hierarchical data as concentric rings, where each ring represents a level in the hierarchy and arc size represents value. It's excellent for visualizing tree structures like org charts, file systems, or category breakdowns. Nodes can have nested `children`, and arcs animate on entry and update.
+The **Sunburst Chart** displays hierarchical data as concentric rings, where each ring represents a level in the hierarchy and arc size represents value. It's excellent for visualizing tree structures like org charts, file systems, or category breakdowns. Nodes can have nested `children`, and arcs animate on entry and update. Segments are filled with their solid series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).
@@ -14,7 +14,11 @@ The **Sunburst Chart** displays hierarchical data as concentric rings, where eac
         </RiplControlGroup>
     </template>
     <template #config>
-        <RiplChartConfig :config="config" />
+        <RiplChartConfig :config="config" extra-title="Sunburst" :extras-reset="reset">
+            <RiplField label="Segment gap" option="padWidth">
+                <RiplInputRange v-model="extras.padWidth" :min="0" :max="10" :step="1" />
+            </RiplField>
+        </RiplChartConfig>
     </template>
 </ripl-example>
 
@@ -26,6 +30,7 @@ import {
 import {
     buildCommonOptions,
     useChartConfig,
+    useChartExtras,
 } from '../.vitepress/compositions/use-chart-config';
 
 import {
@@ -36,6 +41,10 @@ import {
     ref,
     watch,
 } from 'vue';
+
+const { extras, reset } = useChartExtras({
+    padWidth: 2,
+});
 
 const config = useChartConfig({
     features: {
@@ -101,14 +110,21 @@ let data = generateData();
 
 const example = ref();
 
+function buildOptions() {
+    return {
+        padWidth: extras.padWidth,
+        ...buildCommonOptions(config),
+    };
+}
+
 const { contextChanged, chart } = useRiplChart(context => {
     return createSunburstChart(context, {
         data,
-        ...buildCommonOptions(config),
+        ...buildOptions(),
     });
 });
 
-watch(config, () => chart.value?.update(buildCommonOptions(config)), { deep: true });
+watch([config, extras], () => chart.value?.update(buildOptions()), { deep: true });
 
 
 function randomize() {
@@ -194,6 +210,8 @@ createSunburstChart('#container', {
     // Each node carries `id`, `label`, `value` and optional `children`; the ring depth follows
     // the nesting.
     data,
+    // Gap between adjacent segments, in pixels — a constant width whatever the radius.
+    padWidth: 2,
     legend: { position: 'right' },
     format: 'number',
 });

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -1,6 +1,6 @@
 # Sunburst Chart
 
-The **Sunburst Chart** displays hierarchical data as concentric rings, where each ring represents a level in the hierarchy and arc size represents value. It's excellent for visualizing tree structures like org charts, file systems, or category breakdowns. Nodes can have nested `children`, and arcs animate on entry and update. Segments are filled with their solid series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
+The **Sunburst Chart** displays hierarchical data as concentric rings, where each ring represents a level in the hierarchy and arc size represents value. It's excellent for visualizing tree structures like org charts, file systems, or category breakdowns. Nodes can have nested `children`, and arcs animate on entry and update. Segments are filled with a translucent tint of their series color and separated by a constant-width gap (`padWidth`); hovering one dims the rest.
 
 > [!NOTE]
 > For the full API, see the [Charts API Reference](/docs/api/@ripl/charts/).

--- a/packages/charts/OPTIONS.md
+++ b/packages/charts/OPTIONS.md
@@ -78,7 +78,8 @@ all.
   scale with the segment. `padWidth` takes precedence wherever it is
   **provided** — `padWidth: 0` means *no padding*, not *fall back to
   `padAngle`* — so animating it up from `0` is continuous. It is distinct from
-  `gap`, which separates non-radial marks along an axis.
+  `gap`, which separates non-radial marks along an axis. Charts drawing radial
+  segments (`pie`, `polar-area`, `sunburst`, `chord`) default it to `2`.
 - **Radii accept `number | \`${number}%\``**: a value ≤ 1 or a percent string is a
   fraction of the outer radius, a value > 1 is pixels. `innerRadius`,
   `outerRadius`.

--- a/packages/charts/src/charts/arc-diagram.ts
+++ b/packages/charts/src/charts/arc-diagram.ts
@@ -462,6 +462,8 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
                     stroke: setColorAlpha(color, 0.4),
                     lineWidth: linkWidth(link),
                     opacity: 0,
+                    // An open path's fill test closes it against its chord, so a large arc would swallow every smaller one beneath it.
+                    pointerEvents: 'stroke',
                     data: {
                         points,
                         opacity: 1,

--- a/packages/charts/src/charts/chord.ts
+++ b/packages/charts/src/charts/chord.ts
@@ -310,7 +310,7 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
             } = this.options;
 
             const padWidth = resolveSegmentPadWidth(this.options.padWidth, this.options.padAngle);
-            const padAngle = padWidth === undefined ? this.options.padAngle! : 0;
+            const padAngle = padWidth === undefined ? (this.options.padAngle ?? 0) : 0;
 
             const colorGenerator = this.colorGenerator;
 

--- a/packages/charts/src/charts/chord.ts
+++ b/packages/charts/src/charts/chord.ts
@@ -75,6 +75,8 @@ const RIBBON_REST_ALPHA = 0.2;
 const RIBBON_HOVER_ALPHA = 0.5;
 /** Stroke opacity for a ribbon. */
 const RIBBON_STROKE_ALPHA = 0.4;
+/** Fill opacity an outer arc carries at rest, matching the bar series so the two read as one family. */
+const SEGMENT_REST_ALPHA = 0.78;
 
 /** Options for configuring a {@link ChordChart}. */
 export interface ChordChartOptions extends BaseChartOptions {
@@ -367,7 +369,7 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                     radius: 0,
                     innerRadius: 0,
                     padWidth,
-                    fill: arc.color,
+                    fill: setColorAlpha(arc.color, SEGMENT_REST_ALPHA),
                     data: {
                         endAngle: arc.endAngle,
                         radius: outerRadius,
@@ -393,7 +395,7 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                         endAngle: arc.endAngle,
                         radius: outerRadius,
                         innerRadius,
-                        fill: arc.color,
+                        fill: setColorAlpha(arc.color, SEGMENT_REST_ALPHA),
                     } as Partial<ArcState>;
 
                     this._attachArcHover(segment, arc);

--- a/packages/charts/src/charts/chord.ts
+++ b/packages/charts/src/charts/chord.ts
@@ -16,6 +16,7 @@ import type {
 } from '../core/options';
 
 import {
+    resolveSegmentPadWidth,
     resolveValueFormat,
 } from '../core/options';
 
@@ -68,8 +69,6 @@ import {
     arrayJoin,
 } from '@ripl/utilities';
 
-/** Fill opacity for an outer arc at rest (full opacity on hover). */
-const ARC_REST_ALPHA = 0.8;
 /** Fill opacity for a ribbon at rest. */
 const RIBBON_REST_ALPHA = 0.2;
 /** Fill opacity for a ribbon while hovered. */
@@ -85,8 +84,16 @@ export interface ChordChartOptions extends BaseChartOptions {
     matrix: number[][];
     /** Explicit color per group; falls back to the generated palette when omitted. */
     palette?: string[];
-    /** Angular gap (in radians) between adjacent outer arcs. Defaults to 0.04. */
+    /**
+     * Angular gap (in radians) between adjacent outer arcs, taken out of the ring before the arcs are
+     * sized, so it also shifts where the ribbons attach.
+     *
+     * @deprecated Use {@link ChordChartOptions.padWidth} for a gap of constant width. Still honored
+     * when `padWidth` is not set, so existing charts keep their look.
+     */
     padAngle?: number;
+    /** Gap between adjacent outer arcs, in logical pixels. Arcs face each other with parallel edges a constant distance apart, and the ring is not resized, so the ribbons keep their attachment points. Defaults to 2; pass 0 for touching arcs. Takes precedence over the deprecated `padAngle`. */
+    padWidth?: number;
     /** Legend configuration (`true`/`false`, a position, or detailed legend options). */
     legend?: ChartLegendInput;
     /** Format applied to flow values shown as text (e.g. tooltips). */
@@ -300,8 +307,10 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 groups: labels,
                 matrix,
                 palette: colors,
-                padAngle = 0.04,
             } = this.options;
+
+            const padWidth = resolveSegmentPadWidth(this.options.padWidth, this.options.padAngle);
+            const padAngle = padWidth === undefined ? this.options.padAngle! : 0;
 
             const colorGenerator = this.colorGenerator;
 
@@ -357,10 +366,8 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                     endAngle: arc.startAngle,
                     radius: 0,
                     innerRadius: 0,
-                    padAngle: 0,
-                    fill: setColorAlpha(arc.color, ARC_REST_ALPHA),
-                    stroke: arc.color,
-                    lineWidth: 1,
+                    padWidth,
+                    fill: arc.color,
                     data: {
                         endAngle: arc.endAngle,
                         radius: outerRadius,
@@ -380,13 +387,13 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 const segment = group.query('arc') as Arc;
 
                 if (segment) {
+                    segment.padWidth = padWidth;
                     segment.data = {
                         startAngle: arc.startAngle,
                         endAngle: arc.endAngle,
                         radius: outerRadius,
                         innerRadius,
-                        fill: setColorAlpha(arc.color, ARC_REST_ALPHA),
-                        stroke: arc.color,
+                        fill: arc.color,
                     } as Partial<ArcState>;
 
                     this._attachArcHover(segment, arc);
@@ -401,9 +408,6 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 ...arcEntryGroups,
                 ...arcUpdateGroups,
             ];
-
-            // Outer arcs map 1:1 to legend items (by id), so register them for legend hover-highlight.
-            this.registerHighlightGroups(this._arcGroups);
 
             // Draw ribbons
             const {
@@ -472,6 +476,17 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 ...ribbonUpdateGroups,
             ];
 
+            // Outer arcs map 1:1 to legend items by id; a ribbon is incident to the two arcs it joins.
+            const ribbonOwners = new Map(layout.ribbons.map(ribbon => [
+                ribbon.id,
+                [`arc-${ribbon.sourceLabel}`, `arc-${ribbon.targetLabel}`],
+            ]));
+
+            this.registerHighlightGroups(
+                [...this._arcGroups, ...this._ribbonGroups],
+                group => ribbonOwners.get(group.id) ?? group.id
+            );
+
             // Sequential animation: arcs first, then ribbons
             const entryArcs = arcEntryGroups.flatMap(g => g.getElementsByType('arc')) as Arc[];
 
@@ -538,10 +553,14 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 };
             },
             content: () => `${arc.label}: ${formatValue(arc.value)}`,
-            highlight: { fill: arc.color },
-            restore: { fill: setColorAlpha(arc.color, ARC_REST_ALPHA) },
-            onEnter: point => this.emit('segmententer', payload(point)),
-            onLeave: point => this.emit('segmentleave', payload(point)),
+            onEnter: point => {
+                this.highlightSeries(arc.id);
+                this.emit('segmententer', payload(point));
+            },
+            onLeave: point => {
+                this.highlightSeries(null);
+                this.emit('segmentleave', payload(point));
+            },
             onClick: point => this.emit('segmentclick', payload(point)),
         });
     }

--- a/packages/charts/src/charts/pie.ts
+++ b/packages/charts/src/charts/pie.ts
@@ -74,6 +74,7 @@ import {
     createPolyline,
     elementIsArc,
     scaleContinuous,
+    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -84,6 +85,9 @@ import {
 
 /** Slices narrower than this angle (radians) omit their label to avoid clutter. */
 const MIN_LABEL_ANGLE = 0.15;
+
+/** Fill opacity a segment carries at rest, matching the bar series so the two read as one family. */
+const SEGMENT_REST_ALPHA = 0.78;
 
 /** Options for configuring a {@link PieChart}. */
 export interface PieChartOptions<TData = unknown> extends BaseChartOptions {
@@ -270,7 +274,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     cy: segmentCy,
                     startAngle: segmentStart,
                     padWidth: segmentPad,
-                    fill: segmentColor,
+                    fill: setColorAlpha(segmentColor, SEGMENT_REST_ALPHA),
                     endAngle: segmentStart,
                     radius: 0,
                     innerRadius: 0,
@@ -339,7 +343,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 const labelText = group.query('text') as Text;
                 const connector = group.query('polyline') as Polyline;
 
-                const resolvedColor = item.color ?? (arc.fill as string);
+                const resolvedColor = item.color;
 
                 const arcData = {
                     cx: segmentCx,
@@ -348,7 +352,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     innerRadius,
                     startAngle: segmentStart,
                     endAngle: segmentEnd,
-                    fill: resolvedColor,
+                    fill: setColorAlpha(resolvedColor, SEGMENT_REST_ALPHA),
                 } as Partial<ArcState>;
 
                 arc.padWidth = segmentPad;
@@ -494,7 +498,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 };
             },
             content: () => formatValue(value),
-            // Segments are solid at rest, so the hover reads as the others dimming rather than this one lifting.
+            // Every segment shares one rest tint, so the hover reads as the others dimming rather than this one lifting.
             onEnter: point => {
                 this.highlightSeries(key);
                 this.emit('segmententer', payload(point));

--- a/packages/charts/src/charts/pie.ts
+++ b/packages/charts/src/charts/pie.ts
@@ -21,6 +21,7 @@ import type {
 } from '../core/options';
 
 import {
+    DEFAULT_SEGMENT_PAD_WIDTH,
     normalizeSegmentLabels,
     resolveValueFormat,
 } from '../core/options';
@@ -73,7 +74,6 @@ import {
     createPolyline,
     elementIsArc,
     scaleContinuous,
-    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -81,9 +81,6 @@ import {
     arrayJoin,
     numberSum,
 } from '@ripl/utilities';
-
-/** The opacity applied to a segment's fill at rest (full opacity is used on hover). */
-const REST_ALPHA = 0.55;
 
 /** Slices narrower than this angle (radians) omit their label to avoid clutter. */
 const MIN_LABEL_ANGLE = 0.15;
@@ -102,6 +99,8 @@ export interface PieChartOptions<TData = unknown> extends BaseChartOptions {
     colorBy?: keyof TData | ((item: TData) => string);
     /** Inner hole radius (donut). A value `<= 1` is a fraction of the outer radius; larger values are absolute pixels. Defaults to 0 (a solid pie). */
     innerRadius?: number;
+    /** Gap between adjacent segments, in logical pixels. Segments face each other with parallel edges a constant distance apart, rather than a wedge that widens with radius. Defaults to 2; pass 0 for touching segments. */
+    padWidth?: number;
     /** Legend configuration. Shown by default; pass `false` to hide. */
     legend?: ChartLegendInput;
     /**
@@ -166,7 +165,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
 
     public async render() {
         return super.render((scene, renderer) => {
-            const { data, key, value, label, colorBy } = this.options;
+            const { data, key, value, label, colorBy, padWidth = DEFAULT_SEGMENT_PAD_WIDTH } = this.options;
 
             const getKey = resolveAccessor<TData, string>(key);
             const getValue = resolveAccessor<TData, number>(value);
@@ -204,7 +203,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
             const total = numberSum(activeData, getValue);
             const scale = scaleContinuous([0, total], [0, TAU], { clamp: true });
             const offset = TAU / 4;
-            const padAngle = activeData.length <= 1 ? 0 : 0.1 / activeData.length;
+            const segmentPad = activeData.length <= 1 ? 0 : padWidth;
 
             let startAngle = -offset;
 
@@ -233,7 +232,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     cy,
                     startAngle,
                     endAngle,
-                    padAngle,
+                    padWidth: segmentPad,
                     radius,
                     innerRadius,
                     item,
@@ -260,7 +259,7 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     cy: segmentCy,
                     startAngle: segmentStart,
                     endAngle: segmentEnd,
-                    padAngle: segmentPad,
+                    padWidth: segmentPad,
                     radius,
                     innerRadius,
                 } = item;
@@ -270,10 +269,8 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     cx: segmentCx,
                     cy: segmentCy,
                     startAngle: segmentStart,
-                    padAngle: segmentPad,
-                    stroke: segmentColor,
-                    fill: setColorAlpha(segmentColor, REST_ALPHA),
-                    lineWidth: 2,
+                    padWidth: segmentPad,
+                    fill: segmentColor,
                     endAngle: segmentStart,
                     radius: 0,
                     innerRadius: 0,
@@ -285,7 +282,6 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 });
 
                 this._attachSegmentHover(segmentArc, {
-                    color: segmentColor,
                     value: segmentValue,
                     label: segmentLabel,
                     key: segmentKey,
@@ -336,14 +332,14 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     innerRadius,
                     startAngle: segmentStart,
                     endAngle: segmentEnd,
-                    padAngle: segmentPad,
+                    padWidth: segmentPad,
                 } = item;
 
                 const arc = group.query('arc') as Arc;
                 const labelText = group.query('text') as Text;
                 const connector = group.query('polyline') as Polyline;
 
-                const resolvedColor = item.color ?? (arc.stroke as string);
+                const resolvedColor = item.color ?? (arc.fill as string);
 
                 const arcData = {
                     cx: segmentCx,
@@ -352,14 +348,12 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                     innerRadius,
                     startAngle: segmentStart,
                     endAngle: segmentEnd,
-                    padAngle: segmentPad,
-                    stroke: resolvedColor,
-                    fill: setColorAlpha(resolvedColor, REST_ALPHA),
+                    fill: resolvedColor,
                 } as Partial<ArcState>;
 
+                arc.padWidth = segmentPad;
                 arc.data = arcData;
                 this._attachSegmentHover(arc, {
-                    color: resolvedColor,
                     value: item.value,
                     label: item.label,
                     key: item.key,
@@ -473,11 +467,10 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
         });
     }
 
-    private _attachSegmentHover(arc: Arc, segment: { color: string;
-        value: number;
+    private _attachSegmentHover(arc: Arc, segment: { value: number;
         label: string;
         key: string; }) {
-        const { color, value, label, key } = segment;
+        const { value, label, key } = segment;
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -501,10 +494,15 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 };
             },
             content: () => formatValue(value),
-            highlight: { fill: color },
-            restore: { fill: setColorAlpha(color, REST_ALPHA) },
-            onEnter: point => this.emit('segmententer', payload(point)),
-            onLeave: point => this.emit('segmentleave', payload(point)),
+            // Segments are solid at rest, so the hover reads as the others dimming rather than this one lifting.
+            onEnter: point => {
+                this.highlightSeries(key);
+                this.emit('segmententer', payload(point));
+            },
+            onLeave: point => {
+                this.highlightSeries(null);
+                this.emit('segmentleave', payload(point));
+            },
             onClick: point => this.emit('segmentclick', payload(point)),
         });
     }

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -162,6 +162,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
 
     private _groups: Group[] = [];
     private _gridGroup?: Group;
+    private _gridLabelGroup?: Group;
     private _gridRings: Circle[] = [];
     private _gridLabels: Text[] = [];
     private _gridLines: Line[] = [];
@@ -201,7 +202,15 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 zIndex: 0,
             });
 
+            // Segments are opaque, so the value labels are read off a band that paints above them.
+            this._gridLabelGroup = createGroup({
+                id: 'polar-grid-labels',
+                class: 'polar-grid',
+                zIndex: 1,
+            });
+
             this.scene.add(this._gridGroup);
+            this.scene.add(this._gridLabelGroup);
         }
 
         // --- Concentric rings ---
@@ -279,7 +288,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 },
             });
 
-            this._gridGroup!.add(label);
+            this._gridLabelGroup!.add(label);
 
             return label;
         });
@@ -358,7 +367,10 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
         ];
 
         // Animate: staggered entry for new elements, smooth transition for updates
-        const allElements = this._gridGroup!.children;
+        const allElements = [
+            ...this._gridGroup!.children,
+            ...this._gridLabelGroup!.children,
+        ];
 
         if (isEntry) {
             return this.renderer.transition(allElements, (element, index, length) => ({

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -74,6 +74,7 @@ import {
     easeOutQuint,
     elementIsArc,
     scaleRadial,
+    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -84,6 +85,9 @@ import {
     numberMaxOf,
     typeIsFunction,
 } from '@ripl/utilities';
+
+/** Fill opacity a segment carries at rest, matching the bar series so the two read as one family. */
+const SEGMENT_REST_ALPHA = 0.78;
 
 /** Options for configuring a {@link PolarAreaChart}. */
 export interface PolarAreaChartOptions<TData = unknown> extends BaseChartOptions {
@@ -202,7 +206,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 zIndex: 0,
             });
 
-            // Segments are opaque, so the value labels are read off a band that paints above them.
+            // Value labels are read off a band of their own, so a translucent segment never shows through them.
             this._gridLabelGroup = createGroup({
                 id: 'polar-grid-labels',
                 class: 'polar-grid',
@@ -520,7 +524,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     endAngle: startAngle, // animate angle grow subtly
                     padAngle,
                     padWidth,
-                    fill: color,
+                    fill: setColorAlpha(color, SEGMENT_REST_ALPHA),
                     radius: innerRadius, // animate radial growth
                     innerRadius,
                     data: {
@@ -587,7 +591,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 const label = group.query('text') as Text;
                 const connector = group.query('polyline') as Polyline;
 
-                const resolvedColor = item.color ?? (arc.fill as string);
+                const resolvedColor = item.color;
 
                 const arcData = {
                     cx,
@@ -597,7 +601,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle,
                     padAngle,
-                    fill: resolvedColor,
+                    fill: setColorAlpha(resolvedColor, SEGMENT_REST_ALPHA),
                 } as Partial<ArcState>;
 
                 arc.padWidth = padWidth;

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -22,6 +22,7 @@ import type {
 
 import {
     normalizeSegmentLabels,
+    resolveSegmentPadWidth,
     resolveValueFormat,
 } from '../core/options';
 
@@ -73,7 +74,6 @@ import {
     easeOutQuint,
     elementIsArc,
     scaleRadial,
-    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -84,9 +84,6 @@ import {
     numberMaxOf,
     typeIsFunction,
 } from '@ripl/utilities';
-
-/** The opacity applied to a segment's fill at rest (full opacity is used on hover). */
-const REST_ALPHA = 0.55;
 
 /** Options for configuring a {@link PolarAreaChart}. */
 export interface PolarAreaChartOptions<TData = unknown> extends BaseChartOptions {
@@ -104,8 +101,15 @@ export interface PolarAreaChartOptions<TData = unknown> extends BaseChartOptions
     innerRadius?: number;
     /** Maximum radius ratio (0 - 0.5). Defaults to 0.45 (similar to pie chart). */
     maxRadiusRatio?: number;
-    /** Padding angle between segments in radians. Defaults to 0.02 */
+    /**
+     * Padding angle between segments in radians, producing a wedge-shaped gap that widens with radius.
+     *
+     * @deprecated Use {@link PolarAreaChartOptions.padWidth} for a gap of constant width. Still honored
+     * when `padWidth` is not set, so existing charts keep their look.
+     */
     padAngle?: number;
+    /** Gap between adjacent segments, in logical pixels. Segments face each other with parallel edges a constant distance apart, rather than a wedge that widens with radius. Defaults to 2; pass 0 for touching segments. Takes precedence over the deprecated `padAngle`. */
+    padWidth?: number;
     /** Number of concentric grid rings. Defaults to 4 */
     levels?: number;
     /** Legend showing each segment. Shown by default (more than one segment); pass `false` to hide. */
@@ -386,6 +390,8 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 levels = 4,
             } = this.options;
 
+            const padWidth = resolveSegmentPadWidth(this.options.padWidth, this.options.padAngle);
+
             if (!data.length) {
                 return Promise.resolve();
             }
@@ -466,6 +472,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle,
                     padAngle,
+                    padWidth,
                     radius,
                     innerRadius: size * innerRadius,
                     item,
@@ -488,6 +495,7 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle,
                     padAngle,
+                    padWidth,
                     radius,
                     innerRadius,
                 } = item;
@@ -499,9 +507,8 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle: startAngle, // animate angle grow subtly
                     padAngle,
-                    stroke: color,
-                    fill: setColorAlpha(color, REST_ALPHA),
-                    lineWidth: 2,
+                    padWidth,
+                    fill: color,
                     radius: innerRadius, // animate radial growth
                     innerRadius,
                     data: {
@@ -511,7 +518,6 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 });
 
                 this._attachSegmentHover(segmentArc, {
-                    color,
                     value: item.value,
                     label,
                     key,
@@ -562,13 +568,14 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle,
                     padAngle,
+                    padWidth,
                 } = item;
 
                 const arc = group.query('arc') as Arc;
                 const label = group.query('text') as Text;
                 const connector = group.query('polyline') as Polyline;
 
-                const resolvedColor = item.color ?? (arc.stroke as string);
+                const resolvedColor = item.color ?? (arc.fill as string);
 
                 const arcData = {
                     cx,
@@ -578,14 +585,13 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                     startAngle,
                     endAngle,
                     padAngle,
-                    stroke: resolvedColor,
-                    fill: setColorAlpha(resolvedColor, REST_ALPHA),
+                    fill: resolvedColor,
                 } as Partial<ArcState>;
 
+                arc.padWidth = padWidth;
                 arc.data = arcData;
 
                 this._attachSegmentHover(arc, {
-                    color: resolvedColor,
                     value: item.value,
                     label: item.label,
                     key: item.key,
@@ -696,11 +702,10 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
         });
     }
 
-    private _attachSegmentHover(arc: Arc, segment: { color: string;
-        value: number;
+    private _attachSegmentHover(arc: Arc, segment: { value: number;
         label: string;
         key: string; }) {
-        const { color, value, label, key } = segment;
+        const { value, label, key } = segment;
         const formatValue = resolveValueFormat(this.options.format);
 
         const payload = (point: { x: number;
@@ -724,10 +729,14 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 };
             },
             content: () => `${label}: ${formatValue(value)}`,
-            highlight: { fill: color },
-            restore: { fill: setColorAlpha(color, REST_ALPHA) },
-            onEnter: point => this.emit('segmententer', payload(point)),
-            onLeave: point => this.emit('segmentleave', payload(point)),
+            onEnter: point => {
+                this.highlightSeries(key);
+                this.emit('segmententer', payload(point));
+            },
+            onLeave: point => {
+                this.highlightSeries(null);
+                this.emit('segmentleave', payload(point));
+            },
             onClick: point => this.emit('segmentclick', payload(point)),
         });
     }

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -341,6 +341,8 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
                     stroke: setColorAlpha(itemColor, REST_ALPHA),
                     lineWidth: thickness,
                     lineCap,
+                    // An open arc's fill test closes it against its chord, so an outer bar would swallow every inner ring.
+                    pointerEvents: 'stroke',
                     data: {
                         endAngle,
                     } as Partial<ArcState>,

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -341,7 +341,6 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
                     stroke: setColorAlpha(itemColor, REST_ALPHA),
                     lineWidth: thickness,
                     lineCap,
-                    // An open arc's fill test closes it against its chord, so an outer bar would swallow every inner ring.
                     pointerEvents: 'stroke',
                     data: {
                         endAngle,

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -53,6 +53,7 @@ import {
     createGroup,
     easeOutQuint,
     scaleContinuous,
+    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -60,6 +61,9 @@ import {
     arrayJoin,
     numberSum,
 } from '@ripl/utilities';
+
+/** Fill opacity a segment carries at rest, matching the bar series so the two read as one family. */
+const SEGMENT_REST_ALPHA = 0.78;
 
 /** A node in a sunburst hierarchy with optional nested children and an optional typed datum. */
 export interface SunburstNode<TData = unknown> {
@@ -271,7 +275,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                     radius: 0,
                     innerRadius: 0,
                     padWidth,
-                    fill: arc.color,
+                    fill: setColorAlpha(arc.color, SEGMENT_REST_ALPHA),
                     data: {
                         endAngle: arc.endAngle,
                         radius: outerRadius,
@@ -301,7 +305,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                         endAngle: arc.endAngle,
                         radius: outerRadius,
                         innerRadius,
-                        fill: arc.color,
+                        fill: setColorAlpha(arc.color, SEGMENT_REST_ALPHA),
                     } as Partial<ArcState>;
 
                     this._attachSegmentHover(segment, arc);

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -324,8 +324,11 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                 node.children?.forEach(child => assignRoot(child, rootId));
             };
             data.forEach(node => assignRoot(node, node.id));
-            // Owning its own id as well lets a segment hover isolate that one ring, not the whole subtree.
-            this.registerHighlightGroups(this._groups, group => [rootOf.get(group.id) ?? group.id, group.id]);
+            // Namespaced so a root segment's own owner cannot collide with the series owner of its subtree.
+            this.registerHighlightGroups(this._groups, group => [
+                `series:${rootOf.get(group.id) ?? group.id}`,
+                `node:${group.id}`,
+            ]);
 
             // Animate entries
             const entryArcs = entryGroups.flatMap(g => g.getElementsByType('arc')) as Arc[];
@@ -348,6 +351,11 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
 
             return Promise.all([entriesTransition, updatesTransition]);
         });
+    }
+
+    /** Legend items are top-level nodes, so a legend hover addresses the whole branch by its series owner. */
+    protected override highlightSeries(id: string | null) {
+        super.highlightSeries(id === null ? null : `series:${id}`);
     }
 
     private _attachSegmentHover(segment: Arc, arc: FlattenedArc<TData>) {
@@ -376,11 +384,11 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
             },
             content: () => `${arc.label}: ${formatValue(arc.value)}`,
             onEnter: point => {
-                this.highlightSeries(arc.id);
+                super.highlightSeries(`node:${arc.id}`);
                 this.emit('nodeenter', payload(point));
             },
             onLeave: point => {
-                this.highlightSeries(null);
+                super.highlightSeries(null);
                 this.emit('nodeleave', payload(point));
             },
             onClick: point => this.emit('nodeclick', payload(point)),

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -16,6 +16,7 @@ import type {
 } from '../core/options';
 
 import {
+    DEFAULT_SEGMENT_PAD_WIDTH,
     resolveValueFormat,
 } from '../core/options';
 
@@ -52,7 +53,6 @@ import {
     createGroup,
     easeOutQuint,
     scaleContinuous,
-    setColorAlpha,
     TAU,
 } from '@ripl/core';
 
@@ -60,9 +60,6 @@ import {
     arrayJoin,
     numberSum,
 } from '@ripl/utilities';
-
-/** The opacity applied to a segment's fill at rest (full opacity is used on hover). */
-const REST_ALPHA = 0.65;
 
 /** A node in a sunburst hierarchy with optional nested children and an optional typed datum. */
 export interface SunburstNode<TData = unknown> {
@@ -84,6 +81,8 @@ export interface SunburstNode<TData = unknown> {
 export interface SunburstChartOptions<TData = unknown> extends BaseChartOptions {
     /** The root nodes of the hierarchy to render as concentric rings. */
     data: SunburstNode<TData>[];
+    /** Gap between adjacent segments, in logical pixels. Segments face each other with parallel edges a constant distance apart, rather than a wedge that widens with radius. Defaults to 2; pass 0 for touching segments. */
+    padWidth?: number;
     /** Legend configuration, listing the top-level nodes. */
     legend?: ChartLegendInput;
     /** Format applied to node values shown as text (e.g. tooltips). */
@@ -206,7 +205,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
 
     public async render() {
         return super.render(async (scene, renderer) => {
-            const { data } = this.options;
+            const { data, padWidth = DEFAULT_SEGMENT_PAD_WIDTH } = this.options;
 
             const colorGenerator = this.colorGenerator;
 
@@ -262,7 +261,6 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
             const entryGroups = entries.map(arc => {
                 const innerRadius = innerBaseRadius + arc.depth * ringWidth;
                 const outerRadius = innerRadius + ringWidth - 2;
-                const padAngle = 0.02;
 
                 const segment = createArc({
                     id: `${arc.id}-arc`,
@@ -272,10 +270,8 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                     endAngle: arc.startAngle,
                     radius: 0,
                     innerRadius: 0,
-                    padAngle,
-                    fill: setColorAlpha(arc.color, REST_ALPHA),
-                    stroke: arc.color,
-                    lineWidth: 1,
+                    padWidth,
+                    fill: arc.color,
                     data: {
                         endAngle: arc.endAngle,
                         radius: outerRadius,
@@ -297,6 +293,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                 const segment = group.query('arc') as Arc;
 
                 if (segment) {
+                    segment.padWidth = padWidth;
                     segment.data = {
                         cx,
                         cy,
@@ -304,8 +301,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                         endAngle: arc.endAngle,
                         radius: outerRadius,
                         innerRadius,
-                        fill: setColorAlpha(arc.color, REST_ALPHA),
-                        stroke: arc.color,
+                        fill: arc.color,
                     } as Partial<ArcState>;
 
                     this._attachSegmentHover(segment, arc);
@@ -328,7 +324,8 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                 node.children?.forEach(child => assignRoot(child, rootId));
             };
             data.forEach(node => assignRoot(node, node.id));
-            this.registerHighlightGroups(this._groups, group => rootOf.get(group.id) ?? group.id);
+            // Owning its own id as well lets a segment hover isolate that one ring, not the whole subtree.
+            this.registerHighlightGroups(this._groups, group => [rootOf.get(group.id) ?? group.id, group.id]);
 
             // Animate entries
             const entryArcs = entryGroups.flatMap(g => g.getElementsByType('arc')) as Arc[];
@@ -378,10 +375,14 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                 };
             },
             content: () => `${arc.label}: ${formatValue(arc.value)}`,
-            highlight: { fill: arc.color },
-            restore: { fill: setColorAlpha(arc.color, REST_ALPHA) },
-            onEnter: point => this.emit('nodeenter', payload(point)),
-            onLeave: point => this.emit('nodeleave', payload(point)),
+            onEnter: point => {
+                this.highlightSeries(arc.id);
+                this.emit('nodeenter', payload(point));
+            },
+            onLeave: point => {
+                this.highlightSeries(null);
+                this.emit('nodeleave', payload(point));
+            },
             onClick: point => this.emit('nodeclick', payload(point)),
         });
     }

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -8,6 +8,7 @@ import {
 import type {
     Context,
     ContextExport,
+    Element,
     EventMap,
     Group,
     Renderer,
@@ -90,6 +91,10 @@ import {
     Tooltip,
 } from '../components/tooltip';
 
+import type {
+    Disposable,
+} from '@ripl/utilities';
+
 import {
     typeIsArray,
     typeIsFunction,
@@ -134,6 +139,21 @@ const HIGHLIGHT_REST = Symbol('highlight-rest');
 
 interface HighlightHost {
     [HIGHLIGHT_REST]?: number;
+}
+
+/**
+ * The opacity an element is settling to, read from the target state a render stashed on `element.data`,
+ * or `undefined` when the element does not animate its opacity. Reading the target (rather than the
+ * instantaneous value) keeps a hover placed mid-fade-in from recording `0` as an element's rest.
+ */
+function targetOpacityOf(element: Element): number | undefined {
+    const target = (element.data as { opacity?: unknown } | null | undefined)?.opacity;
+
+    return typeIsNumber(target) ? target : undefined;
+}
+
+function highlightOwnersInclude(owners: string | string[], id: string): boolean {
+    return typeIsArray(owners) ? owners.includes(id) : owners === id;
 }
 
 /**
@@ -189,6 +209,8 @@ export class Chart<
     private _hiddenItems: Set<string> = new Set();
     private _highlightGroups: Array<{ group: Group;
         owners: string | string[]; }> = [];
+    private _highlightDisposers: Disposable[] = [];
+    private _activeHighlight: string | null = null;
 
     /** The rendering context the chart's scene draws into. */
     public get context(): Context {
@@ -536,10 +558,33 @@ export class Chart<
      * @param resolveId - Maps a group to the legend item id(s) it belongs to. Defaults to `group.id`.
      */
     protected registerHighlightGroups(groups: Group[], resolveId: (group: Group) => string | string[] = group => group.id) {
+        this._highlightDisposers.forEach(disposer => disposer.dispose());
+
         this._highlightGroups = groups.map(group => ({
             group,
             owners: resolveId(group),
         }));
+
+        this._highlightDisposers = this._highlightGroups.map(({ group }) => group.once('destroyed', () => {
+            this._highlightGroups = this._highlightGroups.filter(entry => entry.group !== group);
+            this._dropOrphanedHighlight();
+        }, { self: true }));
+
+        this._dropOrphanedHighlight();
+    }
+
+    /**
+     * Restores the chart when the highlighted group is gone. A destroyed element never fires
+     * `mouseleave`, so an exiting hovered segment would otherwise strand every other group dimmed.
+     */
+    private _dropOrphanedHighlight() {
+        const active = this._activeHighlight;
+
+        if (active === null || this._highlightGroups.some(({ owners }) => highlightOwnersInclude(owners, active))) {
+            return;
+        }
+
+        this.highlightSeries(null);
     }
 
     /**
@@ -549,11 +594,14 @@ export class Chart<
      *
      * Dims the leaf elements of each group rather than the group itself: a group's opacity does not
      * cascade multiplicatively, and the leaves carry no explicit `opacity` (so a group-level tween is
-     * a no-op; `element.interpolate` skips nil current values). Each leaf's rest opacity is captured
-     * once on the element (via a Symbol slot, like `applyHoverHighlight`), so hidden elements stay
-     * hidden and restoring returns to the true value.
+     * a no-op; `element.interpolate` skips nil current values). Each leaf's rest opacity is remembered
+     * on the element (via a Symbol slot, like `applyHoverHighlight`), tracking the target a render
+     * stashed on `.data` where there is one, so hidden elements stay hidden, an element caught
+     * mid-fade-in still restores to full, and restoring returns to the true value.
      */
     protected highlightSeries(id: string | null) {
+        this._activeHighlight = id;
+
         if (this._highlightGroups.length === 0) {
             return;
         }
@@ -561,19 +609,22 @@ export class Chart<
         const { duration, ease } = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         this._highlightGroups.forEach(({ group, owners }) => {
-            const active = id === null || (typeIsArray(owners) ? owners.includes(id) : owners === id);
+            const active = id === null || highlightOwnersInclude(owners, id);
 
             group.graph(false).forEach(element => {
                 const host = element as unknown as HighlightHost;
+                const target = targetOpacityOf(element);
 
-                if (host[HIGHLIGHT_REST] === undefined) {
-                    const rest = element.opacity ?? 1;
-                    host[HIGHLIGHT_REST] = rest;
-                    // Seed a concrete opacity so the transition below has a non-nil value to animate.
-                    element.opacity = rest;
+                if (target !== undefined) {
+                    host[HIGHLIGHT_REST] = target;
+                } else if (host[HIGHLIGHT_REST] === undefined) {
+                    host[HIGHLIGHT_REST] = element.opacity ?? 1;
                 }
 
                 const rest = host[HIGHLIGHT_REST]!;
+
+                // Seed a concrete opacity only where there is none, or a fade-in would snap to full.
+                element.opacity ??= rest;
 
                 this.renderer.transition(element, {
                     duration,
@@ -593,6 +644,8 @@ export class Chart<
 
     /** Destroys the chart, its scene, context, and cleans up all event subscriptions. */
     public destroy() {
+        this._highlightDisposers.forEach(disposer => disposer.dispose());
+        this._highlightDisposers = [];
         this.scene.destroy(true);
         super.destroy();
     }

--- a/packages/charts/src/core/interaction.ts
+++ b/packages/charts/src/core/interaction.ts
@@ -47,10 +47,10 @@ export interface HoverHighlightOptions<TElement extends Element> {
         /** Easing applied to the highlight/restore transition. */
         ease: Ease;
     };
-    /** Target state applied while hovered. */
-    highlight: StateOf<TElement>;
-    /** Target state applied when the pointer leaves. */
-    restore: StateOf<TElement>;
+    /** Target state applied while hovered. Omit for a chart whose hover treatment is carried entirely by `onEnter`/`onLeave`. */
+    highlight?: StateOf<TElement>;
+    /** Target state applied when the pointer leaves. Omit alongside `highlight`. */
+    restore?: StateOf<TElement>;
     /** Optional tooltip to show/hide alongside the highlight. */
     tooltip?: HoverTooltip;
     /** Resolves the tooltip anchor point (called on enter). */
@@ -130,6 +130,10 @@ export function applyHoverHighlight<TElement extends Element>(
 
         onEnter?.({ ...pointer });
 
+        if (!highlight) {
+            return;
+        }
+
         const { duration, ease } = animation();
 
         renderer.transition(element, {
@@ -143,6 +147,10 @@ export function applyHoverHighlight<TElement extends Element>(
         tooltip?.hide();
 
         onLeave?.({ ...pointer });
+
+        if (!restore) {
+            return;
+        }
 
         const { duration, ease } = animation();
 

--- a/packages/charts/src/core/interaction.ts
+++ b/packages/charts/src/core/interaction.ts
@@ -32,8 +32,8 @@ export interface InteractionPoint {
     y: number;
 }
 
-/** Options describing how an element should respond to hover. */
-export interface HoverHighlightOptions<TElement extends Element> {
+/** Options describing how an element should respond to hover, beyond its {@link HoverHighlightStates}. */
+export interface HoverHighlightOptions {
     /** Renderer used to run the highlight/restore transitions. */
     renderer: Renderer;
     /**
@@ -47,10 +47,6 @@ export interface HoverHighlightOptions<TElement extends Element> {
         /** Easing applied to the highlight/restore transition. */
         ease: Ease;
     };
-    /** Target state applied while hovered. Omit for a chart whose hover treatment is carried entirely by `onEnter`/`onLeave`. */
-    highlight?: StateOf<TElement>;
-    /** Target state applied when the pointer leaves. Omit alongside `highlight`. */
-    restore?: StateOf<TElement>;
     /** Optional tooltip to show/hide alongside the highlight. */
     tooltip?: HoverTooltip;
     /** Resolves the tooltip anchor point (called on enter). */
@@ -70,6 +66,24 @@ export interface HoverHighlightOptions<TElement extends Element> {
     onClick?: (point: InteractionPoint) => void;
 }
 
+/**
+ * The pair of states a hover transitions between, given together or not at all: an element handed a
+ * `highlight` without the `restore` that undoes it would be stranded highlighted once the pointer left.
+ *
+ * @typeParam TElement - The element type the states are applied to.
+ */
+export type HoverHighlightStates<TElement extends Element> = {
+    /** Target state applied while hovered. */
+    highlight: StateOf<TElement>;
+    /** Target state applied when the pointer leaves, undoing `highlight`. */
+    restore: StateOf<TElement>;
+} | {
+    /** Omitted for a chart whose hover treatment is carried entirely by `onEnter`/`onLeave`. */
+    highlight?: undefined;
+    /** Omitted alongside `highlight`. */
+    restore?: undefined;
+};
+
 const HOVER_DISPOSERS = Symbol('hover-disposers');
 
 interface HoverHost {
@@ -83,7 +97,7 @@ interface HoverHost {
  */
 export function applyHoverHighlight<TElement extends Element>(
     element: TElement,
-    options: HoverHighlightOptions<TElement>
+    options: HoverHighlightOptions & HoverHighlightStates<TElement>
 ): void {
     const host = element as unknown as HoverHost;
 

--- a/packages/charts/src/core/options.ts
+++ b/packages/charts/src/core/options.ts
@@ -1004,6 +1004,31 @@ export function normalizeSegmentLabels(input?: ChartSegmentLabelsInput, defaults
     };
 }
 
+// Segment padding (radial charts: pie, polar-area, sunburst, chord)
+
+/** The default gap, in logical pixels, between adjacent segments of a radial chart. */
+export const DEFAULT_SEGMENT_PAD_WIDTH = 2;
+
+/**
+ * Resolves the constant-width gap a radial chart separates its segments with, honoring a chart's
+ * deprecated angular `padAngle` option where one is still passed.
+ *
+ * An explicit `padWidth` always wins (including `0`, which means no gap). Otherwise a chart that was
+ * given only the deprecated `padAngle` resolves to `undefined`, leaving `Arc.padAngle` in charge, so
+ * migrating to `padWidth` is opt-in rather than a silent change of look for those charts.
+ *
+ * @param padWidth - The chart's `padWidth` option, in logical pixels.
+ * @param padAngle - The chart's deprecated `padAngle` option, in radians.
+ * @returns The gap to pass as `Arc.padWidth`, or `undefined` to fall back to `padAngle`.
+ */
+export function resolveSegmentPadWidth(padWidth?: number, padAngle?: number): number | undefined {
+    if (padWidth !== undefined) {
+        return padWidth;
+    }
+
+    return padAngle === undefined ? DEFAULT_SEGMENT_PAD_WIDTH : undefined;
+}
+
 // Format helper
 
 

--- a/packages/charts/test/arc-diagram-hit.test.ts
+++ b/packages/charts/test/arc-diagram-hit.test.ts
@@ -1,0 +1,185 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+} from '@ripl/test-utils';
+
+import type {
+    Point,
+} from '@ripl/core';
+
+import {
+    createArcDiagramChart,
+} from '../src';
+
+const WIDTH = 640;
+const HEIGHT = 320;
+
+const NODES = [
+    { id: 'a' },
+    { id: 'b' },
+    { id: 'c' },
+    { id: 'd' },
+    { id: 'e' },
+    { id: 'f' },
+];
+
+const LINKS = [
+    {
+        source: 'a',
+        target: 'f',
+        value: 10,
+    },
+    {
+        source: 'c',
+        target: 'd',
+        value: 1,
+    },
+];
+
+/**
+ * A `Path2D` that keeps the vertices traced through it, so the stubs below can answer fill and
+ * stroke hit tests from real geometry instead of a constant `false`.
+ */
+class RecordingPath2D {
+
+    public vertices: Point[] = [];
+
+    public moveTo(x: number, y: number) {
+        this.vertices.push([x, y]);
+    }
+
+    public lineTo(x: number, y: number) {
+        this.vertices.push([x, y]);
+    }
+
+    public arc() {}
+    public arcTo() {}
+    public addPath() {}
+    public bezierCurveTo() {}
+    public closePath() {}
+    public ellipse() {}
+    public quadraticCurveTo() {}
+    public rect() {}
+    public roundRect() {}
+
+}
+
+/** Even-odd containment against the traced vertices, implicitly closed the way a native fill test closes an open path. */
+function isPointInPolygon(vertices: Point[], x: number, y: number): boolean {
+    let inside = false;
+
+    for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {
+        const [xi, yi] = vertices[i];
+        const [xj, yj] = vertices[j];
+
+        if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+    }
+
+    return inside;
+}
+
+function distanceToSegment(from: Point, to: Point, x: number, y: number): number {
+    const dx = to[0] - from[0];
+    const dy = to[1] - from[1];
+    const lengthSquared = dx * dx + dy * dy;
+    const t = lengthSquared === 0
+        ? 0
+        : Math.max(0, Math.min(1, ((x - from[0]) * dx + (y - from[1]) * dy) / lengthSquared));
+
+    return Math.hypot(x - (from[0] + t * dx), y - (from[1] + t * dy));
+}
+
+function isPointOnStroke(vertices: Point[], x: number, y: number, lineWidth: number): boolean {
+    for (let i = 1; i < vertices.length; i++) {
+        if (distanceToSegment(vertices[i - 1], vertices[i], x, y) <= lineWidth / 2) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+describe('arc diagram hit testing', () => {
+
+    let host: HTMLDivElement;
+    let previousPath2D: typeof globalThis.Path2D;
+
+    beforeEach(() => {
+        previousPath2D = globalThis.Path2D;
+        (globalThis as { Path2D: unknown }).Path2D = RecordingPath2D;
+
+        const stub = mockCanvasContext();
+
+        stub.isPointInPath.mockImplementation(((path: RecordingPath2D, x: number, y: number) => {
+            return isPointInPolygon(path.vertices, x, y);
+        }) as never);
+
+        stub.isPointInStroke.mockImplementation(((path: RecordingPath2D, x: number, y: number) => {
+            return isPointOnStroke(path.vertices, x, y, stub.lineWidth);
+        }) as never);
+
+        host = document.createElement('div');
+        document.body.appendChild(host);
+    });
+
+    afterEach(() => {
+        globalThis.Path2D = previousPath2D;
+        host.remove();
+        vi.restoreAllMocks();
+    });
+
+    async function createChart() {
+        const chart = createArcDiagramChart(host, {
+            autoRender: false,
+            animation: false,
+            nodes: NODES,
+            links: LINKS,
+        });
+
+        const scene = (chart as unknown as { scene: {
+            context: { rescale(width: number, height: number): void };
+            getElementById(id: string): unknown;
+            render(): void;
+        }; }).scene;
+
+        scene.context.rescale(WIDTH, HEIGHT);
+
+        await chart.render();
+        scene.render();
+
+        return {
+            chart,
+            scene,
+        };
+    }
+
+    // The small link's apex sits inside the large link's chord fill, where the large link used to swallow every hover.
+    test('Should resolve a hover on a small link that overlaps a large one to the small link', async () => {
+        const { scene } = await createChart();
+
+        const large = scene.getElementById('arc-a~f') as { points: Point[] };
+        const small = scene.getElementById('arc-c~d') as { points: Point[] };
+
+        expect(large).toBeTruthy();
+        expect(small).toBeTruthy();
+
+        const [x, y] = small.points[Math.floor(small.points.length / 2)];
+
+        const hits = (scene as unknown as {
+            context: { hitTest(events: string[], x: number, y: number): { id: string }[] };
+        }).context.hitTest(['mousemove', 'mouseenter', 'mouseleave'], x, y);
+
+        expect(hits.map(hit => hit.id)).toEqual(['arc-c~d']);
+    });
+
+});

--- a/packages/charts/test/arc-diagram-hit.test.ts
+++ b/packages/charts/test/arc-diagram-hit.test.ts
@@ -31,16 +31,17 @@ const NODES = [
     { id: 'f' },
 ];
 
+// The large link is declared last so it is drawn on top, where an unfixed fill test resolves the hover to it.
 const LINKS = [
-    {
-        source: 'a',
-        target: 'f',
-        value: 10,
-    },
     {
         source: 'c',
         target: 'd',
         value: 1,
+    },
+    {
+        source: 'a',
+        target: 'f',
+        value: 10,
     },
 ];
 
@@ -179,6 +180,8 @@ describe('arc diagram hit testing', () => {
             context: { hitTest(events: string[], x: number, y: number): { id: string }[] };
         }).context.hitTest(['mousemove', 'mouseenter', 'mouseleave'], x, y);
 
+        // The DOM context dispatches to the first hit, so the large link topping the list is the user-visible failure.
+        expect(hits[0]?.id).toBe('arc-c~d');
         expect(hits.map(hit => hit.id)).toEqual(['arc-c~d']);
     });
 

--- a/packages/charts/test/hover-highlight.test.ts
+++ b/packages/charts/test/hover-highlight.test.ts
@@ -1,0 +1,280 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import type {
+    Element,
+    Group,
+    Scene,
+} from '@ripl/core';
+
+import {
+    createChordChart,
+    createPieChart,
+    createSunburstChart,
+} from '../src';
+
+polyfillPath2D();
+
+interface ChartInternals {
+    scene: Scene;
+    highlightSeries(id: string | null): void;
+}
+
+function sceneOf(chart: unknown) {
+    return (chart as unknown as ChartInternals).scene;
+}
+
+function elementById(chart: unknown, id: string) {
+    const element = sceneOf(chart).getElementById(id) as Element | null;
+
+    expect(element).toBeTruthy();
+
+    return element!;
+}
+
+function segmentArc(chart: unknown, groupId: string) {
+    const group = sceneOf(chart).getElementById(groupId) as Group | null;
+
+    expect(group).toBeTruthy();
+
+    return group!.query('arc') as unknown as Element;
+}
+
+function hover(element: Element, event: 'mouseenter' | 'mouseleave') {
+    element.emit(event, null);
+}
+
+const PIE_DATA = [
+    {
+        label: 'a',
+        value: 3,
+    },
+    {
+        label: 'b',
+        value: 2,
+    },
+    {
+        label: 'c',
+        value: 1,
+    },
+];
+
+function createPie() {
+    return createPieChart<typeof PIE_DATA[number]>(document.createElement('div'), {
+        autoRender: false,
+        data: PIE_DATA,
+        key: 'label',
+        value: 'value',
+        label: 'label',
+        labels: true,
+    });
+}
+
+describe('hover highlight rest opacity', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    test('a chord arc hovered mid-entry leaves the ribbons at full opacity', async () => {
+        const chart = createChordChart(document.createElement('div'), {
+            autoRender: false,
+            groups: [
+                'A',
+                'B',
+            ],
+            matrix: [
+                [0, 4],
+                [4, 0],
+            ],
+        });
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(100);
+
+        const ribbon = elementById(chart, 'ribbon-A-B-ribbon');
+
+        expect(ribbon.opacity).toBe(0);
+
+        hover(elementById(chart, 'arc-A-segment'), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(elementById(chart, 'arc-A-segment'), 'mouseleave');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(ribbon.opacity).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('a pie slice hovered mid-entry leaves the segment labels at full opacity', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(100);
+
+        const label = (sceneOf(chart).getElementById('a') as Group).query('text') as unknown as Element;
+
+        expect(label.opacity).toBe(0);
+
+        hover(segmentArc(chart, 'a'), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(segmentArc(chart, 'a'), 'mouseleave');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(label.opacity).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('removing the hovered slice restores the slices that remain', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(segmentArc(chart, 'c'), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'a').opacity).toBeLessThan(1);
+
+        chart.update({ data: PIE_DATA.slice(0, 2) });
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'a').opacity).toBe(1);
+        expect(segmentArc(chart, 'b').opacity).toBe(1);
+
+        chart.destroy();
+    });
+
+});
+
+describe('sunburst hover owners', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    async function createSunburst() {
+        const chart = createSunburstChart(document.createElement('div'), {
+            autoRender: false,
+            data: [
+                {
+                    id: 'T',
+                    label: 'T',
+                    value: 6,
+                    children: [
+                        {
+                            id: 'T1',
+                            label: 'T1',
+                            value: 4,
+                            children: [
+                                {
+                                    id: 'T1a',
+                                    label: 'T1a',
+                                    value: 2,
+                                },
+                                {
+                                    id: 'T1b',
+                                    label: 'T1b',
+                                    value: 2,
+                                },
+                            ],
+                        },
+                        {
+                            id: 'T2',
+                            label: 'T2',
+                            value: 2,
+                        },
+                    ],
+                },
+                {
+                    id: 'U',
+                    label: 'U',
+                    value: 3,
+                },
+            ],
+        });
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        return chart;
+    }
+
+    function litNodes(chart: unknown, ids: string[]) {
+        return ids.filter(id => elementById(chart, `${id}-arc`).opacity === 1);
+    }
+
+    const ALL = [
+        'T',
+        'T1',
+        'T1a',
+        'T1b',
+        'T2',
+        'U',
+    ];
+
+    test.each([
+        ['T', ['T']],
+        ['T1', ['T1']],
+        ['T1a', ['T1a']],
+    ])('hovering segment %s isolates that ring', async (id, expected) => {
+        const chart = await createSunburst();
+
+        hover(elementById(chart, `${id}-arc`), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(litNodes(chart, ALL)).toEqual(expected);
+
+        hover(elementById(chart, `${id}-arc`), 'mouseleave');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(litNodes(chart, ALL)).toEqual(ALL);
+
+        chart.destroy();
+    });
+
+    test('hovering a legend item lights the whole branch', async () => {
+        const chart = await createSunburst();
+
+        (chart as unknown as ChartInternals).highlightSeries('T');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(litNodes(chart, ALL)).toEqual([
+            'T',
+            'T1',
+            'T1a',
+            'T1b',
+            'T2',
+        ]);
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/radial-labels.test.ts
+++ b/packages/charts/test/radial-labels.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@ripl/test-utils';
 
 import {
+    createPolarAreaChart,
     createPolarScatterChart,
     createRadarChart,
     createRadialBarChart,
@@ -329,6 +330,44 @@ describe('Polar scatter value labels', () => {
         await chart.render();
 
         expect(labelContents(chart, 'readings')).toEqual(['18km']);
+    });
+
+});
+
+describe('Polar area grid value labels', () => {
+
+    it('paints above the segments, which are opaque', async () => {
+        mockContext();
+
+        const chart = createPolarAreaChart(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: [
+                {
+                    label: 'a',
+                    value: 3,
+                },
+                {
+                    label: 'b',
+                    value: 1,
+                },
+            ],
+            key: 'label',
+            value: 'value',
+            label: 'label',
+            levels: 4,
+        });
+
+        await chart.render();
+
+        const scene = (chart as unknown as { scene: { getElementById(id: string): { zIndex: number;
+            getElementsByType(type: string): unknown[]; } | null; }; }).scene;
+
+        const labelGroup = scene.getElementById('polar-grid-labels');
+        const segment = scene.getElementById('a');
+
+        expect(labelGroup?.getElementsByType('text')).toHaveLength(4);
+        expect(labelGroup!.zIndex).toBeGreaterThan(segment!.zIndex);
     });
 
 });

--- a/packages/charts/test/radial-rest-alpha.test.ts
+++ b/packages/charts/test/radial-rest-alpha.test.ts
@@ -1,0 +1,205 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    elementIsArc,
+} from '@ripl/core';
+
+import type {
+    Element,
+    Group,
+} from '@ripl/core';
+
+import {
+    createChordChart,
+    createPieChart,
+    createPolarAreaChart,
+    createSunburstChart,
+} from '../src';
+
+polyfillPath2D();
+
+/** The rest tint every radial segment carries, shared with the bar series. */
+const SEGMENT_REST_ALPHA = 0.78;
+
+interface Slice {
+    label: string;
+    value: number;
+}
+
+const INITIAL: Slice[] = [
+    {
+        label: 'a',
+        value: 1,
+    },
+    {
+        label: 'b',
+        value: 2,
+    },
+    {
+        label: 'c',
+        value: 3,
+    },
+];
+
+const UPDATED: Slice[] = [
+    {
+        label: 'a',
+        value: 5,
+    },
+    {
+        label: 'b',
+        value: 1,
+    },
+    {
+        label: 'd',
+        value: 4,
+    },
+];
+
+interface RadialChart {
+    render(): Promise<unknown>;
+    update(options: unknown): Promise<unknown>;
+    destroy(): void;
+    scene: Group;
+}
+
+function segmentArcs(chart: RadialChart) {
+    const arcs: Element[] = [];
+
+    chart.scene.graph({ deep: true }).forEach(element => {
+        if (elementIsArc(element)) {
+            arcs.push(element);
+        }
+    });
+
+    return arcs;
+}
+
+/** The alpha an element's resolved fill carries, or `null` where the fill is not an `rgba` string. */
+function fillAlpha(element: Element): number | null {
+    const fill = (element as unknown as { fill: unknown }).fill;
+    const match = typeof fill === 'string' ? /^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([\d.]+)\s*\)$/.exec(fill) : null;
+
+    return match ? Number(match[1]) : null;
+}
+
+describe('Radial segments carry the shared rest tint', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    async function settle(chart: RadialChart) {
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+    }
+
+    const factories = {
+        pie: () => createPieChart<Slice>(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL,
+            key: 'label',
+            value: 'value',
+            label: 'label',
+        }),
+        'polar-area': () => createPolarAreaChart<Slice>(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL,
+            key: 'label',
+            value: 'value',
+            label: 'label',
+        }),
+        sunburst: () => createSunburstChart(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL.map(({ label, value }) => ({
+                id: label,
+                label,
+                value,
+            })),
+        }),
+        chord: () => createChordChart(document.createElement('div'), {
+            autoRender: false,
+            groups: ['a', 'b', 'c'],
+            matrix: [
+                [0, 3, 1],
+                [3, 0, 2],
+                [1, 2, 0],
+            ],
+        }),
+    };
+
+    Object.entries(factories).forEach(([name, factory]) => {
+
+        test(`${name} fills every segment at the rest alpha`, async () => {
+            const chart = factory() as unknown as RadialChart;
+
+            await settle(chart);
+
+            const alphas = segmentArcs(chart).map(fillAlpha);
+
+            expect(alphas.length).toBeGreaterThan(0);
+            alphas.forEach(alpha => expect(alpha).toBe(SEGMENT_REST_ALPHA));
+
+            chart.destroy();
+        });
+
+        test(`${name} never strokes a segment`, async () => {
+            const chart = factory() as unknown as RadialChart;
+
+            await settle(chart);
+
+            segmentArcs(chart).forEach(arc => {
+                expect((arc as unknown as { stroke: unknown }).stroke).toBeUndefined();
+            });
+
+            chart.destroy();
+        });
+
+    });
+
+    // The update path once re-derived a segment's colour from its own fill, so a tint applied there compounded.
+    test('pie holds the rest alpha across repeated updates without compounding', async () => {
+        const chart = createPieChart<Slice>(document.createElement('div'), {
+            autoRender: false,
+            data: INITIAL,
+            key: 'label',
+            value: 'value',
+            label: 'label',
+        }) as unknown as RadialChart;
+
+        await settle(chart);
+
+        const before = segmentArcs(chart).map(arc => (arc as unknown as { fill: string }).fill);
+
+        for (let pass = 0; pass < 3; pass++) {
+            chart.update({ data: pass % 2 ? INITIAL : UPDATED });
+            await settle(chart);
+        }
+
+        const survivors = segmentArcs(chart).filter(arc => before.includes((arc as unknown as { fill: string }).fill));
+
+        expect(survivors.length).toBeGreaterThan(0);
+        segmentArcs(chart).forEach(arc => expect(fillAlpha(arc)).toBe(SEGMENT_REST_ALPHA));
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/visual/README.md
+++ b/packages/charts/test/visual/README.md
@@ -118,3 +118,7 @@ CHROMIUM_PATH=/opt/pw-browsers/chromium-1194/chrome-linux/chrome \
 Baselines are written to `__snapshots__/` and are committed. They are rendered with the
 pre-installed Linux Chromium; regenerate them (`test:visual:update`) if you run on a platform
 whose font rendering differs.
+
+The `pie`, `polar-area`, `sunburst` and `chord` baselines need regenerating on CI's Chromium: those
+charts moved from a translucent fill plus a stroke outline to a solid fill with a constant-width
+`padWidth` gap, so their committed snapshots are stale by design rather than by a regression.

--- a/packages/core/src/elements/arc.ts
+++ b/packages/core/src/elements/arc.ts
@@ -15,6 +15,7 @@ import type {
 import {
     Box,
     getPadAngleAtRadius,
+    getPadInnerRadius,
     getThetaPoint,
     HALF_PI,
     TAU,
@@ -53,7 +54,7 @@ export interface ArcState extends BaseElementState {
     innerRadius?: number;
     /** The angular padding between the arc and its neighbors, in radians. Produces a wedge-shaped gap that widens with radius; use {@link ArcState.padWidth} for a gap of constant width. Ignored whenever `padWidth` is provided, `0` included. A `padAngle` wider than the sector collapses it onto its `endAngle`, where an oversized `padWidth` collapses it onto its mid-angle. */
     padAngle?: number;
-    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link ArcState.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
+    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges, its inner radius floored at the radius where those edges would meet so that an `innerRadius` of `0` still carries the gap to the center rather than tapering it away; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link ArcState.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
     padWidth?: number;
     /** The corner radius applied to the arc's corners, clamped to half the band thickness and to what the sector's span allows. An annular sector rounds all four corners; an open arc rounds the two outer corners and keeps a sharp center point. A non-zero value on an open arc also closes the path through the center, turning a chord-closed segment into a wedge and so changing its filled area, hit region and stroke — do not animate it up from `0` on an open arc. */
     borderRadius?: number;
@@ -263,7 +264,7 @@ export class Arc extends Shape2D<ArcState> {
         this.setStateValue('padAngle', value);
     }
 
-    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link Arc.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
+    /** The padding between the arc and its neighbors, in logical pixels. Each radius is inset by `asin(padWidth / 2r)`, so an annular sector holds the gap constant and faces its neighbors with parallel edges, its inner radius floored at the radius where those edges would meet so that an `innerRadius` of `0` still carries the gap to the center rather than tapering it away; an open arc has no inner edge to inset, so the gap becomes a single trim at the outer radius and adjacent edges converge to nothing at the center. Takes precedence over {@link Arc.padAngle} whenever it is provided — `padWidth: 0` means no padding rather than a fall back to `padAngle`, so animating it up from `0` is continuous. Negative values are treated as `0`. */
     public get padWidth() {
         return this.getStateValue('padWidth');
     }
@@ -383,14 +384,15 @@ export class Arc extends Shape2D<ArcState> {
                 return traceRoundedWedge(path, cx, cy, radius, outerStart, outerEnd, cornerRadius);
             }
 
-            const [outerCornerRadius, innerCornerRadius] = getCornerRadii(radius, innerRadius, endAngle - startAngle, gap / 2, borderRadius);
+            const paddedInnerRadius = Math.max(innerRadius, Math.min(radius, getPadInnerRadius(gap, endAngle - startAngle)));
+            const [outerCornerRadius, innerCornerRadius] = getCornerRadii(radius, paddedInnerRadius, endAngle - startAngle, gap / 2, borderRadius);
 
             if (outerCornerRadius || innerCornerRadius) {
                 return traceRoundedAnnularSector(path, {
                     cx,
                     cy,
                     radius,
-                    innerRadius,
+                    innerRadius: paddedInnerRadius,
                     startAngle,
                     endAngle,
                     halfGap: gap / 2,
@@ -400,15 +402,15 @@ export class Arc extends Shape2D<ArcState> {
             }
 
             const [outerStart, outerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, radius));
-            const [innerStart, innerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, innerRadius));
+            const [innerStart, innerEnd] = insetSector(startAngle, endAngle, getPadAngleAtRadius(gap, paddedInnerRadius));
 
             const [x1, y1] = getThetaPoint(outerStart, radius, cx, cy);
-            const [x2, y2] = getThetaPoint(innerEnd, innerRadius, cx, cy);
+            const [x2, y2] = getThetaPoint(innerEnd, paddedInnerRadius, cx, cy);
 
             path.moveTo(x1, y1);
             path.arc(cx, cy, radius, outerStart, outerEnd);
             path.lineTo(x2, y2);
-            path.arc(cx, cy, innerRadius, innerEnd, innerStart, true);
+            path.arc(cx, cy, paddedInnerRadius, innerEnd, innerStart, true);
             path.lineTo(x1, y1);
         });
     }

--- a/packages/core/src/math/geometry.ts
+++ b/packages/core/src/math/geometry.ts
@@ -96,6 +96,31 @@ export function getPadAngleAtRadius(padWidth: number, radius: number): number {
     return Math.asin(Math.min(padWidth / (2 * radius), 1));
 }
 
+/**
+ * Returns the smallest radius at which a sector of `span` radians still faces its neighbors with
+ * edges a full `padWidth` apart — `(padWidth / 2) / sin(min(span, π) / 2)`.
+ *
+ * The straight edges a {@link getPadAngleAtRadius} inset produces are parallel lines offset
+ * `padWidth / 2` from the radial centrelines, and parallel lines never meet: below this radius the
+ * inset needed to reach them exceeds half the span, the sector collapses onto its mid-angle, and
+ * the gap tapers away instead of holding its width. Flooring a sector's inner radius here is what
+ * lets a gap run all the way to the center of a shape that has no hole.
+ *
+ * Returns `0` where no floor applies — a `padWidth` that is non-positive, `NaN` or infinite, a
+ * `span` that is non-positive or `NaN`, and a full turn or wider, which has no neighbor to clear.
+ *
+ * @param padWidth - The gap width, in logical pixels, held constant at every radius.
+ * @param span - The angular span of the sector, in radians.
+ * @returns The radius at which the sector's straight edges converge, or `0` where none does.
+ */
+export function getPadInnerRadius(padWidth: number, span: number): number {
+    if (!(padWidth > 0) || !Number.isFinite(padWidth) || !(span > 0) || span >= TAU) {
+        return 0;
+    }
+
+    return padWidth / 2 / Math.sin(Math.min(span, Math.PI) / 2);
+}
+
 /** Generates the vertex points of a regular polygon centered at `(cx, cy)` with the given radius and number of sides. */
 export function getPolygonPoints(
     sides: number,

--- a/packages/core/test/elements/arc.test.ts
+++ b/packages/core/test/elements/arc.test.ts
@@ -435,6 +435,103 @@ describe('Arc padWidth', () => {
         expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(1e-9);
     });
 
+    test('Should hold the gap constant to the center of a sector with no hole', () => {
+        const padWidth = 6;
+        const base = {
+            cx: 0,
+            cy: 0,
+            radius: 120,
+            innerRadius: 0,
+            padWidth,
+        };
+
+        const widths = facingEdgeWidths(
+            renderCommands({
+                ...base,
+                startAngle: 0.2,
+                endAngle: 1.2,
+            }),
+            renderCommands({
+                ...base,
+                startAngle: 1.2,
+                endAngle: 2.4,
+            })
+        );
+
+        widths.forEach(width => expect(width).toBeCloseTo(padWidth, 9));
+        expect(Math.max(...widths) - Math.min(...widths)).toBeLessThan(1e-9);
+    });
+
+    test('Should floor a hole-less inner radius where the parallel edges converge', () => {
+        const cases = [
+            [TAU / 3, 6, 3.4641016151],
+            [TAU / 3, 2, 1.1547005384],
+            [Math.PI / 30, 2, 19.1073226093],
+            [Math.PI, 2, 1],
+        ] as const;
+
+        cases.forEach(([span, padWidth, expected]) => {
+            const [, inner] = arcCommands(renderCommands({
+                cx: 0,
+                cy: 0,
+                radius: 200,
+                innerRadius: 0,
+                startAngle: 0,
+                endAngle: span,
+                padWidth,
+            }));
+
+            expect(inner[3]).toBeCloseTo(expected, 9);
+        });
+    });
+
+    test('Should leave an inner radius clear of the convergence radius untouched', () => {
+        const [, inner] = arcCommands(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 120,
+            innerRadius: 40,
+            startAngle: 0.2,
+            endAngle: 1.2,
+            padWidth: 6,
+        }));
+
+        expect(inner[3]).toBe(40);
+    });
+
+    test('Should collapse onto the outer radius where the convergence radius exceeds the arc', () => {
+        const commands = renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 10,
+            innerRadius: 0,
+            startAngle: 1,
+            endAngle: 1.2,
+            padWidth: 8,
+        });
+
+        const [outer, inner] = arcCommands(commands);
+
+        expect(outer[4]).toBe(outer[5]);
+        expect(inner[4]).toBe(inner[5]);
+        expect(inner[3]).toBe(10);
+        commands.flat().forEach(value => expect(Number.isNaN(value as number)).toBe(false));
+    });
+
+    test('Should apply no floor to a full turn, which has no neighbor to clear', () => {
+        const [, inner] = arcCommands(renderCommands({
+            cx: 0,
+            cy: 0,
+            radius: 100,
+            innerRadius: 0,
+            startAngle: 0,
+            endAngle: TAU,
+            padWidth: 6,
+        }));
+
+        expect(inner[3]).toBe(0);
+    });
+
     test('Should take precedence over padAngle', () => {
         const withBoth = renderCommands({
             cx: 0,

--- a/packages/core/test/math/geometry.test.ts
+++ b/packages/core/test/math/geometry.test.ts
@@ -13,12 +13,14 @@ import {
     Box,
     getContainingBox,
     getPadAngleAtRadius,
+    getPadInnerRadius,
     getThetaPoint,
     isPointInBox,
     matrixIdentity,
     matrixRotate,
     matrixScale,
     matrixTranslate,
+    TAU,
     transformBox,
 } from '../../src';
 
@@ -140,6 +142,52 @@ describe('Math', () => {
                 expect(getPadAngleAtRadius(NaN, 100)).toBe(0);
                 expect(getPadAngleAtRadius(10, -1)).toBe(0);
                 expect(getPadAngleAtRadius(10, NaN)).toBe(0);
+            });
+
+        });
+
+        describe('getPadInnerRadius', () => {
+
+            test('Should return the radius at which the parallel edges converge', () => {
+                expect(getPadInnerRadius(6, TAU / 3)).toBeCloseTo(3.4641016151, 9);
+                expect(getPadInnerRadius(2, TAU / 3)).toBeCloseTo(1.1547005384, 9);
+                expect(getPadInnerRadius(2, Math.PI / 30)).toBeCloseTo(19.1073226093, 9);
+                expect(getPadInnerRadius(2, Math.PI)).toBeCloseTo(1, 12);
+            });
+
+            test('Should leave the converging endpoint a half gap from the centreline', () => {
+                [0.4, 1, 2, Math.PI].forEach(span => {
+                    const radius = getPadInnerRadius(5, span);
+                    const [, y] = getThetaPoint(getPadAngleAtRadius(5, radius), radius);
+
+                    expect(y).toBeCloseTo(5 / 2, 9);
+                    expect(getPadAngleAtRadius(5, radius)).toBeCloseTo(span / 2, 9);
+                });
+            });
+
+            test('Should stop at the half gap once the span exceeds a half turn', () => {
+                expect(getPadInnerRadius(2, Math.PI * 1.5)).toBeCloseTo(1, 12);
+                expect(getPadInnerRadius(2, Math.PI * 1.99)).toBeCloseTo(1, 12);
+            });
+
+            test('Should push a thin sliver further out than a wide sector', () => {
+                expect(getPadInnerRadius(2, Math.PI / 30)).toBeGreaterThan(getPadInnerRadius(2, TAU / 3));
+            });
+
+            test('Should return zero for a full turn, which has no neighbor to clear', () => {
+                expect(getPadInnerRadius(6, TAU)).toBe(0);
+                expect(getPadInnerRadius(6, TAU + 1)).toBe(0);
+                expect(getPadInnerRadius(6, Infinity)).toBe(0);
+            });
+
+            test('Should return zero for a gap or span that cannot produce a floor', () => {
+                expect(getPadInnerRadius(0, 1)).toBe(0);
+                expect(getPadInnerRadius(-5, 1)).toBe(0);
+                expect(getPadInnerRadius(NaN, 1)).toBe(0);
+                expect(getPadInnerRadius(Infinity, 1)).toBe(0);
+                expect(getPadInnerRadius(6, 0)).toBe(0);
+                expect(getPadInnerRadius(6, -1)).toBe(0);
+                expect(getPadInnerRadius(6, NaN)).toBe(0);
             });
 
         });


### PR DESCRIPTION
Stacked on #80 — review that first; this PR's diff is only the chart commits. It consumes the `Arc.padWidth` property that PR adds.

Pie, polar-area, sunburst and chord all drew each segment as a **translucent fill plus a stroke outline** — `fill: setColorAlpha(color, 0.55)`, `stroke: color`, `lineWidth: 2` — separated by an *angular* pad. Two consequences:

- The gap between neighbouring segments was a wedge: wide at the outer radius, narrowing toward the centre. On a donut from r=40 to r=120 with the old `padAngle: 0.1` the gap ran 3.99 → 11.98 px, a 3× spread.
- Hover raised the fill from 55% to solid, so the outline was doing the work of separating segments that the gap should have been doing.

Separately, **small arcs in an arc diagram could not be hovered at all**. Link arcs are open sampled polylines with the default `pointerEvents: 'all'`, so `Shape2D.intersectsWith` runs `isPointInStroke || isPointInPath` — and the native fill test implicitly closes an open path **against its chord**. The whole half-disc beneath a large arc was therefore a hit region, and since `DOMContext` dispatches only to `hitElements[0]`, a large arc's invisible chord-fill swallowed every smaller arc beneath it. The tooltip never appeared on the short arcs near the axis.

## What changed

All four charts draw **solid fills, no outline**, separated by a constant-width `padWidth` gap (default 2px) whose edges stay parallel at every radius. Because the rest state is now solid, hover no longer brightens the hovered segment — it **dims the others**, reusing the exact `highlightSeries` mechanism legend hover already used rather than a second parallel path.

Precedence lives in one place, `resolveSegmentPadWidth`: `padWidth` wins wherever provided (including `0`, which means no gap); a chart setting only `padAngle` resolves to `undefined` and keeps its previous look byte-for-byte. `polar-area` and `chord` keep `padAngle` working with an `@deprecated` pointer to `padWidth`.

The hover fix is `pointerEvents: 'stroke'` on arc-diagram links and radial-bar value arcs, matching the precedent already set in `sankey.ts`.

Also here, from the audit brief: the scatter demo's `maxRadius` drops from 25 to 15 (demo default and the prose bubble-sizing sample; the slider max narrows to 30 so 15 sits mid-range). The chart-side defaults and the separate `maxRadius: 20` sample are untouched.

## Review findings, fixed in this branch

The first pass routed segment hover through `highlightSeries` and noted that it captures each element's rest opacity **once, permanently**, calling that pre-existing and out of scope. Review showed that is not defensible — sharing the path turns a dormant bug into three failures that **do not reproduce on the parent branch**:

1. **Chord ribbons erased permanently.** Ribbons enter at `opacity: 0` and fade in only after the arc pass (~1.4s). Hovering an arc inside that window recorded `0` as every ribbon's rest; the first `mouseleave` restored them to `0` and they never returned.
2. **Pie and polar-area labels erased the same way**, since labels and connectors also fade in after the arcs settle.
3. **Removing the hovered segment stranded the chart at 15% opacity.** `destroy()` tears down the element's listeners, so an exiting hovered arc never fires `mouseleave` and the highlight was never released.

Fixed at the root: rest opacity is now read from the element's **animation target** (`element.data.opacity`) rather than its instantaneous value, refreshed on each highlight so a later render that changes an element's rest is tracked too; the one-time capture survives only for elements that never animate opacity. Seeding became `element.opacity ??= rest` so a live mid-fade value is not snapped to full. And the chart now drops an orphaned highlight when a highlighted group is destroyed, covering both the render-time re-registration and out-of-band destruction.

Also fixed:

- **Polar-area's radial tick labels were occluded.** With the fill opaque, only `85` and a clipped `63.75` survived where the baseline showed all four values reading through. Fixed by z-order — the grid's value labels now paint above the segments — not by reintroducing translucency.
- **Sunburst root-segment hover lit the whole subtree** instead of isolating one ring, contradicting the page's own "hovering one dims the rest". Owner keys are now namespaced (`series:<rootId>` / `node:<ownId>`), so a segment hover cannot collide with a series owner.
- **The arc-diagram regression test did not demonstrate the user-visible failure.** With the original link order the small arc was already `hitElements[0]` even unfixed, so the test passed for the wrong reason. The links are reversed so the large arc draws last; unfixed, the hover now resolves to `arc-a~f` instead of `arc-c~d` — exactly what a user would experience.
- `applyHoverHighlight`'s doc said `highlight` and `restore` must be given together; the types now enforce it via a new exported `HoverHighlightStates` union, so passing `highlight` alone (which would strand an element highlighted) is a compile error.
- A duplicated rationale comment, a fragile `padAngle!` assertion, and a prototype-chain lookup in the website's coverage script (`option in exclusions` → `Object.hasOwn`) — the last meaning an option named `toString` or `constructor` would have been silently exempt on every chart.

## Verification

- `yarn test` — 195 files, **2465 passed, 2 skipped, 1 todo**. The 2 skips are the pre-existing `conformance.test.ts` jsdom cases.
- `tsc` clean; `eslint .` clean; TypeDoc `notDocumented` clean for `@ripl/charts`.
- Both website gates pass: `check-config-coverage` (316 options across 25 charts) and `generate-chart-options --check` (25 pages).
- **Visual scope is exactly the four intended charts.** The committed `__snapshots__` were rendered on a different Chromium and fail on `main` here, so the gallery was rendered from `origin/main` and from this branch in the same environment and byte-compared: `identical=22 changed=4`, changed being chord, pie, polar-area, sunburst. `radial-bar` and `arc-diagram` are byte-identical, confirming their change is pointer-events only. Independently reproduced during review.
- Every regression test was confirmed to fail without its fix — the three hover failures reproduce the reported symptoms exactly (`expected +0 to be 1` for the erased ribbon and label, `expected 0.15000000000000002 to be 1` for the stranded chart).

## Judgement calls worth your eye

- **Solid at rest is a deliberate look change.** Rendered and compared rather than assumed: it reads cleaner than translucent-plus-outline on all four. On sunburst, children inherit the parent's colour, so a branch now reads as one mass separated by thin gaps where the old 1px outline gave each ring a faint edge. The 2px background-coloured gap separates same-hue rings more strongly than that outline did, but if you want stronger ring definition the fix is a per-depth lightness ramp, not a return to strokes.
- **`HoverHighlightOptions` lost its type parameter** as part of pairing the states in the type. It is exported, so that is a breaking type change for anyone who wrote `HoverHighlightOptions<MyElement>`; nothing in-repo did. Reverting to a doc-only fix is a two-line change if you would rather not take it.

## Follow-up

Hover is now O(all leaves) per pointer crossing — moving between segments fires `highlightSeries(null)` then `highlightSeries(id)`, each walking every registered group and allocating a transition per leaf. Fine at gallery scale (6–40 elements); worth revisiting for a large sunburst or chord.

The four changed baselines need regenerating on CI's Chromium; `packages/charts/test/visual/README.md` records that they are stale by design rather than by regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnbBNvcQzqikWSyApb47Xb)_