### PR TITLE
Keep the device-pixel matrix under a caller's transform

### DIFF
--- a/docs/migrations/coordinate-spaces.md
+++ b/docs/migrations/coordinate-spaces.md
@@ -57,6 +57,23 @@ incoming logical point onto device pixels before the native call. Native `isPoin
 point in untransformed canvas space while the path is transformed by the current matrix, so the
 device-pixel-ratio matrix installed by `rescaleCanvas` has to be applied to the point by hand.
 
+**`CanvasContext.setTransform`** — **behaviour**. The matrix is composed onto the surface's own
+device-pixel base rather than replacing the current one outright. Previously
+`context.setTransform(1, 0, 0, 1, 0, 0)` wiped the ratio matrix `rescaleCanvas` installs, so on a
+retina display it meant "identity in device pixels" — everything drawn afterwards rendered at half
+size, and the translation components were device pixels rather than CSS ones. **Code that
+compensated by passing the device pixel ratio itself (`setTransform(dpr, 0, 0, dpr, 0, 0)`) now
+applies it twice and must drop it.** `transform`, `rotate`, `scale` and `translate` are relative and
+were always correct; they are unchanged.
+
+## @ripl/3d and @ripl/webgpu
+
+**`Context3D.rescale`** and **`WebGPUContext.rescale`** — **behaviour**. `resize` is emitted after
+the device-scaled `scaleX`/`scaleY` and the rebuilt projection matrix are in place, rather than from
+`super.rescale` before either. A bound scene repaints synchronously on `resize`, so the first frame
+after a size change was drawn with identity scales and the previous frame's projection. A `resize`
+handler that read `Context.scaleX` to compensate for the old behaviour should stop.
+
 ## @ripl/webgpu
 
 **`WebGPUContext.isPointInPath`** and **`WebGPUContext.isPointInStroke`** — **behaviour**, and a bug
@@ -65,8 +82,6 @@ surface. Previously `Shape3D` traced its hit path from `Context3D.project`, whic
 coordinates, and compared it against a point the pointer pipeline had already scaled to device
 pixels — so **on a display with a device pixel ratio above 1, hit testing missed by exactly that
 ratio**. No action required; hit testing starts working.
-
-## @ripl/3d
 
 **`Shape3D.intersectsWith`** — **behaviour**. Takes a logical point. The hit path is traced from
 `Context3D.project`, which already emits logical coordinates, so no conversion happens here — the
@@ -87,5 +102,7 @@ longer exists when reading the interaction code.
 2. If you implement a custom `Context` that forwards `isPointInPath`/`isPointInStroke` to a native
    canvas test, add the conversion inside those methods.
 3. If you override `Element.intersectsWith` and converted the point, stop.
-4. Nothing else. Element coordinates, event payloads, bounding boxes, `Context.width`/`height` and
+4. Search for `setTransform`. If you passed the device pixel ratio to compensate for the old
+   replace-outright behaviour, drop it — the backend now supplies it.
+5. Nothing else. Element coordinates, event payloads, bounding boxes, `Context.width`/`height` and
    the navigator were already logical and are untouched.

--- a/packages/3d/src/core/context.ts
+++ b/packages/3d/src/core/context.ts
@@ -364,14 +364,18 @@ export class CanvasContext3D extends canvas2DStateMixin(Context3D) {
 
         const result = rescaleCanvas(this.element, this.context, width, height);
 
-        super.rescale(width, height);
-
+        this.width = width;
+        this.height = height;
         this.scaleX = result.scaleX;
         this.scaleY = result.scaleY;
 
         if (this.viewMatrix) {
             this.updateProjectionMatrix();
         }
+
+        // Emitted last, not through `super.rescale`: a bound scene repaints synchronously here, and
+        // would otherwise draw under identity scales and the previous projection.
+        this.emit('resize', null);
     }
 
     /** Begins a render pass, resetting the frame's face buffer and clip tracking at the outermost depth. */

--- a/packages/3d/test/context.test.ts
+++ b/packages/3d/test/context.test.ts
@@ -15,6 +15,7 @@ import {
 
 import {
     createScene,
+    factory,
 } from '@ripl/core';
 
 import {
@@ -207,6 +208,50 @@ describe('Context3D surface sizing', () => {
 
         expect(ctx.width).toBe(640);
         expect(ctx.height).toBe(480);
+    });
+
+    describe('Resize ordering', () => {
+
+        const nativeDevicePixelRatio = factory.devicePixelRatio;
+
+        afterEach(() => factory.set({ devicePixelRatio: nativeDevicePixelRatio }));
+
+        // `super.rescale` installs identity scales and emits before the DPR-aware ones land, so a
+        // scene repainting synchronously on resize placed one frame at half scale.
+        test('Should install the device-scaled surface scales before announcing a resize', () => {
+            factory.set({ devicePixelRatio: 2 });
+            sizeHost(400, 300);
+
+            const ctx = createContext(document.createElement('div'));
+            const observed: number[] = [];
+
+            ctx.on('resize', () => observed.push(ctx.scaleX(100)));
+
+            sizeHost(500, 300);
+            ctx['rescale'](500, 300);
+
+            expect(observed).toEqual([200]);
+        });
+
+        test('Should rebuild the projection before announcing a resize', () => {
+            sizeHost(400, 300);
+
+            const ctx = createContext(document.createElement('div'));
+
+            ctx.setCamera([0, 0, 5], [0, 0, 0], [0, 1, 0]);
+
+            const observed: unknown[] = [];
+
+            ctx.on('resize', () => observed.push(ctx.viewProjectionMatrix));
+
+            const before = ctx.viewProjectionMatrix;
+
+            sizeHost(800, 300);
+            ctx['rescale'](800, 300);
+
+            expect(observed[0]).not.toBe(before);
+        });
+
     });
 
 });

--- a/packages/canvas/src/mixins.ts
+++ b/packages/canvas/src/mixins.ts
@@ -401,9 +401,14 @@ export function canvas2DStateMixin<TBase extends AbstractConstructor<Context>>(B
             return this.context.translate(x, y);
         }
 
+        // Composed onto the DPR base rather than replacing it: the matrix a caller passes is in
+        // logical space, and assigning it outright reinterprets those units as device pixels.
         // eslint-disable-next-line id-length
         public setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
-            return this.context.setTransform(a, b, c, d, e, f);
+            const dpr = factory.devicePixelRatio ?? 1;
+
+            this.context.setTransform(dpr, 0, 0, dpr, 0, 0);
+            this.context.transform(a, b, c, d, e, f);
         }
 
         // eslint-disable-next-line id-length

--- a/packages/canvas/test/audit.test.ts
+++ b/packages/canvas/test/audit.test.ts
@@ -335,4 +335,56 @@ describe('Canvas audit findings', () => {
         expect(measured[0]?.textBaseline).toBe('middle');
     });
 
+    describe('Transform coordinate space', () => {
+
+        const nativeDevicePixelRatio = factory.devicePixelRatio;
+
+        afterEach(() => factory.set({ devicePixelRatio: nativeDevicePixelRatio }));
+
+        // `setTransform` replaced the CTM outright, taking the DPR matrix `rescaleCanvas` installed
+        // with it — so a logical-space identity silently became a device-space one.
+        test('Should keep the device-pixel matrix under a logical identity transform', () => {
+            factory.set({ devicePixelRatio: 2 });
+
+            const state = mockCanvasState(mockCanvasContext());
+
+            sizeHost(400, 300);
+
+            const context = createContext(el);
+
+            context.setTransform(1, 0, 0, 1, 0, 0);
+
+            expect(state.getMatrix()).toEqual([2, 0, 0, 2, 0, 0]);
+        });
+
+        test('Should express a set transform translation in logical pixels', () => {
+            factory.set({ devicePixelRatio: 2 });
+
+            const state = mockCanvasState(mockCanvasContext());
+
+            sizeHost(400, 300);
+
+            const context = createContext(el);
+
+            context.setTransform(1, 0, 0, 1, 10, 20);
+
+            expect(state.getMatrix()).toEqual([2, 0, 0, 2, 20, 40]);
+        });
+
+        test('Should leave a set transform alone on an unscaled surface', () => {
+            factory.set({ devicePixelRatio: 1 });
+
+            const state = mockCanvasState(mockCanvasContext());
+
+            sizeHost(400, 300);
+
+            const context = createContext(el);
+
+            context.setTransform(2, 0, 0, 2, 5, 5);
+
+            expect(state.getMatrix()).toEqual([2, 0, 0, 2, 5, 5]);
+        });
+
+    });
+
 });

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -647,12 +647,17 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
 
     /**
      * Replaces the current transformation matrix with `[a, b, c, d, e, f]`.
+     *
+     * The matrix is in logical space, so the identity `(1, 0, 0, 1, 0, 0)` restores the context's
+     * own baseline rather than the backend's — on canvas that baseline is the device pixel ratio,
+     * which the backend composes back underneath. Translations are therefore in CSS pixels.
+     *
      * @param a Horizontal scaling.
      * @param b Vertical skewing.
      * @param c Horizontal skewing.
      * @param d Vertical scaling.
-     * @param e Horizontal translation.
-     * @param f Vertical translation.
+     * @param e Horizontal translation, in logical pixels.
+     * @param f Vertical translation, in logical pixels.
      */
     // eslint-disable-next-line id-length
     public setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {

--- a/packages/core/test/context/context.test.ts
+++ b/packages/core/test/context/context.test.ts
@@ -917,13 +917,17 @@ describe('Context', () => {
             ctx.destroy();
         });
 
-        test('setTransform should delegate to native', () => {
+        // Not plain delegation: the caller's matrix is logical, so it composes onto the surface's
+        // own base (the device pixel ratio) rather than replacing it.
+        test('setTransform should compose the caller matrix onto the surface base', () => {
             const ctx = create();
 
             canvasStub.setTransform.mockClear();
+            canvasStub.transform.mockClear();
             ctx.setTransform(1, 0, 0, 1, 5, 10);
 
-            expect(canvasStub.setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 5, 10);
+            expect(canvasStub.setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0);
+            expect(canvasStub.transform).toHaveBeenCalledWith(1, 0, 0, 1, 5, 10);
 
             ctx.destroy();
         });

--- a/packages/webgpu/src/context.ts
+++ b/packages/webgpu/src/context.ts
@@ -149,8 +149,8 @@ export class WebGPUContext3D extends Context3D {
         this._hitCanvas.height = scaledHeight;
         this._hitContext.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-        super.rescale(width, height);
-
+        this.width = width;
+        this.height = height;
         this.scaleX = scaleContinuous([0, width], [0, scaledWidth]);
         this.scaleY = scaleContinuous([0, height], [0, scaledHeight]);
 
@@ -160,6 +160,10 @@ export class WebGPUContext3D extends Context3D {
         if (this.viewMatrix) {
             this.updateProjectionMatrix();
         }
+
+        // Emitted last, not through `super.rescale`: a bound scene repaints synchronously here, and
+        // would otherwise draw under identity scales and against textures still at the old size.
+        this.emit('resize', null);
     }
 
     // Views are immutable, so they are cached with the texture rather than rebuilt every frame.


### PR DESCRIPTION
Stacked on #89 — review that first; this PR's diff is only the second commit.

Two remaining places where a coordinate handed in as logical was silently reinterpreted, found while auditing the seam in #89.

## `setTransform` wiped the device-pixel matrix

`rescaleCanvas` installs `setTransform(dpr, 0, 0, dpr, 0, 0)` so every draw call can be written in CSS pixels. The public `setTransform` handed the caller's matrix straight to the native context:

```ts
public setTransform(a: number, b: number, c: number, d: number, e: number, f: number): void {
    return this.context.setTransform(a, b, c, d, e, f);
}
```

Native `setTransform` *replaces* the CTM, so that took the ratio matrix with it. On a retina display `context.setTransform(1, 0, 0, 1, 0, 0)` meant "identity in device pixels": everything drawn afterwards rendered at half size, and `e`/`f` were device pixels rather than CSS ones. The context's own `reset()` already knew this and re-installed the matrix afterwards (`mixins.ts:386-389`) — the transform API was the gap.

The fix composes onto the base instead of replacing it, written as two native calls rather than hand-multiplied matrix entries so it stays readable:

```ts
const dpr = factory.devicePixelRatio ?? 1;

this.context.setTransform(dpr, 0, 0, dpr, 0, 0);
this.context.transform(a, b, c, d, e, f);
```

`transform`, `rotate`, `scale` and `translate` are relative and were always correct. `applyElementTransform` uses only those, so **element transforms are unaffected** — I checked this specifically, because if it had used `setTransform` this would have been a far bigger change.

## `resize` fired before the scales it describes

`Context3D` and `WebGPUContext` both called `super.rescale(...)`, which installs *identity* scales and emits `resize`, and only then assigned their device-aware ones:

```ts
super.rescale(width, height);

this.scaleX = result.scaleX;
this.scaleY = result.scaleY;

if (this.viewMatrix) {
    this.updateProjectionMatrix();
}
```

A bound scene repaints synchronously on `resize`, so the first frame after any size change was drawn with identity scales *and* the previous frame's projection matrix. `CanvasContext.rescale` already avoided this and says so in a comment; the 3D backends had drifted from it.

Both now assign, rebuild, and emit last. The projection rebuild has to sit inside that window rather than after it, because `updateProjectionMatrix` reads `this.width`/`this.height` for the aspect ratio — which is why this is ordered by hand in each backend rather than factored into a shared helper.

## Verification

- `yarn test` — 211 files, 2753 tests, 2 skipped, 1 todo. All pass.
- `yarn lint`, `yarn typecheck` — clean.
- TypeDoc `notDocumented` — clean across `core`, `canvas`, `3d`, `webgpu`.

Four new tests, **all four failing against the pre-change source**:

- a logical identity leaves a native CTM of `(2,0,0,2,0,0)` at DPR 2
- `setTransform(1,0,0,1,10,20)` translates by 20/40 device pixels, i.e. 10/20 CSS pixels
- a `resize` handler on `Context3D` observes device-scaled `scaleX`, not identity
- a `resize` handler observes the rebuilt projection matrix, not the previous one

A third test pins that an unscaled surface still passes the matrix through unchanged, so the composition is a no-op at DPR 1.

One existing test, `setTransform should delegate to native`, asserted the exact behaviour being changed. It is rewritten to assert the composition rather than deleted, so the reversal shows up in the diff.

Not verified: the chart visual-regression baselines. Per the repo's own guidance these are rendered on a specific Linux Chromium and comparing against them from this sandbox proves nothing, and I did not have a browser here to render the gallery on both branches and diff those instead. **Given this PR changes what reaches the canvas on retina, that comparison is worth running before merge.**

## Breaking

- **`CanvasContext.setTransform` composes onto the device-pixel base instead of replacing the matrix.** Code that compensated by passing the ratio itself — `setTransform(dpr, 0, 0, dpr, 0, 0)` — now applies it twice and must drop it. At DPR 1 nothing changes.
- **`Context3D`/`WebGPUContext` emit `resize` after their scales and projection are current.** A handler that read `Context.scaleX` expecting the pre-resize value, or compensated for the stale projection, should stop.

Migration notes appended to `docs/migrations/coordinate-spaces.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SB6FkCaFeXfPmA3W97LZB)_