### PR TITLE
Take hit-test points in logical space, not surface space

### DIFF
--- a/docs/migrations/coordinate-spaces.md
+++ b/docs/migrations/coordinate-spaces.md
@@ -1,0 +1,91 @@
+# Migrating to one public coordinate space
+
+Ripl works in two coordinate spaces. Before this change, the boundary between them ran through the
+public API: pointer events reported one space, hit testing took the other, and a consumer had to
+know which method wanted which. Now the boundary sits inside the backends, and **every coordinate
+crossing the public API is in logical space**.
+
+- **Logical space** — CSS pixels, unaffected by the device pixel ratio, with `0,0` at the top-left
+  of the context's own element. Elements are authored here, pointer events report here, and every
+  public method takes and returns coordinates here.
+- **Surface space** — the backend's own drawing coordinates: device pixels on canvas and WebGPU,
+  identity on SVG, a scaled and letterboxed raster grid on the terminal. Backend-internal.
+
+`Context.toLogicalPoint`/`toSurfacePoint` still exist and are unchanged, but they are now a seam for
+authors of custom contexts. **A consumer never needs to call either.**
+
+Entries marked **behaviour** change what gets computed without changing any type — code keeps
+compiling, results move. Entries marked **API** change a type or signature and will surface as a
+compile error.
+
+## @ripl/core
+
+**`Element.intersectsWith`** — **behaviour**. The `x`/`y` arguments are in logical space. The method
+no longer maps the point through `Context.toLogicalPoint` before testing it against the bounding
+box. Callers passing the coordinates from a pointer event payload were already holding logical
+coordinates and were previously required to convert; **drop the `toSurfacePoint` call**, because it
+now doubles the point on a retina canvas. On SVG and at a device pixel ratio of 1 nothing moves.
+
+**`Shape2D.intersectsWith`** — **behaviour**. Same argument change. Internally the
+surface → logical → surface round-trip is gone: the inverted world transform now applies directly to
+the incoming logical point, and the local point is handed to `isPointInPath`/`isPointInStroke`
+unscaled. A subclass overriding `intersectsWith` and calling `super` needs no change; one that
+converted the point itself must stop.
+
+**`Context.isPointInPath`** and **`Context.isPointInStroke`** — **behaviour**. Both take a logical
+point. A backend whose native test wants its own drawing coordinates converts internally (see
+`@ripl/canvas` and `@ripl/webgpu` below). A **custom `Context` implementation that forwards these to
+a native canvas test must now convert the point itself**, with `this.toSurfacePoint(x, y)` — it is
+the one place the helpers are still needed.
+
+**`Context.hitTest`** — **behaviour**. Takes a logical point, so `protected` callers forwarding a
+pointer coordinate no longer convert.
+
+**`RenderElement.intersectsWith`** — **API**, documentation only. The declared space in the
+interface's doc comment changes from surface to logical; the signature is unchanged. Any structural
+implementation of `RenderElement` (a test double, say) that did its own conversion is now off by the
+device pixel ratio.
+
+**`Context.toLogicalPoint`** and **`Context.toSurfacePoint`** — unchanged in behaviour and still
+public. Reframed as the backend seam. Overriding them in a custom context (as the terminal does for
+its letterbox offset) is still correct and still required for a non-pure-scale mapping.
+
+## @ripl/canvas
+
+**`CanvasContext.isPointInPath`** and **`CanvasContext.isPointInStroke`** — **behaviour**. Map the
+incoming logical point onto device pixels before the native call. Native `isPointInPath` reads its
+point in untransformed canvas space while the path is transformed by the current matrix, so the
+device-pixel-ratio matrix installed by `rescaleCanvas` has to be applied to the point by hand.
+
+## @ripl/webgpu
+
+**`WebGPUContext.isPointInPath`** and **`WebGPUContext.isPointInStroke`** — **behaviour**, and a bug
+fix. Same conversion as canvas; the offscreen hit canvas carries the same device-pixel matrix as the
+surface. Previously `Shape3D` traced its hit path from `Context3D.project`, which emits logical
+coordinates, and compared it against a point the pointer pipeline had already scaled to device
+pixels — so **on a display with a device pixel ratio above 1, hit testing missed by exactly that
+ratio**. No action required; hit testing starts working.
+
+## @ripl/3d
+
+**`Shape3D.intersectsWith`** — **behaviour**. Takes a logical point. The hit path is traced from
+`Context3D.project`, which already emits logical coordinates, so no conversion happens here — the
+fix is that the point now arrives in the space the path was built in. Same retina bug as WebGPU
+above, and the same non-action.
+
+## @ripl/dom
+
+**`DOMContext`** — **behaviour**, internal. The single `toSurfacePoint` call that sat between the
+pointer handlers and `hitTest` is gone; handlers pass the coordinates they emit. Nothing public
+changes, but this is the line that made the whole seam necessary, and it is worth knowing it no
+longer exists when reading the interaction code.
+
+## Migration checklist
+
+1. Search for `toSurfacePoint` in your own code. Every call that existed to feed `intersectsWith`,
+   `isPointInPath`, or `isPointInStroke` should be deleted.
+2. If you implement a custom `Context` that forwards `isPointInPath`/`isPointInStroke` to a native
+   canvas test, add the conversion inside those methods.
+3. If you override `Element.intersectsWith` and converted the point, stop.
+4. Nothing else. Element coordinates, event payloads, bounding boxes, `Context.width`/`height` and
+   the navigator were already logical and are untouched.

--- a/packages/3d/src/core/shape.ts
+++ b/packages/3d/src/core/shape.ts
@@ -502,6 +502,17 @@ export class Shape3D<TState extends Shape3DState = Shape3DState> extends Shape<T
         hitPath.closePath();
     }
 
+    /**
+     * Tests whether a point intersects this shape's projected silhouette.
+     *
+     * The hit path is traced from {@link Context3D.project}, which already emits logical
+     * coordinates, so the point needs no mapping — unlike {@link Shape2D}, whose path is local.
+     *
+     * @param x - X coordinate in logical space (CSS pixels relative to the surface origin), the same space pointer event payloads report.
+     * @param y - Y coordinate in logical space (CSS pixels relative to the surface origin).
+     * @param options - Hit-testing options, such as whether the test originates from a pointer event.
+     * @returns Whether the point lies within the shape's projected faces, honoring its pointer-event region.
+     */
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
         const context = this.context;
         const hitPath = this._getHitPath();

--- a/packages/3d/test/shape.test.ts
+++ b/packages/3d/test/shape.test.ts
@@ -28,6 +28,7 @@ import type {
 
 import {
     createScene,
+    factory,
 } from '@ripl/core';
 
 import type {
@@ -49,6 +50,8 @@ describe('Shape3D', () => {
     let host: HTMLDivElement;
     let paint: PaintLogStub;
 
+    const nativeDevicePixelRatio = factory.devicePixelRatio;
+
     beforeEach(() => {
         paint = mockPaintLog();
         host = document.createElement('div');
@@ -58,6 +61,10 @@ describe('Shape3D', () => {
     });
 
     afterEach(() => {
+        factory.set({
+            devicePixelRatio: nativeDevicePixelRatio,
+        });
+
         host.remove();
         vi.restoreAllMocks();
     });
@@ -434,6 +441,38 @@ describe('Shape3D', () => {
             cube.intersectsWith(x, y, { isPointer: true });
 
             expect(hitPathCalls(createPath, cube.id)).toBe(1);
+        });
+
+        // The pointer pipeline mapped logical onto surface before hit testing, but a 3D hit path is
+        // traced from `project`, which is already logical — so on retina every hit missed by the ratio.
+        test('Should hit a projected face at the logical pointer position on a device-scaled surface', () => {
+            factory.set({
+                devicePixelRatio: 2,
+            });
+
+            const context = createFixture();
+            const cube = createCube({
+                size: 1,
+                fill: '#ff0000',
+            });
+
+            const clicked = vi.fn();
+
+            cube.on('click', clicked);
+            mockPolygonHitTesting(context);
+
+            createScene(context, {
+                children: [cube],
+            }).render();
+
+            const [x, y] = firstFaceCentroid();
+
+            context.element.dispatchEvent(new MouseEvent('click', {
+                clientX: x,
+                clientY: y,
+            }));
+
+            expect(clicked).toHaveBeenCalled();
         });
 
         test('Should rebuild the hit path after the next render', () => {

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -435,9 +435,11 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
             return applyCanvasStroke(this.context, element);
         }
 
+        // Native `isPointInPath` reads its point in untransformed canvas space, so the DPR matrix
+        // the path is drawn through has to be applied to the point by hand.
         public isPointInPath(path: ContextPath, x: number, y: number, fillRule?: FillRule): boolean {
             if (path instanceof CanvasPath) {
-                return canvasIsPointInPath(this.context, path, x, y, fillRule);
+                return canvasIsPointInPath(this.context, path, ...this.toSurfacePoint(x, y), fillRule);
             }
 
             return false;
@@ -445,7 +447,7 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
 
         public isPointInStroke(path: ContextPath, x: number, y: number): boolean {
             if (path instanceof CanvasPath) {
-                return canvasIsPointInStroke(this.context, path, x, y);
+                return canvasIsPointInStroke(this.context, path, ...this.toSurfacePoint(x, y));
             }
 
             return false;

--- a/packages/canvas/test/surface-sizing.test.ts
+++ b/packages/canvas/test/surface-sizing.test.ts
@@ -13,8 +13,13 @@ import {
 } from '@ripl/test-utils';
 
 import {
+    CanvasPath,
     createContext,
 } from '../src';
+
+import {
+    factory,
+} from '@ripl/core';
 
 polyfillPath2D();
 
@@ -111,6 +116,38 @@ describe('Canvas surface sizing', () => {
         context['rescale'](400, 300);
 
         expect(resized).not.toHaveBeenCalled();
+    });
+
+    describe('Hit-test coordinate space', () => {
+
+        const nativeDevicePixelRatio = factory.devicePixelRatio;
+
+        afterEach(() => factory.set({ devicePixelRatio: nativeDevicePixelRatio }));
+
+        // Native `isPointInPath` ignores the CTM, so a logical point handed straight to it missed
+        // the DPR-scaled path by exactly the ratio.
+        test('Should map a logical hit point onto device pixels before the native test', () => {
+            factory.set({ devicePixelRatio: 2 });
+            sizeHost(400, 300);
+
+            const context = createContext(el);
+
+            context.isPointInPath(new CanvasPath(), 125, 47);
+
+            expect(canvasStub.isPointInPath).toHaveBeenLastCalledWith(expect.anything(), 250, 94, undefined);
+        });
+
+        test('Should hand a logical hit point through unchanged on an unscaled surface', () => {
+            factory.set({ devicePixelRatio: 1 });
+            sizeHost(400, 300);
+
+            const context = createContext(el);
+
+            context.isPointInStroke(new CanvasPath(), 125, 47);
+
+            expect(canvasStub.isPointInStroke).toHaveBeenLastCalledWith(expect.anything(), 125, 47);
+        });
+
     });
 
 });

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -674,13 +674,16 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     }
 
     /**
-     * Maps a point from surface space — the space pointer coordinates arrive in, as produced by
+     * Maps a point from surface space — this backend's own drawing coordinates, as produced by
      * {@link Context.scaleX} and {@link Context.scaleY} — into the logical space elements are
-     * authored in.
+     * authored in and every public coordinate is expressed in.
      *
      * Backends disagree on what surface space is: canvas maps logical coordinates onto device
-     * pixels while SVG leaves them identity, so hit testing has to invert what *this* context
+     * pixels while SVG leaves them identity, so a backend has to invert what *this* context
      * actually does rather than assume the device pixel ratio.
+     *
+     * This is a seam for backend implementors, not for consumers — nothing crossing the public API
+     * is in surface space, so a caller holding a pointer coordinate already has a logical one.
      *
      * @param x - X coordinate in surface space.
      * @param y - Y coordinate in surface space.
@@ -691,8 +694,9 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
     }
 
     /**
-     * Maps a point from the logical space elements are authored in back into surface space.
-     * The inverse of {@link Context.toLogicalPoint}.
+     * Maps a point from the logical space elements are authored in into this backend's own drawing
+     * coordinates. The inverse of {@link Context.toLogicalPoint}, and likewise a seam for backend
+     * implementors rather than consumers.
      *
      * @param x - X coordinate in logical space.
      * @param y - Y coordinate in logical space.
@@ -755,12 +759,27 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
         // noop
     }
 
-    /** Tests whether a point is inside the filled region of a path. */
+    /**
+     * Tests whether a point is inside the filled region of a path.
+     *
+     * @param path - The path to test against.
+     * @param x - X coordinate in logical space (CSS pixels relative to the surface origin); a backend whose native test wants its own drawing coordinates converts internally.
+     * @param y - Y coordinate in logical space (CSS pixels relative to the surface origin).
+     * @param fillRule - The fill rule determining what counts as inside. Defaults to the backend's own default.
+     * @returns Whether the point lies inside the path's fill.
+     */
     public isPointInPath(path: ContextPath, x: number, y: number, fillRule?: FillRule): boolean {
         return false;
     }
 
-    /** Tests whether a point is on the stroked outline of a path. */
+    /**
+     * Tests whether a point is on the stroked outline of a path.
+     *
+     * @param path - The path to test against.
+     * @param x - X coordinate in logical space (CSS pixels relative to the surface origin); a backend whose native test wants its own drawing coordinates converts internally.
+     * @param y - Y coordinate in logical space (CSS pixels relative to the surface origin).
+     * @returns Whether the point lies on the path's stroke.
+     */
     public isPointInStroke(path: ContextPath, x: number, y: number): boolean {
         return false;
     }
@@ -773,8 +792,8 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
      * Tests which rendered elements intersect the given point for the given event types,
      * returning them topmost-first — the exact reverse of the order they were painted in.
      *
-     * The point is in surface space, so a caller holding the logical coordinates a pointer event
-     * carries must map them through {@link Context.toSurfacePoint} first.
+     * The point is in logical space — the space pointer event payloads report — so a handler passes
+     * the coordinates it was given straight through.
      *
      * Paint order is the sole key. {@link Context.renderedElements} already records the resolved
      * stacking order (groups paint as contiguous stacking contexts), whereas

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -62,7 +62,7 @@ export interface RenderElement {
     getBoundingBox?(local?: boolean): Box;
     /** Returns whether the element has any listeners registered for the given event. */
     has(event: string): boolean;
-    /** Tests whether the point `(x, y)`, in surface space (see {@link Context.toSurfacePoint}), lies within the element, honoring its pointer-event region. */
+    /** Tests whether the point `(x, y)`, in logical space (CSS pixels relative to the surface origin, as pointer event payloads report), lies within the element, honoring its pointer-event region. */
     intersectsWith(x: number, y: number, options?: Partial<RenderElementIntersectionOptions>): boolean;
     /** Emits an event of the given type carrying the given data on this element. */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/core/element.ts
+++ b/packages/core/src/core/element.ts
@@ -826,13 +826,17 @@ export class Element<
         );
     }
 
-    /** Tests whether a point intersects this element’s bounding box. Override for custom hit testing. */
+    /**
+     * Tests whether a point intersects this element's bounding box. Override for custom hit testing.
+     *
+     * @param x - X coordinate in logical space (CSS pixels relative to the surface origin), the same space pointer event payloads report.
+     * @param y - Y coordinate in logical space (CSS pixels relative to the surface origin).
+     * @param options - Hit-testing options, such as whether the test originates from a pointer event.
+     * @returns Whether the point lies within the element.
+     */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
-        // The point arrives in the context's surface space; the box is logical, so map it back.
-        const point: [number, number] = this.context?.toLogicalPoint(x, y) ?? [x, y];
-
-        return isPointInBox(point, this.getBoundingBox());
+        return isPointInBox([x, y], this.getBoundingBox());
     }
 
     /** Creates an interpolator that transitions from the current state towards the target state, supporting keyframes and custom interpolator overrides. */

--- a/packages/core/src/core/shape.ts
+++ b/packages/core/src/core/shape.ts
@@ -120,7 +120,14 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
         context.applyStroke(path);
     }
 
-    /** Tests whether a point intersects this shape using path-based fill and stroke hit testing. */
+    /**
+     * Tests whether a point intersects this shape using path-based fill and stroke hit testing.
+     *
+     * @param x - X coordinate in logical space (CSS pixels relative to the surface origin), the same space pointer event payloads report.
+     * @param y - Y coordinate in logical space (CSS pixels relative to the surface origin).
+     * @param options - Hit-testing options, such as whether the test originates from a pointer event.
+     * @returns Whether the point lies within the shape's fill or stroke, honoring its pointer-event region.
+     */
     public intersectsWith(x: number, y: number, options?: Partial<ElementIntersectionOptions>) {
         const context = this.context;
         const paths = this.hitPaths;
@@ -135,10 +142,7 @@ export class Shape2D<TState extends BaseElementState = BaseElementState> extends
             const inverse = worldTransform && matrixInvert(worldTransform);
 
             if (inverse) {
-                // The point is in surface space but the world transform is logical, so round-trip it.
-                const local = matrixApplyToPoint(inverse, context.toLogicalPoint(x, y));
-
-                [x, y] = context.toSurfacePoint(local[0], local[1]);
+                [x, y] = matrixApplyToPoint(inverse, [x, y]);
             }
         }
 

--- a/packages/core/test/core/element.test.ts
+++ b/packages/core/test/core/element.test.ts
@@ -289,7 +289,6 @@ describe('Element.intersectsWith', () => {
         vi.restoreAllMocks();
     });
 
-    // An identity-scale surface (SVG) never scales the point up, so dividing by the DPR halved every hit.
     test('Should hit an unscaled surface at the point it was given', () => {
         const context = new TestContext(400, 300, 1);
         const el = boxedElement(context);
@@ -298,12 +297,14 @@ describe('Element.intersectsWith', () => {
         expect(el.intersectsWith(250, 94)).toBe(false);
     });
 
-    test('Should map the point back through the surface scale on a device-scaled surface', () => {
+    // The point used to arrive in surface space, so the CSS-pixel coordinate a pointer event
+    // reports hit or missed depending on the device pixel ratio.
+    test('Should hit a device-scaled surface at the same logical point as an unscaled one', () => {
         const context = new TestContext(400, 300, dpr);
         const el = boxedElement(context);
 
-        expect(el.intersectsWith(250, 94)).toBe(true);
-        expect(el.intersectsWith(125, 47)).toBe(false);
+        expect(el.intersectsWith(125, 47)).toBe(true);
+        expect(el.intersectsWith(250, 94)).toBe(false);
     });
 
 });

--- a/packages/core/test/core/shape.test.ts
+++ b/packages/core/test/core/shape.test.ts
@@ -86,7 +86,7 @@ describe('Shape2D', () => {
         expect(rect.intersectsWith(200, 200)).toBe(false);
     });
 
-    test('Should map a surface-space hit point into local space using the context scale', () => {
+    test('Should map a logical hit point into local space without touching the surface scale', () => {
         const rect = createRect({
             x: 0,
             y: 0,
@@ -98,15 +98,14 @@ describe('Shape2D', () => {
 
         const recorded: [number, number][] = [];
 
-        // A 2x surface: scaleX/scaleY map logical onto device pixels, as rescaleCanvas does.
+        // A 2x surface: scaleX/scaleY map logical onto device pixels, as rescaleCanvas does. The
+        // conversion helpers are omitted so a stray call to either throws rather than passing.
         const scale = (value: number) => value * 2;
 
         (rect as unknown as { context: unknown }).context = {
             hitTestHonorsTransform: false,
             scaleX: scale,
             scaleY: scale,
-            toLogicalPoint: (x: number, y: number) => [x / 2, y / 2],
-            toSurfacePoint: (x: number, y: number) => [x * 2, y * 2],
             layer: (body: () => unknown) => body(),
             isPointInStroke: () => false,
             isPointInPath: (_path: unknown, x: number, y: number) => {
@@ -116,11 +115,10 @@ describe('Shape2D', () => {
         };
         (rect as unknown as { path: unknown }).path = {};
 
-        // Surface point for logical (60, 20) at 2x → (120, 40).
-        rect.intersectsWith(120, 40);
+        rect.intersectsWith(60, 20);
 
-        // surface (120,40) → logical (60,20) → inverse translate(-50) → local (10,20) → surface (20,40).
-        expect(recorded.at(-1)).toEqual([20, 40]);
+        // logical (60,20) → inverse translate(-50) → local (10,20), handed on unscaled.
+        expect(recorded.at(-1)).toEqual([10, 20]);
     });
 
     // A hit test runs after the frame's trailing restore, so the backend stroked at the default width of 1.

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -159,10 +159,6 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         return [event.clientX - state.left, event.clientY - state.top];
     }
 
-    private _hitTestLogical(events: string[], x: number, y: number): RenderElement[] {
-        return this.hitTest(events, ...this.toSurfacePoint(x, y));
-    }
-
     private _handleMouseDown(event: MouseEvent): void {
         this._refreshOrigin();
 
@@ -176,7 +172,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         this.emit('mousedown', payload);
 
-        const hitElements = this._hitTestLogical(PRESS_EVENTS, x, y);
+        const hitElements = this.hitTest(PRESS_EVENTS, x, y);
 
         // Assigned unconditionally: a press that hits nothing must not inherit the last gesture's origin.
         state.dragElement = hitElements.find(element => DRAG_EVENTS.some(dragEvent => element.has(dragEvent)));
@@ -250,7 +246,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
     }
 
     private _handleHoverHitTest(x: number, y: number): void {
-        const hitElements = this._hitTestLogical(['mousemove', 'mouseenter', 'mouseleave'], x, y);
+        const hitElements = this.hitTest(['mousemove', 'mouseenter', 'mouseleave'], x, y);
         const topmost = hitElements.length > 0 ? [hitElements[0]] : [];
 
         const {
@@ -308,7 +304,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         this.emit('mouseup', payload);
 
-        this._hitTestLogical(['mouseup'], x, y).at(0)?.emit('mouseup', payload);
+        this.hitTest(['mouseup'], x, y).at(0)?.emit('mouseup', payload);
 
         if (state.dragStarted) {
             const dragPayload = {
@@ -351,7 +347,7 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
 
         this.emit('click', payload);
 
-        this._hitTestLogical(['click'], x, y).at(0)?.emit('click', payload);
+        this.hitTest(['click'], x, y).at(0)?.emit('click', payload);
     }
 
     /** Enables DOM interaction events (mouse enter, leave, move, down, up, click, drag) with element hit testing. */

--- a/packages/webgpu/src/context.ts
+++ b/packages/webgpu/src/context.ts
@@ -285,7 +285,7 @@ export class WebGPUContext3D extends Context3D {
         return super.createText(options);
     }
 
-    /** Tests whether (x, y) lies inside the given path's fill, using an offscreen 2D canvas. */
+    /** Tests whether the logical-space point (x, y) lies inside the given path's fill, using an offscreen 2D canvas. */
     public isPointInPath(path: ContextPath, x: number, y: number, fillRule?: FillRule): boolean {
         const canvasPath = this._rebuildPath2D(path);
 
@@ -293,10 +293,11 @@ export class WebGPUContext3D extends Context3D {
             return false;
         }
 
-        return this._hitContext.isPointInPath(canvasPath, x, y, fillRule);
+        // The hit canvas carries the same DPR matrix as the surface, which the native test ignores.
+        return this._hitContext.isPointInPath(canvasPath, ...this.toSurfacePoint(x, y), fillRule);
     }
 
-    /** Tests whether (x, y) lies on the given path's stroke, using an offscreen 2D canvas. */
+    /** Tests whether the logical-space point (x, y) lies on the given path's stroke, using an offscreen 2D canvas. */
     public isPointInStroke(path: ContextPath, x: number, y: number): boolean {
         const canvasPath = this._rebuildPath2D(path);
 
@@ -304,7 +305,7 @@ export class WebGPUContext3D extends Context3D {
             return false;
         }
 
-        return this._hitContext.isPointInStroke(canvasPath, x, y);
+        return this._hitContext.isPointInStroke(canvasPath, ...this.toSurfacePoint(x, y));
     }
 
     private _rebuildPath2D(path: ContextPath): Path2D | null {


### PR DESCRIPTION
## The problem

The boundary between Ripl's two coordinate spaces ran straight through the public API. Pointer events report logical space:

```ts
/** X coordinate of the pointer, in logical space (CSS pixels relative to the surface origin). */
x: number;
```

Hit testing took the other one:

```ts
/** Tests whether the point `(x, y)`, in surface space (see {@link Context.toSurfacePoint}), lies within the element… */
intersectsWith(x: number, y: number, options?: Partial<RenderElementIntersectionOptions>): boolean;
```

So a user holding a `mousemove` payload had to know that `intersectsWith` wanted something else, and convert. Four public entry points were affected: `Element.intersectsWith`, `RenderElement.intersectsWith`, `Context.isPointInPath`, `Context.isPointInStroke`.

The cost was not only conceptual. `Shape2D.intersectsWith` had to round-trip a point back and forth across the seam just to apply a transform expressed in the other space:

```ts
// The point is in surface space but the world transform is logical, so round-trip it.
const local = matrixApplyToPoint(inverse, context.toLogicalPoint(x, y));

[x, y] = context.toSurfacePoint(local[0], local[1]);
```

And it hid a live bug. `Shape3D` traces its hit path from `Context3D.project`, which emits logical coordinates — but the pointer pipeline had already scaled the point to device pixels before the test. **On any display with a device pixel ratio above 1, 3D and WebGPU hit testing missed by exactly that ratio.** There was no test covering it.

## The fix

The conversion moves from the caller to the backend, which is the only place that knows its own drawing coordinates. `DOMContext` loses the one line that made the seam public:

```diff
-    private _hitTestLogical(events: string[], x: number, y: number): RenderElement[] {
-        return this.hitTest(events, ...this.toSurfacePoint(x, y));
-    }
```

Handlers now pass `hitTest` the coordinates they emit. `Element.intersectsWith` tests the box directly, `Shape2D.intersectsWith` applies the inverse world transform to the logical point with no round-trip, and canvas and WebGPU convert inside `isPointInPath`/`isPointInStroke` — the one place it is genuinely needed, because native `isPointInPath` reads its point in untransformed canvas space while the path goes through the current matrix.

SVG and terminal need no conversion at all (identity, and `isPointIn*` always `false` respectively), which is a good sign the seam is now in the right place.

`toLogicalPoint`/`toSurfacePoint` keep their behaviour and stay public — they are still required for a custom backend, and the terminal still overrides them for its letterbox offset. Their docs now say they are a backend seam rather than something a consumer calls.

## Verification

- `yarn test` — 211 files, 2748 tests, 2 skipped, 1 todo. All pass.
- `yarn lint`, `yarn typecheck` — clean.
- TypeDoc `notDocumented` — clean across `core`, `canvas`, `svg`, `dom`, `3d`, `webgpu` and `terminal`.

Four tests pin the change. Re-run against the pre-change source, **all four fail**:

| Test | What it pins |
|---|---|
| `element.test.ts` — hits a device-scaled surface at the same logical point | the DPR no longer decides whether a CSS-pixel coordinate hits |
| `shape.test.ts` — maps a logical point into local space without touching the surface scale | the round-trip is gone; the mock context omits the conversion helpers entirely, so a stray call throws rather than passing |
| `surface-sizing.test.ts` — maps a logical point onto device pixels before the native test | the canvas backend converts at its own boundary |
| `3d/shape.test.ts` — hits a projected face at the logical pointer position on a device-scaled surface | end-to-end through the real pointer pipeline at DPR 2; this is the retina bug above |

Two existing tests asserted the old contract and are inverted rather than deleted, so the reversal is visible in the diff.

Not verified: no browser here, so the by-hand check at 200% browser zoom on a canvas and an SVG demo is outstanding, as is `/demos/jet-engine-webgpu/` (jsdom has no WebGPU, so the WebGPU path is covered only by the shared conversion, not directly).

## Breaking

Full details and a migration checklist in `docs/migrations/coordinate-spaces.md`. In short:

- **`Element.intersectsWith`, `Shape2D.intersectsWith`, `Context.isPointInPath`, `Context.isPointInStroke` and `Context.hitTest` take logical coordinates.** If you were converting with `toSurfacePoint` before calling them, delete the conversion — it now doubles the point on retina. At DPR 1, and on SVG at any DPR, nothing moves.
- **A custom `Context` that forwards `isPointInPath`/`isPointInStroke` to a native canvas test must now convert the point itself** with `this.toSurfacePoint(x, y)`.
- **A custom `Element.intersectsWith` override that converted the point must stop.**

Element coordinates, event payloads, bounding boxes, `Context.width`/`height` and the navigator were already logical and are untouched.

## Follow-ups

Two related coordinate leaks are deliberately left for the next PR in this stack: `CanvasContext.setTransform` replaces the DPR matrix rather than composing onto it, and `Context3D`/`WebGPUContext` emit `resize` before their DPR-aware scales land.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SB6FkCaFeXfPmA3W97LZB)_