### PR TITLE
Move the graphing calculator presets into a header catalogue

### DIFF
--- a/apps/website/src/.vitepress/components/ripl-config-drawer.vue
+++ b/apps/website/src/.vitepress/components/ripl-config-drawer.vue
@@ -8,9 +8,11 @@
             @click="$emit('update:modelValue', false)"
         ></div>
         <aside
+            ref="panel"
             class="ripl-config-drawer__panel"
             role="dialog"
-            aria-label="Chart options"
+            tabindex="-1"
+            :aria-label="title"
         >
             <header class="ripl-config-drawer__header">
                 <span class="ripl-config-drawer__title">{{ title }}</span>
@@ -33,23 +35,60 @@
 </template>
 
 <script lang="ts" setup>
-withDefaults(defineProps<{
+import {
+    nextTick,
+    onBeforeUnmount,
+    ref,
+    watch,
+} from 'vue';
+
+const props = withDefaults(defineProps<{
+    /** Whether the drawer is open. */
     modelValue: boolean;
+    /** Heading shown in the drawer, and the dialog's accessible name. */
     title?: string;
 }>(), {
     title: 'Customize',
 });
 
-defineEmits<{
+const emit = defineEmits<{
+    /** The drawer was opened or dismissed. */
     'update:modelValue': [value: boolean];
 }>();
+
+const panel = ref<HTMLElement | null>(null);
+
+let previouslyFocused: HTMLElement | null = null;
+
+function onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+        emit('update:modelValue', false);
+    }
+}
+
+watch(() => props.modelValue, async open => {
+    if (open) {
+        previouslyFocused = document.activeElement as HTMLElement | null;
+        window.addEventListener('keydown', onKeydown);
+        await nextTick();
+        panel.value?.focus();
+
+        return;
+    }
+
+    window.removeEventListener('keydown', onKeydown);
+    previouslyFocused?.focus();
+    previouslyFocused = null;
+});
+
+onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 </script>
 
 <style scoped>
 .ripl-config-drawer {
     position: absolute;
     inset: 0;
-    z-index: 10;
+    z-index: var(--ripl-drawer-z, 10);
     pointer-events: none;
 }
 
@@ -68,7 +107,7 @@ defineEmits<{
     bottom: 0;
     display: flex;
     flex-direction: column;
-    width: min(340px, 92%);
+    width: var(--ripl-drawer-width, min(340px, 92%));
     background-color: var(--vp-c-bg);
     border-left: 1px solid var(--vp-c-divider);
     box-shadow: -4px 0 16px rgba(0, 0, 0, 0.08);

--- a/apps/website/src/.vitepress/components/ripl-config-drawer.vue
+++ b/apps/website/src/.vitepress/components/ripl-config-drawer.vue
@@ -71,7 +71,10 @@ watch(() => props.modelValue, async open => {
         previouslyFocused = document.activeElement as HTMLElement | null;
         window.addEventListener('keydown', onKeydown);
         await nextTick();
-        panel.value?.focus();
+
+        // The panel is still translated off-screen mid-transition, so a scrolling focus drags the
+        // page across to meet it and the slide-in plays on the content instead of the drawer.
+        panel.value?.focus({ preventScroll: true });
 
         return;
     }
@@ -113,6 +116,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
     box-shadow: -4px 0 16px rgba(0, 0, 0, 0.08);
     transform: translateX(100%);
     transition: transform 220ms ease-out;
+}
+
+/* Focused only to move the keyboard into the dialog; it is not tabbable, so it shows no ring. */
+.ripl-config-drawer__panel:focus {
+    outline: none;
 }
 
 .ripl-config-drawer--open {

--- a/apps/website/src/demos/graphing-calculator/components/preset-gallery.vue
+++ b/apps/website/src/demos/graphing-calculator/components/preset-gallery.vue
@@ -65,8 +65,8 @@ const groups = computed(() => {
 .preset-gallery {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-    padding: 0.625rem;
+    gap: 1.25rem;
+    padding: 1rem;
 }
 
 .preset-gallery__heading {
@@ -92,7 +92,7 @@ const groups = computed(() => {
 .preset-gallery__items {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
-    gap: 0.375rem;
+    gap: 0.5rem;
     margin: 0;
     padding: 0;
     list-style: none;

--- a/apps/website/src/demos/graphing-calculator/graphing-calculator.vue
+++ b/apps/website/src/demos/graphing-calculator/graphing-calculator.vue
@@ -16,12 +16,23 @@
                     <RiplButton
                         :active="panelOpen"
                         aria-label="Toggle the equation panel"
-                        @click="panelOpen = !panelOpen"
+                        @click="onPanelToggle"
                     >
                         <PanelLeft :size="14" />
                         Equations
                     </RiplButton>
                 </div>
+
+                <RiplButton
+                    :active="catalogueOpen"
+                    aria-haspopup="dialog"
+                    :aria-expanded="catalogueOpen"
+                    title="Browse preset plots"
+                    @click="onCatalogueToggle"
+                >
+                    <LayoutGrid :size="14" />
+                    Presets
+                </RiplButton>
 
                 <RiplButtonGroup
                     :model-value="mode"
@@ -60,15 +71,6 @@
                     />
                 </section>
 
-                <section class="graphing-calculator__section">
-                    <h2 class="graphing-calculator__section-title">Presets</h2>
-                    <PresetGallery
-                        :presets="PRESETS"
-                        :mode="mode"
-                        @select="onPresetSelect"
-                    />
-                </section>
-
                 <p class="graphing-calculator__note">
                     Forms: <code>y =</code>, <code>x =</code>, <code>r =</code>, <code>z =</code>,
                     <code>(f(t), g(t))</code>, or an equation in x and y. Inequalities, regression fits and
@@ -95,6 +97,18 @@
                     label="Loading the expression engine"
                 />
             </div>
+
+            <RiplConfigDrawer
+                v-model="catalogueOpen"
+                class="graphing-calculator__catalogue"
+                title="Presets"
+            >
+                <PresetGallery
+                    :presets="PRESETS"
+                    :mode="mode"
+                    @select="onPresetSelect"
+                />
+            </RiplConfigDrawer>
         </div>
     </div>
 </template>
@@ -105,6 +119,7 @@ import ParameterSliders from './components/parameter-sliders.vue';
 import PresetGallery from './components/preset-gallery.vue';
 import RiplButton from '../../.vitepress/components/ripl-button.vue';
 import RiplButtonGroup from '../../.vitepress/components/ripl-button-group.vue';
+import RiplConfigDrawer from '../../.vitepress/components/ripl-config-drawer.vue';
 import RiplControlGroup from '../../.vitepress/components/ripl-control-group.vue';
 import RiplSpinner from '../../.vitepress/components/ripl-spinner.vue';
 
@@ -122,6 +137,7 @@ import {
 } from 'vitepress';
 
 import {
+    LayoutGrid,
     PanelLeft,
     RotateCcw,
 } from 'lucide-vue-next';
@@ -267,6 +283,7 @@ const expressions = ref<GraphExpression[]>([]);
 const params = ref<ParameterState[]>([]);
 const viewport = ref<SurfaceDomain>({ ...DEFAULT_VIEWPORT });
 const panelOpen = ref(false);
+const catalogueOpen = ref(false);
 const loading = ref(true);
 
 const compiled = new Map<string, CompiledExpression>();
@@ -731,7 +748,19 @@ function onPresetSelect(preset: GraphPreset): void {
     }
 
     panelOpen.value = false;
+    catalogueOpen.value = false;
     scheduleSave();
+}
+
+// Both are overlays on small screens, so opening one has to dismiss the other.
+function onCatalogueToggle(): void {
+    catalogueOpen.value = !catalogueOpen.value;
+    panelOpen.value = false;
+}
+
+function onPanelToggle(): void {
+    panelOpen.value = !panelOpen.value;
+    catalogueOpen.value = false;
 }
 
 function onResetView(): void {

--- a/apps/website/src/demos/graphing-calculator/styles/graphing-calculator.scss
+++ b/apps/website/src/demos/graphing-calculator/styles/graphing-calculator.scss
@@ -97,6 +97,12 @@
     display: block;
 }
 
+// Wide enough for two columns of preset cards, and above the mobile equations drawer's z-index 20.
+.graphing-calculator__catalogue {
+    --ripl-drawer-width: min(30rem, 94%);
+    --ripl-drawer-z: 30;
+}
+
 .graphing-calculator__scrim {
     display: none;
 }

--- a/apps/website/src/demos/graphing-calculator/styles/graphing-calculator.scss
+++ b/apps/website/src/demos/graphing-calculator/styles/graphing-calculator.scss
@@ -4,6 +4,7 @@
     height: calc(100vh - var(--vp-nav-height));
     overflow: hidden;
     border-top: 1px solid var(--vp-c-divider);
+    border-right: 1px solid var(--vp-c-divider);
 }
 
 .graphing-calculator__header {


### PR DESCRIPTION
## The problem

Fourteen preset cards sat in a third section of the 21rem sidebar, below Expressions and Parameters. On a laptop the equations the demo is actually about were pushed most of the way off screen, and the presets themselves were squeezed into a single narrow column.

## The fix

The presets move to a `Presets` button in the header's `RiplControlGroup`, opening a `RiplConfigDrawer` over the calculator body. The sidebar keeps Expressions and Parameters.

`preset-gallery.vue` is reused unchanged apart from spacing — its mode-first grouping and two-line description cards were already right, they just needed room. In the wider drawer the existing `minmax(12rem, 1fr)` grid lands on two columns without any change to the rule.

Rather than add props for the two things the calculator needed to vary, `RiplConfigDrawer` exposes `--ripl-drawer-width` and `--ripl-drawer-z`, matching the `--ripl-panel-pad` hook already in that file. The calculator sets both in one place. The z-index override matters: the mobile equations drawer sits at 20, and the catalogue has to clear it.

Three accessibility fixes to `RiplConfigDrawer` while I was in there, all of which the catalogue needs and `ripl-chart-config.vue` gets for free:

- `aria-label` was hardcoded to `"Chart options"` regardless of the `title` prop; it now derives from `title`.
- Escape closes the drawer.
- Focus moves into the panel on open and returns to the trigger on close.

The trigger carries `aria-haspopup="dialog"` and `aria-expanded`. Opening either overlay dismisses the other, since on a phone they would otherwise stack.

## Verification

- `yarn lint`, `yarn typecheck` — clean.
- `yarn workspace @ripl/website build` — succeeds (213s), including the chart-options and config-coverage checks.
- Driven in the built site with the sandbox's Chromium, at 1440×900 and 390×844. **No page errors.** Confirmed:
  - the catalogue lists all 14 presets under "2D curves" and "3D surfaces", current mode first, descriptions intact, with the "switches mode" note on the non-current group
  - `getByRole('dialog', { name: 'Presets' })` resolves, so the accessible name is right
  - focus lands on the panel on open, and returns to the Presets button after Escape
  - picking "Monkey saddle" loads `z = x^3 - 3*x*y^2`, flips the mode toggle to 3D, closes the catalogue, and renders the surface
  - clicking the overlay dismisses
  - the sidebar contains only Expressions and Parameters

Screenshots of desktop, desktop-with-catalogue, and mobile-with-catalogue were reviewed; the mobile drawer is a single column at 94% width with the Equations toggle still reachable.

`data/presets.ts` and `data/presets.test.ts` are untouched.

## Note

The site build regenerates `apps/website/src/docs/api/typedoc-sidebar.json`, which is checked in and already stale on `main` — it is missing `ProjectedFaceState3D`, `contextIsContext3D` and others that exist today. I reverted that file rather than fold an unrelated 150-line regeneration into this PR, but it is worth regenerating separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_014SB6FkCaFeXfPmA3W97LZB)_