### PR TITLE
Report drag deltas as the total since the drag started

### DIFF
--- a/apps/website/src/.vitepress/components/playground/examples/bezier-editor.js
+++ b/apps/website/src/.vitepress/components/playground/examples/bezier-editor.js
@@ -71,6 +71,8 @@ function syncHull() {
 
 handles.forEach(handle => {
     let dragging = false;
+    let originX = 0;
+    let originY = 0;
 
     handle.on('mouseenter', () => {
         handle.fill = dragging ? FILL_DRAG : FILL_HOVER;
@@ -82,14 +84,16 @@ handles.forEach(handle => {
 
     handle.on('dragstart', () => {
         dragging = true;
+        originX = handle.cx;
+        originY = handle.cy;
         handle.fill = FILL_DRAG;
         handle.radius = 12;
     });
 
-    // `deltaX`/`deltaY` are the movement since the previous event, which keeps the grab offset intact.
+    // `deltaX`/`deltaY` are the total since dragstart, so anchoring on the origin keeps the grab offset.
     handle.on('drag', event => {
-        handle.cx += event.data.deltaX;
-        handle.cy += event.data.deltaY;
+        handle.cx = originX + event.data.deltaX;
+        handle.cy = originY + event.data.deltaY;
         syncHull();
     });
 

--- a/apps/website/src/docs/core/advanced/events.md
+++ b/apps/website/src/docs/core/advanced/events.md
@@ -43,9 +43,17 @@ circle.on('click', () => {
 });
 
 // Drag the circle to reposition it
+let originX = 0;
+let originY = 0;
+
+circle.on('dragstart', () => {
+    originX = circle.cx;
+    originY = circle.cy;
+});
+
 circle.on('drag', (event) => {
-    circle.cx += event.data.deltaX;
-    circle.cy += event.data.deltaY;
+    circle.cx = originX + event.data.deltaX;
+    circle.cy = originY + event.data.deltaY;
     scene.render();
 });
 ```
@@ -152,13 +160,18 @@ circle.on('mouseleave', () => {
 Ripl supports drag interactions on elements via `dragstart`, `drag`, and `dragend` events. A drag begins when the pointer is pressed on an element and moved beyond a configurable threshold (default 3px). Once the threshold is exceeded, `dragstart` fires, followed by `drag` on each subsequent move, and `dragend` on pointer release.
 
 ```ts
+let originX = 0;
+let originY = 0;
+
 circle.on('dragstart', (event) => {
+    originX = circle.cx;
+    originY = circle.cy;
     console.log('Drag started at', event.data.x, event.data.y);
 });
 
 circle.on('drag', (event) => {
-    circle.cx += event.data.deltaX;
-    circle.cy += event.data.deltaY;
+    circle.cx = originX + event.data.deltaX;
+    circle.cy = originY + event.data.deltaY;
     scene.render();
 });
 
@@ -167,9 +180,9 @@ circle.on('dragend', (event) => {
 });
 ```
 
-The `drag` and `dragend` events include `startX`/`startY` (where the drag originated) and `deltaX`/`deltaY` (movement since the last event). Use `deltaX`/`deltaY` for repositioning elements to preserve the offset between the cursor and the element's origin.
+The `drag` and `dragend` events include `startX`/`startY` (where the drag originated) and `deltaX`/`deltaY` (**the total movement since the drag started**, not the step since the previous event). Record the element's position on `dragstart` and add the delta to it, as above: that preserves the offset between the cursor and the element's origin, and — because each payload is a total rather than a running sum — the element stays put under the cursor even if a move event is coalesced or dropped.
 
-Every pointer payload — `x`/`y`, `startX`/`startY`, and the deltas — is in **logical** space: CSS pixels relative to the surface origin, the space elements themselves are authored in. They are not device pixels, and they are not element-local, so a `drag` delta can be added straight onto an element's coordinates as above.
+Every pointer payload — `x`/`y`, `startX`/`startY`, and the deltas — is in **logical** space: CSS pixels relative to the surface origin, the space elements themselves are authored in. They are not device pixels, and they are not element-local.
 
 The drag threshold can be configured via context options:
 
@@ -281,19 +294,20 @@ const {
     scene.render();
 
     const colors = { circle: '#3a86ff', rect: '#ff006e' };
+    const origin = { cx: 0, cy: 0, x: 0, y: 0 };
 
     circle.on('mouseenter', () => { circle.fill = '#8338ec'; label.content = 'mouseenter: circle'; scene.render(); });
     circle.on('mouseleave', () => { circle.fill = colors.circle; label.content = 'mouseleave: circle'; scene.render(); });
     circle.on('click', () => { colors.circle = colors.circle === '#3a86ff' ? '#fb5607' : '#3a86ff'; circle.fill = colors.circle; label.content = 'click: circle'; scene.render(); });
-    circle.on('dragstart', () => { label.content = 'dragstart: circle'; scene.render(); });
-    circle.on('drag', (event) => { circle.cx += event.data.deltaX; circle.cy += event.data.deltaY; label.content = 'drag: circle'; scene.render(); });
+    circle.on('dragstart', () => { origin.cx = circle.cx; origin.cy = circle.cy; label.content = 'dragstart: circle'; scene.render(); });
+    circle.on('drag', (event) => { circle.cx = origin.cx + event.data.deltaX; circle.cy = origin.cy + event.data.deltaY; label.content = 'drag: circle'; scene.render(); });
     circle.on('dragend', () => { label.content = 'dragend: circle'; scene.render(); });
 
     rect.on('mouseenter', () => { rect.fill = '#8338ec'; label.content = 'mouseenter: rect'; scene.render(); });
     rect.on('mouseleave', () => { rect.fill = colors.rect; label.content = 'mouseleave: rect'; scene.render(); });
     rect.on('click', () => { colors.rect = colors.rect === '#ff006e' ? '#fb5607' : '#ff006e'; rect.fill = colors.rect; label.content = 'click: rect'; scene.render(); });
-    rect.on('dragstart', () => { label.content = 'dragstart: rect'; scene.render(); });
-    rect.on('drag', (event) => { rect.x += event.data.deltaX; rect.y += event.data.deltaY; label.content = 'drag: rect'; scene.render(); });
+    rect.on('dragstart', () => { origin.x = rect.x; origin.y = rect.y; label.content = 'dragstart: rect'; scene.render(); });
+    rect.on('drag', (event) => { rect.x = origin.x + event.data.deltaX; rect.y = origin.y + event.data.deltaY; label.content = 'drag: rect'; scene.render(); });
     rect.on('dragend', () => { label.content = 'dragend: rect'; scene.render(); });
 });
 </script>

--- a/apps/website/src/docs/core/essentials/scene.md
+++ b/apps/website/src/docs/core/essentials/scene.md
@@ -55,9 +55,17 @@ circle.on('mouseleave', () => {
 });
 
 // Drag elements to reposition them
+let originX = 0;
+let originY = 0;
+
+circle.on('dragstart', () => {
+    originX = circle.cx;
+    originY = circle.cy;
+});
+
 circle.on('drag', (event) => {
-    circle.cx += event.data.deltaX;
-    circle.cy += event.data.deltaY;
+    circle.cx = originX + event.data.deltaX;
+    circle.cy = originY + event.data.deltaY;
     scene.render();
 });
 ```
@@ -203,14 +211,18 @@ const {
 
     scene.render();
 
+    const origin = { cx: 0, cy: 0, x: 0, y: 0 };
+
     circle.on('mouseenter', () => { circle.fill = '#8338ec'; scene.render(); });
     circle.on('mouseleave', () => { circle.fill = '#3a86ff'; scene.render(); });
     circle.on('click', () => { circle.fill = '#fb5607'; scene.render(); });
-    circle.on('drag', (event) => { circle.cx += event.data.deltaX; circle.cy += event.data.deltaY; scene.render(); });
+    circle.on('dragstart', () => { origin.cx = circle.cx; origin.cy = circle.cy; });
+    circle.on('drag', (event) => { circle.cx = origin.cx + event.data.deltaX; circle.cy = origin.cy + event.data.deltaY; scene.render(); });
 
     rect.on('mouseenter', () => { rect.fill = '#8338ec'; scene.render(); });
     rect.on('mouseleave', () => { rect.fill = '#ff006e'; scene.render(); });
     rect.on('click', () => { rect.fill = '#fb5607'; scene.render(); });
-    rect.on('drag', (event) => { rect.x += event.data.deltaX; rect.y += event.data.deltaY; scene.render(); });
+    rect.on('dragstart', () => { origin.x = rect.x; origin.y = rect.y; });
+    rect.on('drag', (event) => { rect.x = origin.x + event.data.deltaX; rect.y = origin.y + event.data.deltaY; scene.render(); });
 });
 </script>

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -114,7 +114,7 @@ export interface ContextEventMap extends EventMap {
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         y: number;
     };
-    /** Emitted continuously during a drag, carrying the current position, drag start, and delta from the start. */
+    /** Emitted continuously during a drag, carrying the current position, drag start, and total movement since the drag started. */
     drag: {
         /** Current X coordinate of the pointer, in logical space (CSS pixels relative to the surface origin). */
         x: number;
@@ -124,12 +124,12 @@ export interface ContextEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         startY: number;
-        /** Horizontal distance moved since the drag started, in logical pixels. */
+        /** Total horizontal distance moved since the drag started, in logical pixels. */
         deltaX: number;
-        /** Vertical distance moved since the drag started, in logical pixels. */
+        /** Total vertical distance moved since the drag started, in logical pixels. */
         deltaY: number;
     };
-    /** Emitted when a drag gesture ends, carrying the final position, drag start, and total delta. */
+    /** Emitted when a drag gesture ends, carrying the final position, drag start, and total movement since the drag started. */
     dragend: {
         /** Final X coordinate of the pointer, in logical space (CSS pixels relative to the surface origin). */
         x: number;
@@ -139,9 +139,9 @@ export interface ContextEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         startY: number;
-        /** Total horizontal distance moved over the drag, in logical pixels. */
+        /** Total horizontal distance moved since the drag started, in logical pixels. */
         deltaX: number;
-        /** Total vertical distance moved over the drag, in logical pixels. */
+        /** Total vertical distance moved since the drag started, in logical pixels. */
         deltaY: number;
     };
 }

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -144,7 +144,7 @@ export interface ElementEventMap extends EventMap {
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         y: number;
     };
-    /** Emitted continuously while dragging the element, carrying the current position, drag start, and delta from the start. */
+    /** Emitted continuously while dragging the element, carrying the current position, drag start, and total movement since the drag started. */
     drag: {
         /** Current X coordinate of the pointer, in logical space (CSS pixels relative to the surface origin). */
         x: number;
@@ -154,12 +154,12 @@ export interface ElementEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         startY: number;
-        /** Horizontal distance moved since the drag started, in logical pixels. */
+        /** Total horizontal distance moved since the drag started, in logical pixels. */
         deltaX: number;
-        /** Vertical distance moved since the drag started, in logical pixels. */
+        /** Total vertical distance moved since the drag started, in logical pixels. */
         deltaY: number;
     };
-    /** Emitted when a drag gesture on the element ends, carrying the final position, drag start, and total delta. */
+    /** Emitted when a drag gesture on the element ends, carrying the final position, drag start, and total movement since the drag started. */
     dragend: {
         /** Final X coordinate of the pointer, in logical space (CSS pixels relative to the surface origin). */
         x: number;
@@ -169,9 +169,9 @@ export interface ElementEventMap extends EventMap {
         startX: number;
         /** Y coordinate at which the drag started, in logical space (CSS pixels relative to the surface origin). */
         startY: number;
-        /** Total horizontal distance moved over the drag, in logical pixels. */
+        /** Total horizontal distance moved since the drag started, in logical pixels. */
         deltaX: number;
-        /** Total vertical distance moved over the drag, in logical pixels. */
+        /** Total vertical distance moved since the drag started, in logical pixels. */
         deltaY: number;
     };
     /** Emitted when the element is destroyed; carries no payload. */

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -32,8 +32,6 @@ interface InteractionState {
     dragElement: RenderElement | undefined;
     dragStartX: number;
     dragStartY: number;
-    dragPrevX: number;
-    dragPrevY: number;
     dragStarted: boolean;
     suppressClick: boolean;
     scheduleHitTest: ReturnType<typeof createFrameBuffer>;
@@ -215,8 +213,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         if (!state.dragStarted) {
             if (getEuclideanDistance(dx, dy) >= this._dragThreshold) {
                 state.dragStarted = true;
-                state.dragPrevX = state.dragStartX;
-                state.dragPrevY = state.dragStartY;
 
                 const payload = {
                     x: state.dragStartX,
@@ -230,19 +226,13 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             return;
         }
 
-        const deltaX = x - state.dragPrevX;
-        const deltaY = y - state.dragPrevY;
-
-        state.dragPrevX = x;
-        state.dragPrevY = y;
-
         const payload = {
             x,
             y,
             startX: state.dragStartX,
             startY: state.dragStartY,
-            deltaX,
-            deltaY,
+            deltaX: dx,
+            deltaY: dy,
         };
 
         this.emit('drag', payload);
@@ -316,8 +306,8 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
                 y,
                 startX: state.dragStartX,
                 startY: state.dragStartY,
-                deltaX: x - state.dragPrevX,
-                deltaY: y - state.dragPrevY,
+                deltaX: x - state.dragStartX,
+                deltaY: y - state.dragStartY,
             };
 
             this.emit('dragend', dragPayload);
@@ -369,8 +359,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             dragElement: undefined,
             dragStartX: 0,
             dragStartY: 0,
-            dragPrevX: 0,
-            dragPrevY: 0,
             dragStarted: false,
             suppressClick: false,
             scheduleHitTest: createFrameBuffer(),

--- a/packages/dom/test/context.test.ts
+++ b/packages/dom/test/context.test.ts
@@ -397,6 +397,77 @@ describe('DOMContext pointer state machine', () => {
         expect(typesOf(element)).toEqual(['dragstart', 'drag', 'dragend']);
     });
 
+    // The payload advanced a running `dragPrev`, so it reported the step rather than the total the
+    // docs promised, and a consumer following them wrote `x = startX + deltaX` and got a stutter.
+    test('Should report drag deltas as the total since the drag started', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mousemove', 140, 140);
+        mouse(context, 'mousemove', 160, 160);
+
+        const drags = element.events.filter(({ type }) => type === 'drag');
+
+        expect(drags[0].data).toMatchObject({
+            deltaX: 130,
+            deltaY: 130,
+        });
+        expect(drags[1].data).toMatchObject({
+            deltaX: 150,
+            deltaY: 150,
+        });
+    });
+
+    test('Should report the dragend delta as the total since the drag started', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 10);
+        mouse(context, 'mousemove', 100, 100);
+        mouse(context, 'mousemove', 140, 140);
+        mouse(context, 'mouseup', 160, 160);
+
+        const dragend = element.events.find(({ type }) => type === 'dragend');
+
+        expect(dragend?.data).toMatchObject({
+            startX: 10,
+            startY: 10,
+            deltaX: 150,
+            deltaY: 150,
+        });
+    });
+
+    test('Should report a negative delta for a drag back past its start', () => {
+        const context = create();
+        const element = createMockElement('a', DRAG_EVENTS);
+
+        register(context, [element]);
+
+        mouse(context, 'mousedown', 10, 50);
+
+        // The move that crosses the threshold emits `dragstart` alone, so arm the drag first.
+        mouse(context, 'mousemove', 14, 54);
+        mouse(context, 'mousemove', 30, 80);
+        mouse(context, 'mousemove', 5, 30);
+
+        const drags = element.events.filter(({ type }) => type === 'drag');
+
+        expect(drags[0].data).toMatchObject({
+            deltaX: 20,
+            deltaY: 30,
+        });
+        expect(drags[1].data).toMatchObject({
+            deltaX: -5,
+            deltaY: -20,
+        });
+    });
+
     test('Should not resume a stranded drag once the button is released', () => {
         const context = create();
         const element = createMockElement('a', DRAG_EVENTS);


### PR DESCRIPTION
Supersedes #84, which resolves the same contradiction the other way round.

## The problem

Both event maps document `drag`/`dragend` deltas as the total:

```ts
/** Horizontal distance moved since the drag started, in logical pixels. */
deltaX: number;
```

The runtime emitted the step. `_handleDrag` seeded `dragPrev` to the drag start, then advanced it on every move:

```ts
const deltaX = x - state.dragPrevX;
const deltaY = y - state.dragPrevY;

state.dragPrevX = x;
state.dragPrevY = y;
```

`dragend` did the same, against the last `drag` rather than the start — so the event named "end of gesture" reported the last mouse twitch, not the gesture.

#84 proposes fixing the docs to match. This PR fixes the runtime to match the docs, because the total is the better contract:

- **It survives a dropped move.** With a running sum, one coalesced `mousemove` desynchronises the element from the cursor for the rest of the gesture. With a total, the next event re-establishes the truth.
- **It is consistent with the payload it ships in.** `startX`/`startY` are already in there; a step delta makes them decorative, whereas `x - startX == deltaX` is a property a reader can rely on.
- **It matches the drag threshold**, which has always measured from the press point.

## The fix

`_handleDrag` already computes the total for the threshold test, so the payload just reuses it — the change is a net deletion:

```ts
const dx = x - state.dragStartX;
const dy = y - state.dragStartY;
```

`dragPrevX`/`dragPrevY` are gone from `InteractionState`, its initialiser, and the `dragstart` branch. `dragend` reads from `dragStartX`/`dragStartY`.

The JSDoc was already correct in substance, so it is only normalised: `drag` and `dragend` now describe their deltas with the same sentence, so no difference can be inferred between them.

## Consumers

Every place in the repo teaching `element.cx += event.data.deltaX` moves to capturing the origin on `dragstart` and assigning `origin + delta`:

- `docs/core/advanced/events.md` — the tabbed example, the drag-events snippet, and the live demo script
- `docs/core/essentials/scene.md` — the tabbed example and the live demo script
- `playground/examples/bezier-editor.js` — the control-point editor this bug was originally found with

`grep` for `deltaX`/`deltaY` with `+=` or `-=` across `apps/` and `packages/` now returns nothing.

## Verification

- `yarn test` — 211 files, 2748 tests, 2 skipped, 1 todo. All pass.
- `yarn lint`, `yarn typecheck` — clean.
- TypeDoc `notDocumented` over `@ripl/core` — no warnings.
- Three new tests in `packages/dom/test/context.test.ts`. Re-run against the pre-fix `context.ts`, **all three fail**, so they pin the change rather than the shape of the payload:
  - a three-move drag reports `130` then `150`, not `130` then `20`
  - `dragend` reports the total from the press point, not the last step
  - the worked case from the bug report — press `10,50`, move to `30,80` (`+20,+30`), then to `5,30` (`-5,-20`) — including the sign flip back past the start

One thing worth knowing while reading the tests: the move that crosses the threshold emits `dragstart` alone, so the first `drag` arrives on the move after it. That is unchanged behaviour, but it does mean the delta sequences look off by one move until you notice it.

Not verified: no browser here, so the by-hand check on the Bézier editor and the two live drag demos is still outstanding.

## Breaking

**`drag` and `dragend` `deltaX`/`deltaY` now carry the total since `dragstart`, not the step since the previous event.** Any handler accumulating them (`el.cx += event.data.deltaX`) will now move the element quadratically. Migration is the idiom shown above: record the position on `dragstart`, assign `origin + delta` on `drag`. Code that only reads `x`/`y`/`startX`/`startY` is unaffected.

To recover the old step without state, subtract the previous payload's delta.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SB6FkCaFeXfPmA3W97LZB)_