### PR TITLE
Size the legend swatch from its row, not a fixed 10 pixels

### DIFF
--- a/packages/charts/src/components/legend.ts
+++ b/packages/charts/src/components/legend.ts
@@ -75,8 +75,10 @@ export interface LegendOptions extends ChartComponentOptions {
     onHighlight?: (id: string | null) => void;
 }
 
-const SWATCH_SIZE = 10;
-const SWATCH_RADIUS = 2;
+/** Smallest a swatch may be. It otherwise fills its row, so it scales with the label beside it. */
+const MIN_SWATCH_SIZE = 10;
+/** Corner radius as a fraction of the swatch, so a larger swatch keeps the same rounded look. */
+const SWATCH_RADIUS_RATIO = 0.2;
 const ITEM_GAP_X = SPACING.md;
 const ROW_GAP = SPACING.sm;
 const LABEL_GAP = SPACING.sm;
@@ -87,6 +89,7 @@ const INACTIVE_LABEL_COLOR = '#999999';
 
 interface ItemPlacement {
     item: LegendItem;
+    swatchSize: number;
     swatchX: number;
     swatchY: number;
     labelX: number;
@@ -173,8 +176,16 @@ export class Legend extends ChartComponent {
         return width;
     }
 
+    /**
+     * The swatch fills its row, so it stays square against the label rather than a fixed size that
+     * a backend's own resolution can make far larger or far smaller than the text beside it.
+     */
+    private get _swatchSize(): number {
+        return Math.max(MIN_SWATCH_SIZE, this._fontHeight);
+    }
+
     private _itemWidth(item: LegendItem): number {
-        return SWATCH_SIZE + LABEL_GAP + this._measureLabel(item.label);
+        return this._swatchSize + LABEL_GAP + this._measureLabel(item.label);
     }
 
     /**
@@ -182,7 +193,8 @@ export class Legend extends ChartComponent {
      * Horizontal legends wrap across the available width; vertical legends stack in a column.
      */
     private _computeLayout(region: ChartArea): LegendLayout {
-        const rowHeight = Math.max(SWATCH_SIZE, this._fontHeight);
+        const swatchSize = this._swatchSize;
+        const rowHeight = swatchSize;
         const placements: ItemPlacement[] = [];
 
         if (this._isHorizontal) {
@@ -220,8 +232,9 @@ export class Legend extends ChartComponent {
                     placements.push({
                         item,
                         swatchX: x,
-                        swatchY: y + (rowHeight - SWATCH_SIZE) / 2,
-                        labelX: x + SWATCH_SIZE + LABEL_GAP,
+                        swatchSize,
+                        swatchY: y + (rowHeight - swatchSize) / 2,
+                        labelX: x + swatchSize + LABEL_GAP,
                         labelY: y + rowHeight / 2,
                     });
 
@@ -249,8 +262,9 @@ export class Legend extends ChartComponent {
             placements.push({
                 item,
                 swatchX: x,
-                swatchY: y + (rowHeight - SWATCH_SIZE) / 2,
-                labelX: x + SWATCH_SIZE + LABEL_GAP,
+                swatchSize,
+                swatchY: y + (rowHeight - swatchSize) / 2,
+                labelX: x + swatchSize + LABEL_GAP,
                 labelY: y + rowHeight / 2,
             });
 
@@ -330,9 +344,9 @@ export class Legend extends ChartComponent {
                 id: `legend-swatch-${item.id}`,
                 x: placement.swatchX,
                 y: placement.swatchY,
-                width: SWATCH_SIZE,
-                height: SWATCH_SIZE,
-                borderRadius: SWATCH_RADIUS,
+                width: placement.swatchSize,
+                height: placement.swatchSize,
+                borderRadius: placement.swatchSize * SWATCH_RADIUS_RATIO,
                 fill: isActive ? item.color : INACTIVE_COLOR,
                 opacity: animation?.enabled ? 0 : restOpacity,
                 data: item,
@@ -394,12 +408,17 @@ export class Legend extends ChartComponent {
             const target = placementById.get(item.id)!;
 
             if (animation?.enabled) {
+                // Size is tweened, not assigned: it tracks the row, so a font or backend change
+                // between renders resizes an existing swatch rather than leaving it at its old size.
                 this.renderer.transition(swatch, {
                     duration: animation.duration,
                     ease: animation.ease,
                     state: {
                         x: target.swatchX,
                         y: target.swatchY,
+                        width: target.swatchSize,
+                        height: target.swatchSize,
+                        borderRadius: target.swatchSize * SWATCH_RADIUS_RATIO,
                         opacity: isActive ? 1 : 0.5,
                     },
                 });
@@ -418,6 +437,9 @@ export class Legend extends ChartComponent {
             } else {
                 swatch.x = target.swatchX;
                 swatch.y = target.swatchY;
+                swatch.width = target.swatchSize;
+                swatch.height = target.swatchSize;
+                swatch.borderRadius = target.swatchSize * SWATCH_RADIUS_RATIO;
                 swatch.opacity = isActive ? 1 : 0.5;
 
                 if (label) {

--- a/packages/charts/test/legend-swatch.test.ts
+++ b/packages/charts/test/legend-swatch.test.ts
@@ -1,0 +1,171 @@
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    mockTextMetrics,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createBarChart,
+} from '../src';
+
+/** The smallest a swatch may be, mirroring the legend's own floor. */
+const MIN_SWATCH_SIZE = 10;
+
+interface ChartInternals {
+    scene: {
+        getElementById(id: string): {
+            width: number;
+            height: number;
+            borderRadius: number;
+            y: number;
+        } | null;
+    };
+}
+
+interface LabelInternals {
+    scene: {
+        getElementById(id: string): {
+            y: number;
+        } | null;
+    };
+}
+
+/** Builds a two-series bar chart whose legend reports the given font metrics. */
+function createChart(metrics: {
+    ascent: number;
+    descent: number;
+}) {
+    polyfillPath2D();
+
+    const stub = mockCanvasContext();
+
+    mockTextMetrics(stub, metrics);
+
+    const chart = createBarChart(document.createElement('div'), {
+        autoRender: false,
+        animation: false,
+        data: [
+            {
+                m: 'a',
+                small: 8,
+                large: 100,
+            },
+            {
+                m: 'b',
+                small: 12,
+                large: 140,
+            },
+        ],
+        key: 'm',
+        series: [
+            {
+                id: 'small',
+                label: 'Small',
+                value: 'small' as const,
+            },
+            {
+                id: 'large',
+                label: 'Large',
+                value: 'large' as const,
+            },
+        ],
+    });
+
+    return {
+        chart,
+        stub,
+        swatch: () => (chart as unknown as ChartInternals).scene.getElementById('legend-swatch-small')!,
+        label: () => (chart as unknown as LabelInternals).scene.getElementById('legend-label-small')!,
+    };
+}
+
+describe('Legend swatch sizing', () => {
+
+    it('Should centre the swatch on the same point as its label', async () => {
+        const { chart, swatch, label } = createChart({
+            ascent: 18,
+            descent: 6,
+        });
+
+        await chart.render();
+
+        const block = swatch();
+
+        expect(block.y + block.height / 2).toBeCloseTo(label().y, 5);
+    });
+
+    it('Should keep the swatch square', async () => {
+        const { chart, swatch } = createChart({
+            ascent: 18,
+            descent: 6,
+        });
+
+        await chart.render();
+
+        expect(swatch().width).toBe(swatch().height);
+    });
+
+    it('Should hold the swatch at its floor for a small font', async () => {
+        const { chart, swatch } = createChart({
+            ascent: 6,
+            descent: 2,
+        });
+
+        await chart.render();
+
+        expect(swatch().height).toBe(MIN_SWATCH_SIZE);
+    });
+
+    it('Should grow the swatch with the font', async () => {
+        const { chart, swatch } = createChart({
+            ascent: 18,
+            descent: 6,
+        });
+
+        await chart.render();
+
+        expect(swatch().height).toBe(24);
+    });
+
+    it('Should scale the corner radius with the swatch', async () => {
+        const { chart, swatch } = createChart({
+            ascent: 18,
+            descent: 6,
+        });
+
+        await chart.render();
+
+        expect(swatch().borderRadius / swatch().height).toBeCloseTo(0.2, 5);
+    });
+
+    // The update path repositioned an existing swatch without resizing it, which only became a
+    // defect once the size tracked the row rather than being a constant.
+    it('Should resize an existing swatch when the font metrics change', async () => {
+        const { chart, stub, swatch } = createChart({
+            ascent: 6,
+            descent: 2,
+        });
+
+        await chart.render();
+
+        expect(swatch().height).toBe(MIN_SWATCH_SIZE);
+
+        mockTextMetrics(stub, {
+            ascent: 18,
+            descent: 6,
+        });
+
+        await chart.render();
+
+        expect(swatch().height).toBe(24);
+        expect(swatch().width).toBe(24);
+        expect(swatch().borderRadius).toBeCloseTo(24 * 0.2, 5);
+    });
+
+});


### PR DESCRIPTION
## The problem

The legend swatch is pinned to an absolute size while the row it sits in is not:

```ts
const SWATCH_SIZE = 10;
...
const rowHeight = Math.max(SWATCH_SIZE, this._fontHeight);
```

On canvas those agree closely enough that nobody notices. On a backend whose resolution is not CSS pixels they come apart badly. In a letterboxed terminal a 10px swatch maps to roughly **two braille dots — half a character cell** — so where it lands *within* the cell is arbitrary, while the glyph beside it always fills the whole cell.

Same chart, same code, legend moved from bottom to top:

```
legend top:     ⠛⠃Revenue  ⠛⠃Margin  ⠘⠛Units      ← dots at the cell's top
legend bottom:  ⣤⡄Revenue  ⣤⡄Margin  ⢠⣤Units      ← dots at the cell's bottom
```

Both are on the *same character row* as their label — the phase is the only thing that differs, and it shifts with legend position, chart size and padding. That is what "some charts' legends look aligned and some don't" actually was.

Worth stating what this is **not**: I checked the terminal backend first. Across 48 terminal-size × legend-position combinations the label lands on the swatch's centre row every time, and a sweep of all 16 sub-cell phases showed no misplacement. The glyph placement is already optimal; the swatch is the thing that is the wrong size.

## The fix

Let the swatch fill its row. `rowHeight` is already `max(SWATCH_SIZE, fontHeight)`, so this reframes the constant from a fixed size into a **minimum** — renamed to `MIN_SWATCH_SIZE` so the name doesn't lie. The corner radius scales with it, keeping the existing `2 / 10` ratio, so a larger swatch doesn't read as a square.

After:

```
legend top:     ⠸⠿⠿Revenue ⠸⠿⠿Margin  ⠿⠿⠇Units
legend bottom:  ⢰⣶⣶Revenue ⢰⣶⣶Margin  ⣶⣶⡆Units
```

A block beside its label at both positions, rather than a smudge whose height depends on where the legend happens to sit.

**At the default 11px font the swatch stays ~10px, so canvas and SVG are visually unchanged.** With a larger font it now scales with the label it annotates, which is the behaviour it should always have had.

### The update path

`_render`'s update branch repositioned an existing swatch but never resized it:

```ts
swatch.x = target.swatchX;
swatch.y = target.swatchY;
swatch.opacity = isActive ? 1 : 0.5;
```

That was safe while the size was a constant. It is not now — `update({ font })` changes it, and so does a terminal resize, which changes `_rasterScale` and therefore what `measureText` reports. Both branches now carry `width`, `height` and `borderRadius`; in the animated branch they sit in the transition `state` so they tween rather than jump.

## Verification

- `yarn test` — 214 files, 2845 tests, 2 skipped, 1 todo. Green.
- `yarn lint`, `yarn typecheck` — clean.
- The CI-gated browser suites, `parity.spec.ts` and `hit.spec.ts` — **8 passed**. Neither builds a legend (they use hand-authored scenes), so this change cannot reach them, but I ran them rather than assuming. They need `CHROMIUM_PATH` set in a sandbox without a Playwright-managed browser.
- Terminal: rendered the three-series line chart above at both legend positions on this branch and on `next` in the same process, and compared `export().toString()`. That is where the before/after art comes from.

New tests in `packages/charts/test/legend-swatch.test.ts` pin what the change promises: the swatch is square, centred on the same point as its label, floored at 10px for a small font, grown for a large one, and with the radius holding its ratio. The last one covers the update path — **it fails with `expected 10 to be 24` when the `width`/`height` assignments are removed**, so it is testing the regression and not just the happy path.

## What this does not fix

It narrows the terminal case rather than closing it. A one-cell-tall swatch at an arbitrary sub-cell offset still spills into the neighbouring cell — visible above as the thin `⢀⣀⣀` / `⠈⠉⠉` row next to the solid block. Closing that needs the terminal to snap sub-cell fills to their cell, which is a real semantic change to how fills rasterize and belongs in `@ripl/terminal`, not here.

## Baselines

The 18 PNGs under `packages/charts/test/visual/__snapshots__/charts.spec.ts-snapshots/` will drift for every chart with a legend — by a fraction of a pixel at the default font, but they will drift. **I have deliberately left them untouched.** They are not a CI gate (`.github/workflows/test.yml` runs only `parity.spec.ts` and `hit.spec.ts`) and they are renderer-specific, so regenerating them from this sandbox's Chromium risks shifting the whole set rather than just the legend regions. They need `yarn test:visual:update` run in the environment the existing baselines came from.

## Follow-ups

- `LABEL_GAP` uses `SPACING.sm` (8) where `packages/charts/src/constants/spacing.ts` documents `xs` (4) as the step for gaps *within* a single component — naming a legend swatch and its label as the example. A one-line fix, but horizontal and unrelated to this defect.
- `TerminalContext.measureText` ignores its `font` argument, so every font size reports one cell of height. That is why the swatch becomes exactly one cell on a terminal rather than tracking the requested font.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dbT1gwRnpQeBe91Fr4QhL)_