### PR TITLE
Lay out demo controls in the footer, and stop the 3D scenes overlapping

### DIFF
--- a/.claude/skills/ripl-charts/SKILL.md
+++ b/.claude/skills/ripl-charts/SKILL.md
@@ -198,6 +198,9 @@ VitePress page with a live example. Copy an existing page (e.g. `radial-bar.md`)
         <RiplControlGroup>
             <RiplButton @click="randomize">Randomize</RiplButton>
         </RiplControlGroup>
+        <RiplField label="Points">
+            <RiplInputRange v-model="points" :min="3" :max="12" :step="1" />
+        </RiplField>
     </template>
     <template #config>
         <RiplChartConfig :config="config" extra-title="<Name>">

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Check chart config coverage
         run: yarn workspace @ripl/website check-config-coverage
 
+      # Demo controls belong in the pane's footer, wrapped in a RiplField. The website build is not
+      # a lerna package, so without this step the guard would only run on deploy, after merge.
+      - name: Check demo controls
+        run: yarn workspace @ripl/website check-demo-controls
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,6 +620,7 @@ Reusable UI components live in `apps/website/src/.vitepress/components/` and are
 | `RiplButtonGroup` | Radio-toggle group: `v-model` + `:options="[{ label, value }]"` |
 | `RiplControlGroup` | Flex container with gap for grouping controls (toolbar-style) |
 | `RiplSwitch` | Toggle switch: `v-model` + `label` |
+| `RiplField` | Label + control wrapper: `label` (+ optional `option`); stacked by default, `inline` for the config drawer's two-column rows |
 | `RiplSelect` | Styled `<select>` wrapper with slot for `<option>` elements |
 | `RiplInputRange` | Styled range input: `v-model`, `min`, `max`, `step` |
 | `RiplDropdown` | Popover dropdown with `#trigger` slot and `align` prop (`left`/`right`) |
@@ -633,6 +634,7 @@ Reusable UI components live in `apps/website/src/.vitepress/components/` and are
 - **Markdown files** — Use Vue component tags (e.g. `<RiplButton>`, `<RiplSwitch v-model="x" label="Y" />`) instead of raw HTML with CSS classes
 - **Icons** — Use `lucide-vue-next` for icons. Render as slot content: `<RiplButton><RotateCcw :size="14" /></RiplButton>`
 - **Global registration** — New reusable components should be registered in `theme/index.ts` so they're available in markdown
+- **Demo pane** — A `<ripl-example>` demo puts its controls in `#footer`, never `#header`: the header is reserved for the context switcher, Customize and Export. Buttons and switches sit in a `RiplControlGroup`; every slider, select, colour, number and text input is wrapped in `<RiplField label="…">`. Chart options belong in the `#config` drawer instead, and the standalone demos under `src/demos/` keep their own toolbars. Enforced by `yarn workspace @ripl/website check-demo-controls`
 
 ### Playground
 

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -8,7 +8,8 @@
         "prepare-playground": "node scripts/prepare-playground.mjs",
         "start": "yarn generate-api && yarn prepare-playground && vitepress dev ./src",
         "check-config-coverage": "node scripts/check-config-coverage.mjs",
-        "build": "yarn check-chart-options && yarn check-config-coverage && yarn generate-api && yarn prepare-playground && vitepress build ./src",
+        "check-demo-controls": "node scripts/check-demo-controls.mjs",
+        "build": "yarn check-chart-options && yarn check-config-coverage && yarn check-demo-controls && yarn generate-api && yarn prepare-playground && vitepress build ./src",
         "preview": "vitepress preview ./src"
     },
     "dependencies": {

--- a/apps/website/scripts/check-demo-controls.mjs
+++ b/apps/website/scripts/check-demo-controls.mjs
@@ -1,0 +1,313 @@
+/**
+ * Checks that every demo pane follows the control conventions: controls live in the pane's footer,
+ * and each input carries a label.
+ *
+ * The convention is structural, not cosmetic. The pane's header is built by `example.vue` and is
+ * reserved for the context switcher, Customize and Export — a demo that drops its own control in
+ * there competes with those for the row and reads as a second toolbar, so `#header` is expected to
+ * have no users at all. Labelling has one implementation now: `RiplField`. Two hand-rolled label
+ * classes (`ripl-example__label`, `teapot-demo__label`) were referenced by demos whose CSS never
+ * defined them, which is invisible in review and renders as an unstyled span, so both names are
+ * banned outright and a bare slider or select in a footer is a control the reader cannot name.
+ *
+ * This is a documentation site, so the scan runs over markup only: fenced code blocks and HTML
+ * comments are blanked out first (in place, so line numbers still point at the source), because a
+ * page that *shows* `<template #header>` in a fence is documenting the slot rather than using one.
+ * Templates name a component either way round, so `<ripl-field>` counts as `<RiplField>`.
+ *
+ * Scope is the demo pane: the `#footer` checks read the pane's footer slots, so the standalone demo
+ * apps under `src/demos/`, which build their own toolbars, are covered only by the `#header` and
+ * dead-class checks.
+ *
+ *   node scripts/check-demo-controls.mjs   # report violations and exit non-zero
+ */
+
+import {
+    fileURLToPath,
+} from 'node:url';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const websiteRoot = path.resolve(dirname, '..');
+const sourceRoot = path.join(websiteRoot, 'src');
+
+/** `public/` is copied verbatim and `docs/api/` is written by TypeDoc, so neither is ours to check. */
+const EXCLUDED_DIRS = [
+    path.join(sourceRoot, 'public'),
+    path.join(sourceRoot, 'docs/api'),
+];
+
+/** Inputs that carry no label of their own, so each one must sit inside a `RiplField`. */
+const LABELLED_CONTROLS = [
+    'RiplInputRange',
+    'RiplSelect',
+    'RiplColorInput',
+    'RiplInputNumber',
+    'RiplInputText',
+];
+
+/**
+ * Raw HTML controls a footer may not use, and the component that replaces each one. `color.md` shipped
+ * a bare `<input type="color">`, which every check above reads as markup rather than as a control.
+ */
+const RAW_CONTROLS = {
+    range: 'RiplInputRange',
+    color: 'RiplColorInput',
+    number: 'RiplInputNumber',
+    text: 'RiplInputText',
+};
+
+/** Label classes deleted along with the move to `RiplField`; neither has any CSS behind it. */
+const DEAD_LABEL_CLASSES = [
+    'ripl-example__label',
+    'teapot-demo__label',
+];
+
+/** Both spellings of a component's tag: templates use PascalCase and kebab-case interchangeably. */
+function tagNames(name) {
+    return [name, name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()];
+}
+
+/** Matches a slot name as one attribute among others, so `<template #footer v-if="ready">` counts. */
+function slotAttribute(name) {
+    return new RegExp(`(?:^|\\s)(?:#${name}|v-slot:${name})(?![\\w-])`);
+}
+
+const CONTROL_NAMES = new Map(['RiplField', ...LABELLED_CONTROLS]
+    .flatMap(name => tagNames(name).map(tag => [tag, name])));
+
+const HEADER_SLOT = slotAttribute('header');
+const FOOTER_SLOT = slotAttribute('footer');
+const DEAD_LABELS = new RegExp(`(?:${DEAD_LABEL_CLASSES.join('|')})(?![\\w-])`, 'g');
+const TEMPLATE_TAGS = /<(\/?)template\b([^>]*?)(\/?)>/g;
+const CONTROL_TAGS = new RegExp(`<(/?)(${[...CONTROL_NAMES.keys()].join('|')})(?![\\w-])([^>]*?)(/?)>`, 'g');
+const RAW_TAGS = /<(input|select)(?![\w-])([^>]*?)\/?>/gi;
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/** Every markdown page and component of the site. */
+function siteFiles() {
+    const files = [];
+
+    const walk = dir => {
+        fs.readdirSync(dir, { withFileTypes: true }).forEach(entry => {
+            const full = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (!EXCLUDED_DIRS.includes(full)) {
+                    walk(full);
+                }
+
+                return;
+            }
+
+            if (/\.(md|vue)$/.test(entry.name)) {
+                files.push(full);
+            }
+        });
+    };
+
+    walk(sourceRoot);
+
+    return files.sort();
+}
+
+/** Replaces every character but the line breaks, so masking a region cannot move the ones after it. */
+function blank(text) {
+    return text.replace(/[^\n]/g, ' ');
+}
+
+/** The file with its fenced code blocks blanked out. */
+function maskFences(contents) {
+    let fence = null;
+
+    return contents.split('\n').map(line => {
+        const match = FENCE.exec(line);
+
+        if (!fence) {
+            fence = match?.[1] ?? null;
+
+            return fence ? blank(line) : line;
+        }
+
+        if (match && match[1][0] === fence[0] && match[1].length >= fence.length && /^ {0,3}[`~]+\s*$/.test(line)) {
+            fence = null;
+        }
+
+        return blank(line);
+    }).join('\n');
+}
+
+/** The markup of a file: what is in a code fence is documentation, and what is commented out is gone. */
+function markupOf(contents) {
+    return maskFences(contents).replace(/<!--[\s\S]*?-->/g, match => blank(match));
+}
+
+/** The 1-based line an offset falls on. */
+function lineAt(contents, index) {
+    return contents.slice(0, index).split('\n').length;
+}
+
+/**
+ * The body of every `<template #footer>` block, with the offset it starts at.
+ *
+ * Matched by pairing template tags rather than by a non-greedy `</template>`: a page carries one
+ * block per demo (seven on the interpolators page) and a block may nest a `<template v-if>`, both of
+ * which a non-greedy match closes in the wrong place.
+ */
+function footerBlocks(contents) {
+    const tags = [...contents.matchAll(TEMPLATE_TAGS)];
+    const blocks = [];
+
+    tags.forEach((tag, index) => {
+        if (tag[1] || !FOOTER_SLOT.test(tag[2])) {
+            return;
+        }
+
+        const start = tag.index + tag[0].length;
+
+        let depth = 0;
+        let end = contents.length;
+
+        for (let next = index + 1; next < tags.length; next++) {
+            const candidate = tags[next];
+
+            if (candidate[3]) {
+                continue;
+            }
+
+            if (!candidate[1]) {
+                depth++;
+                continue;
+            }
+
+            if (depth > 0) {
+                depth--;
+                continue;
+            }
+
+            end = candidate.index;
+            break;
+        }
+
+        blocks.push({
+            start,
+            body: contents.slice(start, end),
+        });
+    });
+
+    return blocks;
+}
+
+/** The controls in a footer body that no `RiplField` encloses, with their offsets into the body. */
+function unwrappedControls(body) {
+    const found = [];
+
+    let depth = 0;
+
+    [...body.matchAll(CONTROL_TAGS)].forEach(tag => {
+        const [, closing, tagName, , selfClosing] = tag;
+        const name = CONTROL_NAMES.get(tagName);
+
+        if (name === 'RiplField') {
+            if (!selfClosing) {
+                depth = Math.max(0, depth + (closing ? -1 : 1));
+            }
+
+            return;
+        }
+
+        if (!closing && depth === 0) {
+            found.push({
+                name,
+                index: tag.index,
+            });
+        }
+    });
+
+    return found;
+}
+
+/**
+ * The raw HTML controls in a footer body, whatever encloses them: a `RiplField` around an `<input>`
+ * labels it but still leaves the demo styling and behaving unlike every other pane.
+ *
+ * A `:type` binding is left alone — the type is only known at runtime — as is any type with no shared
+ * component behind it.
+ */
+function rawControls(body) {
+    return [...body.matchAll(RAW_TAGS)].flatMap(tag => {
+        const [, tagName, attributes] = tag;
+        const type = attributes.match(/\btype\s*=\s*["']([^"']*)["']/)?.[1] ?? 'text';
+        const dynamic = /(?::|v-bind:)type\s*=/.test(attributes);
+        const select = tagName.toLowerCase() === 'select';
+        const component = select ? 'RiplSelect' : !dynamic && RAW_CONTROLS[type];
+
+        if (!component) {
+            return [];
+        }
+
+        return [{
+            component,
+            tag: select ? '<select>' : `<input type="${type}">`,
+            index: tag.index,
+        }];
+    });
+}
+
+/** Every convention violation in one file, in source order. */
+function violationsOf(file, contents) {
+    const markup = markupOf(contents);
+    const problems = [];
+    const report = (index, message) => problems.push({
+        index,
+        message,
+    });
+
+    [...markup.matchAll(TEMPLATE_TAGS)].forEach(tag => {
+        if (!tag[1] && HEADER_SLOT.test(tag[2])) {
+            report(tag.index, 'uses the reserved `#header` slot — demo controls belong in `#footer`');
+        }
+    });
+
+    [...markup.matchAll(DEAD_LABELS)].forEach(match => {
+        report(match.index, `\`${match[0]}\` no longer exists — wrap the control in \`<RiplField label="…">\``);
+    });
+
+    footerBlocks(markup).forEach(block => {
+        unwrappedControls(block.body).forEach(control => {
+            report(block.start + control.index, `\`${control.name}\` is not inside a \`RiplField\``);
+        });
+
+        rawControls(block.body).forEach(control => {
+            report(block.start + control.index, `\`${control.tag}\` is a raw control — use the shared \`${control.component}\` component`);
+        });
+    });
+
+    return problems
+        .sort((left, right) => left.index - right.index)
+        .map(problem => `${file}:${lineAt(markup, problem.index)}: ${problem.message}`);
+}
+
+function main() {
+    const files = siteFiles();
+    const problems = files.flatMap(file => violationsOf(
+        path.relative(websiteRoot, file),
+        fs.readFileSync(file, 'utf8')
+    ));
+
+    if (problems.length > 0) {
+        console.error('Demo controls disagree with the convention:');
+        problems.forEach(problem => console.error(`  - ${problem}`));
+        console.error(`\n${problems.length} problem(s) across ${files.length} files.`);
+        process.exit(1);
+    }
+
+    console.log('Every control in a demo pane `#footer` is a shared component inside a `RiplField`,'
+        + ` the reserved \`#header\` slot has no users, and no retired label class remains: ${files.length}`
+        + ' pages and components checked.');
+}
+
+main();

--- a/apps/website/src/.vitepress/components/example-3d-webgpu.vue
+++ b/apps/website/src/.vitepress/components/example-3d-webgpu.vue
@@ -1,11 +1,7 @@
 <template>
     <div class="ripl-example">
         <div class="ripl-example__header">
-            <div class="ripl-example__context-type-options" layout="row">
-                <label class="ripl-example__context-type-option" style="pointer-events: none;">
-                    WebGPU 3D
-                </label>
-            </div>
+            <span class="ripl-example__context-label">WebGPU 3D</span>
             <slot name="header"></slot>
         </div>
         <div class="ripl-example__root" self="size-x1" ref="root"></div>

--- a/apps/website/src/.vitepress/components/example.vue
+++ b/apps/website/src/.vitepress/components/example.vue
@@ -261,6 +261,19 @@ onUnmounted(() => {
         margin-left: auto;
     }
 
+    // Stands in for the context switcher on a pane with only one context to offer.
+    .ripl-example__context-label {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.35rem 0.875rem;
+        font-size: 0.8125rem;
+        line-height: 1.5;
+        color: var(--vp-c-text-2);
+        border: 1px solid var(--vp-c-divider);
+        border-radius: 0.375rem;
+        background-color: var(--vp-button-alt-bg);
+    }
+
     .ripl-example__config-button {
         display: inline-flex;
         align-items: center;
@@ -282,7 +295,22 @@ onUnmounted(() => {
     }
 
     .ripl-example__footer {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        gap: 0.75rem 1rem;
         border-top: 1px solid var(--vp-c-divider);
+    }
+
+    .ripl-example__footer .ripl-control-group {
+        flex: 0 1 auto;
+        min-width: 0;
+    }
+
+    // A stacked field sizes to its own basis so sliders share a row instead of each claiming one.
+    .ripl-example__footer .ripl-field {
+        flex: 1 1 12rem;
+        max-width: 20rem;
     }
 
     .ripl-example__root {

--- a/apps/website/src/.vitepress/components/playground/examples/lighting-rig.js
+++ b/apps/website/src/.vitepress/components/playground/examples/lighting-rig.js
@@ -43,7 +43,7 @@ scene.add([
         fill: '#e8e8e8',
     }),
     createTorus({
-        y: -1.2,
+        y: -0.95,
         radius: 1.8,
         tube: 0.14,
         radialSegments: 12,

--- a/apps/website/src/.vitepress/components/playground/examples/material-showcase.js
+++ b/apps/website/src/.vitepress/components/playground/examples/material-showcase.js
@@ -19,7 +19,8 @@ context.lights.add(
 );
 
 scene.add(SHININESS.map((shininess, index) => createSphere({
-    x: (index - 1.5) * 1.5,
+    x: index % 2 === 0 ? -0.8 : 0.8,
+    y: index < 2 ? 0.8 : -0.8,
     radius: 0.6,
     segments: 36,
     rings: 24,

--- a/apps/website/src/.vitepress/components/playground/examples/multiple-3d-shapes.js
+++ b/apps/website/src/.vitepress/components/playground/examples/multiple-3d-shapes.js
@@ -5,8 +5,8 @@ import {
 
 scene.add([
     createCube({
-        x: -1.5,
-        size: 0.8,
+        x: -1.35,
+        size: 0.9,
         fill: '#6366f1',
     }),
     createSphere({
@@ -15,8 +15,8 @@ scene.add([
         fill: '#f59e0b',
     }),
     createCube({
-        x: 1.5,
-        size: 0.8,
+        x: 1.35,
+        size: 0.9,
         fill: '#10b981',
     }),
 ]);

--- a/apps/website/src/.vitepress/components/playground/examples/multiple-shapes.js
+++ b/apps/website/src/.vitepress/components/playground/examples/multiple-shapes.js
@@ -10,12 +10,12 @@ const cy = scene.context.height / 2;
 const group = createGroup({
     children: [
         createRect({
-            x: cx - 100,
+            x: cx - 140,
             y: cy - 40,
             width: 80,
             height: 80,
             fill: '#6366f1',
-            cornerRadius: 8,
+            borderRadius: 8,
         }),
         createCircle({
             cx: cx,
@@ -24,12 +24,12 @@ const group = createGroup({
             fill: '#f59e0b',
         }),
         createRect({
-            x: cx + 20,
+            x: cx + 60,
             y: cy - 40,
             width: 80,
             height: 80,
             fill: '#10b981',
-            cornerRadius: 8,
+            borderRadius: 8,
         }),
     ],
 });

--- a/apps/website/src/.vitepress/components/ripl-button-group.vue
+++ b/apps/website/src/.vitepress/components/ripl-button-group.vue
@@ -5,6 +5,7 @@
             :key="option.value"
             class="ripl-button-group__item"
             :class="{ 'ripl-button-group__item--active': modelValue === option.value }"
+            :aria-pressed="modelValue === option.value"
             @click="$emit('update:modelValue', option.value)"
         >{{ option.label }}</button>
     </div>

--- a/apps/website/src/.vitepress/components/ripl-color-input.vue
+++ b/apps/website/src/.vitepress/components/ripl-color-input.vue
@@ -4,20 +4,47 @@
             type="color"
             class="ripl-color-input__picker"
             :value="modelValue"
-            @change="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+            @input="onInput"
         >
-        <span class="ripl-color-input__value">{{ modelValue }}</span>
+        <span class="ripl-color-input__value" aria-hidden="true">{{ modelValue }}</span>
     </span>
 </template>
 
 <script lang="ts" setup>
+import {
+    createFrameBuffer,
+} from '@ripl/web';
+
+import {
+    onBeforeUnmount,
+} from 'vue';
+
 defineProps<{
     modelValue: string;
 }>();
 
-defineEmits<{
+const emit = defineEmits<{
     'update:modelValue': [value: string];
 }>();
+
+// Live while dragging (`input`, not `change`), coalesced so a drag can't flood chart updates.
+const scheduleFlush = createFrameBuffer();
+
+let unmounted = false;
+
+function onInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+
+    scheduleFlush(() => {
+        if (!unmounted) {
+            emit('update:modelValue', value);
+        }
+    });
+}
+
+onBeforeUnmount(() => {
+    unmounted = true;
+});
 </script>
 
 <style scoped>

--- a/apps/website/src/.vitepress/components/ripl-input-range.vue
+++ b/apps/website/src/.vitepress/components/ripl-input-range.vue
@@ -9,7 +9,7 @@
             :step="step"
             @input="onInput"
         >
-        <span class="ripl-input-range__value">{{ display }}</span>
+        <span class="ripl-input-range__value" aria-hidden="true">{{ display }}</span>
     </span>
 </template>
 

--- a/apps/website/src/charts/realtime.md
+++ b/apps/website/src/charts/realtime.md
@@ -17,12 +17,14 @@ The **Realtime Chart** holds a sliding window of the most recent values and scro
         <RiplControlGroup>
             <RiplButton @click="toggle">{{ streaming ? 'Stop' : 'Start' }}</RiplButton>
             <RiplButton @click="reset">Reset</RiplButton>
+        </RiplControlGroup>
+        <RiplField label="Speed">
             <RiplSelect v-model="speed" @change="startStreaming">
                 <option value="100">Fast (100ms)</option>
                 <option value="300">Normal (300ms)</option>
                 <option value="1000">Slow (1s)</option>
             </RiplSelect>
-        </RiplControlGroup>
+        </RiplField>
     </template>
     <template #config>
         <RiplChartConfig :config="config" :series="seriesMeta" extra-title="Stream" :extras-reset="resetExtras">

--- a/apps/website/src/demos/freeform-drawing/components/style-panel.vue
+++ b/apps/website/src/demos/freeform-drawing/components/style-panel.vue
@@ -9,6 +9,7 @@
                     class="freeform-style__swatch"
                     :class="{ 'freeform-style__swatch--active': color === style.stroke }"
                     :style="{ background: color }"
+                    :aria-label="`Color ${color}`"
                     @click="$emit('patch', { stroke: color })"
                 ></button>
             </div>
@@ -32,7 +33,7 @@
             />
         </div>
 
-        <div class="freeform-style__section">
+        <label class="freeform-style__section">
             <span class="freeform-style__label">Stroke width: {{ style.strokeWidth }}px</span>
             <RiplInputRange
                 :model-value="style.strokeWidth"
@@ -41,9 +42,9 @@
                 :step="1"
                 @update:model-value="$emit('patch', { strokeWidth: $event })"
             />
-        </div>
+        </label>
 
-        <div class="freeform-style__section">
+        <label class="freeform-style__section">
             <span class="freeform-style__label">Opacity: {{ Math.round(style.opacity * 100) }}%</span>
             <RiplInputRange
                 :model-value="style.opacity"
@@ -52,7 +53,7 @@
                 :step="0.05"
                 @update:model-value="$emit('patch', { opacity: $event })"
             />
-        </div>
+        </label>
 
         <div class="freeform-style__section freeform-style__section--row">
             <RiplSwitch

--- a/apps/website/src/demos/freeform-drawing/components/tool-bar.vue
+++ b/apps/website/src/demos/freeform-drawing/components/tool-bar.vue
@@ -6,6 +6,7 @@
             class="freeform-toolbar__button"
             :class="{ 'freeform-toolbar__button--active': tool.id === activeTool }"
             :title="`${tool.label} (${tool.key})`"
+            :aria-label="`${tool.label} (${tool.key})`"
             @click="$emit('select', tool.id)"
         >
             <component :is="tool.icon" :size="18" />

--- a/apps/website/src/demos/freeform-drawing/components/zoom-bar.vue
+++ b/apps/website/src/demos/freeform-drawing/components/zoom-bar.vue
@@ -3,6 +3,7 @@
         <button
             class="freeform-zoom__button"
             title="Undo (⌘Z)"
+            aria-label="Undo (⌘Z)"
             :disabled="!canUndo"
             @click="$emit('action', 'undo')"
         >
@@ -11,6 +12,7 @@
         <button
             class="freeform-zoom__button"
             title="Redo (⌘⇧Z)"
+            aria-label="Redo (⌘⇧Z)"
             :disabled="!canRedo"
             @click="$emit('action', 'redo')"
         >
@@ -19,31 +21,31 @@
 
         <span class="freeform-zoom__divider"></span>
 
-        <button class="freeform-zoom__button" title="Zoom out" @click="$emit('action', 'zoom-out')">
+        <button class="freeform-zoom__button" title="Zoom out" aria-label="Zoom out" @click="$emit('action', 'zoom-out')">
             <ZoomOut :size="16" />
         </button>
         <button class="freeform-zoom__readout" title="Reset to 100%" @click="$emit('action', 'reset')">
             {{ Math.round(zoom * 100) }}%
         </button>
-        <button class="freeform-zoom__button" title="Zoom in" @click="$emit('action', 'zoom-in')">
+        <button class="freeform-zoom__button" title="Zoom in" aria-label="Zoom in" @click="$emit('action', 'zoom-in')">
             <ZoomIn :size="16" />
         </button>
-        <button class="freeform-zoom__button" title="Fit to content" @click="$emit('action', 'fit')">
+        <button class="freeform-zoom__button" title="Fit to content" aria-label="Fit to content" @click="$emit('action', 'fit')">
             <Maximize :size="16" />
         </button>
 
         <span class="freeform-zoom__divider"></span>
 
-        <button class="freeform-zoom__button" title="Export PNG" @click="$emit('action', 'png')">
+        <button class="freeform-zoom__button" title="Export PNG" aria-label="Export PNG" @click="$emit('action', 'png')">
             <Image :size="16" />
         </button>
-        <button class="freeform-zoom__button" title="Export SVG" @click="$emit('action', 'svg')">
+        <button class="freeform-zoom__button" title="Export SVG" aria-label="Export SVG" @click="$emit('action', 'svg')">
             <FileCode :size="16" />
         </button>
-        <button class="freeform-zoom__button" title="Add 5,000 shapes (stress test)" @click="$emit('action', 'stress')">
+        <button class="freeform-zoom__button" title="Add 5,000 shapes (stress test)" aria-label="Add 5,000 shapes (stress test)" @click="$emit('action', 'stress')">
             <Boxes :size="16" />
         </button>
-        <button class="freeform-zoom__button freeform-zoom__button--danger" title="Clear canvas" @click="$emit('action', 'clear')">
+        <button class="freeform-zoom__button freeform-zoom__button--danger" title="Clear canvas" aria-label="Clear canvas" @click="$emit('action', 'clear')">
             <Trash2 :size="16" />
         </button>
     </div>

--- a/apps/website/src/demos/jet-engine/styles/jet-engine.scss
+++ b/apps/website/src/demos/jet-engine/styles/jet-engine.scss
@@ -29,6 +29,7 @@
 
 .jet-engine-demo__controls {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
 }
 

--- a/apps/website/src/demos/piston-mechanism/styles/piston-mechanism.scss
+++ b/apps/website/src/demos/piston-mechanism/styles/piston-mechanism.scss
@@ -27,6 +27,7 @@
 
     &__controls {
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
         gap: 16px;
     }

--- a/apps/website/src/demos/product-analytics/product-analytics.vue
+++ b/apps/website/src/demos/product-analytics/product-analytics.vue
@@ -5,15 +5,8 @@
                 <h1 class="analytics-dashboard__title">Product Analytics</h1>
                 <p class="analytics-dashboard__subtitle">Mock data dashboard showcasing Ripl Charts</p>
             </div>
-            <div class="analytics-dashboard__period-selector">
-                <label
-                    v-for="p in periods"
-                    :key="p.value"
-                    class="analytics-dashboard__period-option"
-                >
-                    <input type="radio" name="period" :value="p.value" v-model="store.period">
-                    {{ p.label }}
-                </label>
+            <div class="analytics-dashboard__period-selector" role="group" aria-label="Reporting period">
+                <RiplButtonGroup :modelValue="store.period" @update:modelValue="onPeriodChange" :options="periods" />
             </div>
         </div>
 
@@ -47,10 +40,15 @@ import {
     PERIODS,
 } from './data/mock';
 
+import type {
+    Period,
+} from './data/mock';
+
 import {
     useAnalyticsStore,
 } from './store/analytics';
 
+import RiplButtonGroup from '../../.vitepress/components/ripl-button-group.vue';
 import ActiveUsersChart from './components/active-users-chart.vue';
 import BrowserShareChart from './components/browser-share-chart.vue';
 import ConversionFunnel from './components/conversion-funnel.vue';
@@ -62,6 +60,10 @@ import UserJourneySankey from './components/user-journey-sankey.vue';
 
 const periods = PERIODS;
 const store = useAnalyticsStore();
+
+function onPeriodChange(value: string) {
+    store.period = value as Period;
+}
 </script>
 
 <style lang="scss">

--- a/apps/website/src/demos/product-analytics/styles/dashboard.scss
+++ b/apps/website/src/demos/product-analytics/styles/dashboard.scss
@@ -122,56 +122,9 @@
     border-top: 1px solid var(--vp-c-divider);
 }
 
+// Scrolls rather than wraps: a segmented control broken across two lines loses its joined edges.
 .analytics-dashboard__period-selector {
-    display: inline-flex;
-}
-
-.analytics-dashboard__period-option {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.35rem 0.875rem;
-    font: inherit;
-    font-size: 0.8125rem;
-    line-height: 1.5;
-    color: var(--vp-button-alt-text);
-    border: 1px solid var(--vp-c-divider);
-    background-color: var(--vp-button-alt-bg);
-    cursor: pointer;
-    user-select: none;
-    transition: color 150ms ease-out, background-color 150ms ease-out, border-color 150ms ease-out;
-
-    & input {
-        display: none;
-    }
-
-    &:first-child {
-        border-radius: 0.375rem 0 0 0.375rem;
-    }
-
-    &:last-child {
-        border-radius: 0 0.375rem 0.375rem 0;
-    }
-
-    & + & {
-        margin-left: -1px;
-    }
-
-    &:hover {
-        border-color: var(--vp-c-gray-2);
-        background-color: var(--vp-button-alt-hover-bg);
-    }
-
-    &:has(:checked) {
-        color: var(--vp-button-brand-text);
-        border-color: var(--vp-button-brand-border);
-        background-color: var(--vp-button-brand-bg);
-        position: relative;
-        z-index: 1;
-
-        &:hover {
-            border-color: var(--vp-button-brand-hover-border);
-            background-color: var(--vp-button-brand-hover-bg);
-        }
-    }
+    display: flex;
+    max-width: 100%;
+    overflow-x: auto;
 }

--- a/apps/website/src/demos/teapot/styles/teapot.scss
+++ b/apps/website/src/demos/teapot/styles/teapot.scss
@@ -6,10 +6,14 @@
     &__toolbar {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-end;
         gap: 1rem;
         padding: 0.75rem 1.5rem;
         border-bottom: 1px solid var(--vp-c-divider);
+
+        > .ripl-field {
+            flex: 0 1 14rem;
+        }
     }
 
     &__viewport {

--- a/apps/website/src/demos/teapot/teapot.vue
+++ b/apps/website/src/demos/teapot/teapot.vue
@@ -10,10 +10,9 @@
                 <RiplSwitch v-model="flatShading" label="Flat" />
                 <RiplSwitch v-model="spinning" label="Spin" />
             </RiplControlGroup>
-            <RiplControlGroup>
-                <label class="teapot-demo__label">Shine</label>
+            <RiplField label="Shine">
                 <RiplInputRange v-model="shininess" :min="0" :max="120" :step="1" />
-            </RiplControlGroup>
+            </RiplField>
         </div>
         <div class="teapot-demo__viewport" ref="viewport"></div>
         <p class="teapot-demo__note">
@@ -35,6 +34,7 @@ import {
 
 import RiplButtonGroup from '../../.vitepress/components/ripl-button-group.vue';
 import RiplControlGroup from '../../.vitepress/components/ripl-control-group.vue';
+import RiplField from '../../.vitepress/components/ripl-field.vue';
 import RiplInputRange from '../../.vitepress/components/ripl-input-range.vue';
 import RiplSwitch from '../../.vitepress/components/ripl-switch.vue';
 

--- a/apps/website/src/demos/trading-dashboard/components/commodity-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/commodity-chart.vue
@@ -1,7 +1,7 @@
 <template>
     <dashboard-card :title="store.commodityLabel()" :loading="store.commodityLoading">
         <template #actions>
-            <RiplSelect :modelValue="store.commodity" @update:modelValue="onCommodityChange">
+            <RiplSelect :modelValue="store.commodity" @update:modelValue="onCommodityChange" aria-label="Commodity">
                 <option value="GOLD">Gold</option>
                 <option value="SILVER">Silver</option>
                 <option value="WTI">Crude Oil (WTI)</option>

--- a/apps/website/src/demos/trading-dashboard/components/market-overview-chart.vue
+++ b/apps/website/src/demos/trading-dashboard/components/market-overview-chart.vue
@@ -1,7 +1,7 @@
 <template>
     <dashboard-card :title="store.marketLabel() + ' Overview'" :loading="store.marketLoading">
         <template #actions>
-            <RiplSelect :modelValue="store.marketIndex" @update:modelValue="onMarketChange">
+            <RiplSelect :modelValue="store.marketIndex" @update:modelValue="onMarketChange" aria-label="Market index">
                 <option value="SPY">S&amp;P 500</option>
                 <option value="QQQ">NASDAQ</option>
                 <option value="DIA">Dow Jones</option>

--- a/apps/website/src/demos/trading-dashboard/components/symbol-search.vue
+++ b/apps/website/src/demos/trading-dashboard/components/symbol-search.vue
@@ -8,6 +8,7 @@
             <input
                 type="text"
                 class="symbol-search__input ripl-select"
+                aria-label="Search symbol"
                 placeholder="Search symbol (e.g. AAPL, MSFT)..."
                 v-model="query"
                 @input="onInput"

--- a/apps/website/src/docs/3d/contexts/webgpu.md
+++ b/apps/website/src/docs/3d/contexts/webgpu.md
@@ -45,13 +45,13 @@ const camera = createCamera(context, {
 scene.add(createCube({
     size: 1,
     fill: '#3a86ff',
-    translateX: -1.2,
+    x: -1.2,
 }));
 
 scene.add(createSphere({
     radius: 0.6,
     fill: '#ff006e',
-    translateX: 1.2,
+    x: 1.2,
 }));
 
 camera.flush();
@@ -229,7 +229,6 @@ if (navigator.gpu) {
 <script lang="ts" setup>
 import {
     onUnmounted,
-    shallowRef,
 } from 'vue';
 
 import {
@@ -239,7 +238,6 @@ import {
 } from '@ripl/3d';
 
 import type {
-    Camera,
     Context3D,
 } from '@ripl/3d';
 
@@ -249,7 +247,6 @@ import {
 } from '@ripl/web';
 
 import type {
-    Renderer,
     Scene,
 } from '@ripl/web';
 
@@ -263,9 +260,9 @@ function contextChanged(ctx: Context3D) {
     const scene = createScene(ctx) as Scene<Context3D>;
     currentScene = scene;
 
-    const renderer = createRenderer(scene, { autoStop: false });
+    createRenderer(scene, { autoStop: false });
 
-    const camera = createCamera(context, {
+    const camera = createCamera(ctx, {
         position: [0, 1.5, 5],
         target: [0, 0, 0],
         fov: 50,
@@ -274,13 +271,13 @@ function contextChanged(ctx: Context3D) {
     scene.add(createCube({
         size: 1,
         fill: '#3a86ff',
-        translateX: -1.2,
+        x: -1.2,
     }));
 
     scene.add(createSphere({
         radius: 0.6,
         fill: '#ff006e',
-        translateX: 1.2,
+        x: 1.2,
     }));
 
     camera.flush();

--- a/apps/website/src/docs/3d/essentials/lighting.md
+++ b/apps/website/src/docs/3d/essentials/lighting.md
@@ -16,7 +16,7 @@ A 3D **context** carries a list of **lights**. Each one has a colour and an inte
 :::tabs
 == Demo
 <ripl-3d-example @context-changed="contextChanged">
-    <template #header>
+    <template #footer>
         <RiplControlGroup>
             <RiplSwitch v-model="ambient" label="Ambient" />
             <RiplSwitch v-model="key" label="Key" />
@@ -214,7 +214,7 @@ const { contextChanged, startRotation } = useRipl3DExample((scene, camera) => {
 
     scene.add([
         createSphere({ radius: 1.1, segments: 40, rings: 28, fill: '#e8e8e8' }),
-        createTorus({ x: 0, y: -1.35, radius: 1.7, tube: 0.16, radialSegments: 12, tubularSegments: 48, fill: '#8899aa' }),
+        createTorus({ x: 0, y: -1, radius: 1.7, tube: 0.16, radialSegments: 12, tubularSegments: 48, fill: '#8899aa' }),
     ]);
 
     applyToggles();

--- a/apps/website/src/docs/3d/essentials/materials.md
+++ b/apps/website/src/docs/3d/essentials/materials.md
@@ -18,13 +18,14 @@ Every property is optional. An element with only a `fill` behaves exactly as it 
 :::tabs
 == Demo
 <ripl-3d-example @context-changed="contextChanged">
-    <template #header>
+    <template #footer>
         <RiplControlGroup>
             <RiplSwitch v-model="flatShading" label="Flat" />
             <RiplSwitch v-model="wireframe" label="Wireframe" />
-            <label class="ripl-example__label">Shine</label>
-            <RiplInputRange v-model="shininess" :min="0" :max="120" :step="1" />
         </RiplControlGroup>
+        <RiplField label="Shine">
+            <RiplInputRange v-model="shininess" :min="0" :max="120" :step="1" />
+        </RiplField>
     </template>
 </ripl-3d-example>
 == Code
@@ -175,9 +176,9 @@ const { contextChanged, startRotation } = useRipl3DExample((scene, camera) => {
 
     spheres.length = 0;
     spheres.push(
-        createSphere({ x: -1.6, radius: 0.9, segments: 32, rings: 24, fill: '#b87333' }),
-        createSphere({ x: 0, radius: 0.9, segments: 32, rings: 24, fill: '#7f9ec4' }),
-        createSphere({ x: 1.6, radius: 0.9, segments: 32, rings: 24, fill: '#5c9e78' }),
+        createSphere({ x: -1.9, radius: 0.7, segments: 32, rings: 24, fill: '#b87333' }),
+        createSphere({ x: 0, radius: 0.7, segments: 32, rings: 24, fill: '#7f9ec4' }),
+        createSphere({ x: 1.9, radius: 0.7, segments: 32, rings: 24, fill: '#5c9e78' }),
     );
 
     scene.add(spheres);

--- a/apps/website/src/docs/3d/essentials/textures.md
+++ b/apps/website/src/docs/3d/essentials/textures.md
@@ -16,12 +16,13 @@ A **texture** maps an image across a surface. Every built-in shape emits the tex
 :::tabs
 == Demo
 <ripl-3d-example @context-changed="contextChanged">
-    <template #header>
+    <template #footer>
         <RiplControlGroup>
             <RiplSwitch v-model="textured" label="Texture" />
-            <label class="ripl-example__label">Repeat</label>
-            <RiplInputRange v-model="repeat" :min="1" :max="6" :step="1" />
         </RiplControlGroup>
+        <RiplField label="Repeat">
+            <RiplInputRange v-model="repeat" :min="1" :max="6" :step="1" />
+        </RiplField>
     </template>
 </ripl-3d-example>
 == Code

--- a/apps/website/src/docs/core/advanced/animations.md
+++ b/apps/website/src/docs/core/advanced/animations.md
@@ -405,9 +405,9 @@ Use the controls below to start a transition, then pause, seek, and reverse it i
             <RiplButton @click="togglePause" :active="isPaused">{{ isPaused ? 'Play' : 'Pause' }}</RiplButton>
             <RiplButton @click="reversePlayback">Reverse</RiplButton>
         </RiplControlGroup>
-        <RiplControlGroup>
+        <RiplField label="Seek">
             <RiplInputRange v-model="seekValue" :min="0" :max="1" :step="0.01" @update:model-value="onSeek" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/clip-paths.md
+++ b/apps/website/src/docs/core/advanced/clip-paths.md
@@ -16,10 +16,9 @@ The demo below shows a circle clip path masking a gradient-filled rectangle and 
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Clip Radius</span>
+        <RiplField label="Clip Radius">
             <RiplInputRange v-model="clipRadiusPct" :min="10" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/color.md
+++ b/apps/website/src/docs/core/advanced/color.md
@@ -19,11 +19,12 @@ Type or pick a color to see it parsed into every supported color space in real t
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <input type="color" v-model="pickedColor" style="width: 40px; height: 32px; border: none; padding: 0; cursor: pointer;" />
-            <span>Alpha</span>
+        <RiplField label="Color">
+            <RiplColorInput v-model="pickedColor" />
+        </RiplField>
+        <RiplField label="Alpha">
             <RiplInputRange v-model="alpha" :min="0" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/custom-elements.md
+++ b/apps/website/src/docs/core/advanced/custom-elements.md
@@ -14,12 +14,12 @@ Ripl's built-in elements cover common shapes, but you can create your own custom
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Points</span>
+        <RiplField label="Points">
             <RiplInputRange v-model="starPoints" :min="3" :max="12" :step="1" @update:model-value="redraw" />
-            <span>Inner Radius %</span>
+        </RiplField>
+        <RiplField label="Inner Radius %">
             <RiplInputRange v-model="innerPct" :min="10" :max="90" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/gradients.md
+++ b/apps/website/src/docs/core/advanced/gradients.md
@@ -14,10 +14,9 @@ Ripl supports CSS gradient strings directly in `fill` and `stroke` properties. T
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Angle</span>
+        <RiplField label="Angle">
             <RiplInputRange v-model="angleDeg" :min="0" :max="360" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/interpolators.md
+++ b/apps/website/src/docs/core/advanced/interpolators.md
@@ -186,10 +186,9 @@ circle.radius = interp(t);
 == Demo
 <ripl-example @context-changed="numberCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="numberT" :min="0" :max="100" :step="1" @update:model-value="numberRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="numberT" :min="0" :max="100" :step="1" @update:model-value="numberRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -211,10 +210,9 @@ rect.fill = interp(t);
 == Demo
 <ripl-example @context-changed="colorCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="colorT" :min="0" :max="100" :step="1" @update:model-value="colorRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="colorT" :min="0" :max="100" :step="1" @update:model-value="colorRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -239,10 +237,9 @@ rect.fill = interp(t);
 == Demo
 <ripl-example @context-changed="gradientCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="gradientT" :min="0" :max="100" :step="1" @update:model-value="gradientRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="gradientT" :min="0" :max="100" :step="1" @update:model-value="gradientRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -267,10 +264,9 @@ rect.fill = interp(t);
 == Demo
 <ripl-example @context-changed="patternCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="patternT" :min="0" :max="100" :step="1" @update:model-value="patternRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="patternT" :min="0" :max="100" :step="1" @update:model-value="patternRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -292,10 +288,9 @@ rect.rotation = interp(t);
 == Demo
 <ripl-example @context-changed="rotationCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="rotationT" :min="0" :max="100" :step="1" @update:model-value="rotationRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="rotationT" :min="0" :max="100" :step="1" @update:model-value="rotationRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -318,10 +313,9 @@ polyline.points = interp(t);
 == Demo
 <ripl-example @context-changed="pathCtxChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>t</span>
-            <RiplInputRange v-model="pathT" :min="0" :max="100" :step="1" @update:model-value="pathRedraw" style="flex:1" />
-        </RiplControlGroup>
+        <RiplField label="t">
+            <RiplInputRange v-model="pathT" :min="0" :max="100" :step="1" @update:model-value="pathRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::
@@ -346,7 +340,7 @@ polygon.points = interp(t); // smoothly morphs between shapes
 == Demo
 <ripl-example @context-changed="morphCtxChanged">
     <template #footer>
-        <RiplControlGroup>
+        <RiplField label="From">
             <RiplSelect v-model="morphFrom" @change="morphRedraw">
                 <option value="3">Triangle</option>
                 <option value="4">Square</option>
@@ -354,7 +348,8 @@ polygon.points = interp(t); // smoothly morphs between shapes
                 <option value="6">Hexagon</option>
                 <option value="8">Octagon</option>
             </RiplSelect>
-            <span>→</span>
+        </RiplField>
+        <RiplField label="To">
             <RiplSelect v-model="morphTo" @change="morphRedraw">
                 <option value="3">Triangle</option>
                 <option value="4">Square</option>
@@ -362,8 +357,10 @@ polygon.points = interp(t); // smoothly morphs between shapes
                 <option value="6">Hexagon</option>
                 <option value="8">Octagon</option>
             </RiplSelect>
-            <RiplInputRange v-model="morphT" :min="0" :max="100" :step="1" @update:model-value="morphRedraw" style="flex:1" />
-        </RiplControlGroup>
+        </RiplField>
+        <RiplField label="t">
+            <RiplInputRange v-model="morphT" :min="0" :max="100" :step="1" @update:model-value="morphRedraw" />
+        </RiplField>
     </template>
 </ripl-example>
 :::

--- a/apps/website/src/docs/core/advanced/math.md
+++ b/apps/website/src/docs/core/advanced/math.md
@@ -19,12 +19,12 @@ The demo below visualizes several geometry utilities: polygon vertex generation,
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Sides</span>
+        <RiplField label="Sides">
             <RiplInputRange v-model="sides" :min="3" :max="12" :step="1" @update:model-value="redraw" />
-            <span>Waypoint %</span>
+        </RiplField>
+        <RiplField label="Waypoint %">
             <RiplInputRange v-model="waypoint" :min="0" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/pattern-fills.md
+++ b/apps/website/src/docs/core/advanced/pattern-fills.md
@@ -16,10 +16,9 @@ Patterns keep shapes distinguishable without relying on color alone, which helps
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Tile size</span>
+        <RiplField label="Tile size">
             <RiplInputRange v-model="tileSize" :min="4" :max="24" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/advanced/scales.md
+++ b/apps/website/src/docs/core/advanced/scales.md
@@ -23,16 +23,17 @@ Use the controls below to explore different scale types. The scale maps a domain
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
+        <RiplField label="Scale">
             <RiplSelect v-model="currentScale" @change="redraw">
                 <option value="continuous">Continuous</option>
                 <option value="logarithmic">Logarithmic</option>
                 <option value="power">Power (x²)</option>
                 <option value="sqrt">Square Root</option>
             </RiplSelect>
-            <span>Input</span>
+        </RiplField>
+        <RiplField label="Input">
             <RiplInputRange v-model="inputValue" :min="0" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/arc.md
+++ b/apps/website/src/docs/core/elements/arc.md
@@ -16,31 +16,35 @@ An **Arc** draws a circular or annular (donut) arc segment defined by a center p
 == Single
 <ripl-example @context-changed="singleChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>End Angle</span>
+        <RiplField label="End Angle">
             <RiplInputRange v-model="singleEndAnglePct" :min="0" :max="100" :step="1" @update:model-value="redrawSingle" />
-            <span>Inner Radius %</span>
+        </RiplField>
+        <RiplField label="Inner Radius %">
             <RiplInputRange v-model="singleInnerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redrawSingle" />
-            <span>Border Radius</span>
+        </RiplField>
+        <RiplField label="Border Radius">
             <RiplInputRange v-model="singleBorderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redrawSingle" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Stacked
 <ripl-example @context-changed="stackedChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>End Angle</span>
+        <RiplField label="End Angle">
             <RiplInputRange v-model="stackedEndAnglePct" :min="0" :max="100" :step="1" @update:model-value="redrawStacked" />
-            <span>Inner Radius %</span>
+        </RiplField>
+        <RiplField label="Inner Radius %">
             <RiplInputRange v-model="stackedInnerRadiusPct" :min="0" :max="90" :step="1" @update:model-value="redrawStacked" />
-            <span>Pad Width (px, takes precedence)</span>
+        </RiplField>
+        <RiplField label="Pad Width">
             <RiplInputRange v-model="stackedPadWidthVal" :min="0" :max="40" :step="1" @update:model-value="redrawStacked" />
-            <span>Pad Angle (applies only at Pad Width 0)</span>
+        </RiplField>
+        <RiplField label="Pad Angle">
             <RiplInputRange v-model="stackedPadAngleVal" :min="0" :max="20" :step="1" @update:model-value="redrawStacked" />
-            <span>Border Radius</span>
+        </RiplField>
+        <RiplField label="Border Radius">
             <RiplInputRange v-model="stackedBorderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redrawStacked" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code
@@ -65,7 +69,7 @@ createArc({
 ```
 :::
 
-**Single** is one `createArc` call. **Stacked** is three of them sharing a centre, which is the only arrangement where padding has anything to separate — hence the two extra controls.
+**Single** is one `createArc` call. **Stacked** is three of them sharing a centre, which is the only arrangement where padding has anything to separate — hence the two extra controls. **Pad Width** is in pixels and takes precedence; this demo passes it only while it is non-zero, so drag it to `0` to hand control back to **Pad Angle**.
 
 <script lang="ts" setup>
 import {

--- a/apps/website/src/docs/core/elements/circle.md
+++ b/apps/website/src/docs/core/elements/circle.md
@@ -14,14 +14,15 @@ A **Circle** draws a filled and/or stroked circle defined by a center point (`cx
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Radius</span>
+        <RiplField label="Radius">
             <RiplInputRange v-model="radius" :min="10" :max="100" :step="1" @update:model-value="redraw" />
-            <span>Stroke</span>
+        </RiplField>
+        <RiplField label="Stroke Width">
             <RiplInputRange v-model="lineWidth" :min="0" :max="10" :step="1" @update:model-value="redraw" />
-            <span>Opacity</span>
+        </RiplField>
+        <RiplField label="Opacity">
             <RiplInputRange v-model="opacity" :min="0" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code
@@ -82,7 +83,7 @@ function renderDemo(context: Context) {
 
         createText({
             x: w / 2, y: h / 2 + r + 24,
-            content: `radius: ${Math.round(r)}  stroke: ${lineWidth.value}  opacity: ${opacity.value}%`,
+            content: `radius: ${Math.round(r)}  lineWidth: ${lineWidth.value}  opacity: ${opacity.value}%`,
             fill: '#666', textAlign: 'center', font: '12px sans-serif',
         }).render(context);
     });

--- a/apps/website/src/docs/core/elements/ellipse.md
+++ b/apps/website/src/docs/core/elements/ellipse.md
@@ -14,14 +14,15 @@ An **Ellipse** draws an elliptical shape with independent X and Y radii (`radius
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Radius X</span>
+        <RiplField label="Radius X">
             <RiplInputRange v-model="rxPct" :min="10" :max="100" :step="1" @update:model-value="redraw" />
-            <span>Radius Y</span>
+        </RiplField>
+        <RiplField label="Radius Y">
             <RiplInputRange v-model="ryPct" :min="10" :max="100" :step="1" @update:model-value="redraw" />
-            <span>Rotation</span>
+        </RiplField>
+        <RiplField label="Rotation">
             <RiplInputRange v-model="rotationDeg" :min="0" :max="360" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/line.md
+++ b/apps/website/src/docs/core/elements/line.md
@@ -14,14 +14,15 @@ A **Line** draws a straight line between two points (`x1`, `y1`) to (`x2`, `y2`)
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Line Width</span>
+        <RiplField label="Line Width">
             <RiplInputRange v-model="lineWidthVal" :min="1" :max="10" :step="1" @update:model-value="redraw" />
-            <span>Dash Gap</span>
+        </RiplField>
+        <RiplField label="Dash Gap">
             <RiplInputRange v-model="dashGap" :min="0" :max="20" :step="1" @update:model-value="redraw" />
-            <span>Angle</span>
+        </RiplField>
+        <RiplField label="Angle">
             <RiplInputRange v-model="angleDeg" :min="0" :max="360" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/path.md
+++ b/apps/website/src/docs/core/elements/path.md
@@ -17,16 +17,17 @@ The **Path** element is a general-purpose shape that delegates its geometry to a
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
+        <RiplField label="Shape">
             <RiplSelect v-model="currentShape" @change="redraw">
                 <option value="star">Star</option>
                 <option value="heart">Heart</option>
                 <option value="arrow">Arrow</option>
                 <option value="cross">Cross</option>
             </RiplSelect>
-            <span>Size</span>
+        </RiplField>
+        <RiplField label="Size">
             <RiplInputRange v-model="size" :min="40" :max="160" :step="4" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/polygon.md
+++ b/apps/website/src/docs/core/elements/polygon.md
@@ -14,12 +14,12 @@ A **Polygon** draws a regular polygon (triangle, pentagon, hexagon, etc.) define
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Sides</span>
+        <RiplField label="Sides">
             <RiplInputRange v-model="sides" :min="3" :max="12" :step="1" @update:model-value="redraw" />
-            <span>Radius</span>
+        </RiplField>
+        <RiplField label="Radius">
             <RiplInputRange v-model="radiusPct" :min="20" :max="100" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/polyline.md
+++ b/apps/website/src/docs/core/elements/polyline.md
@@ -16,11 +16,11 @@ The demo below shows the same set of points rendered with different renderer mod
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
+        <RiplField label="Renderer">
             <RiplSelect v-model="currentRenderer">
                 <option v-for="r in renderers" :key="r" :value="r">{{ r }}</option>
             </RiplSelect>
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/rect.md
+++ b/apps/website/src/docs/core/elements/rect.md
@@ -14,14 +14,15 @@ A **Rect** draws a rectangle defined by position (`x`, `y`) and dimensions (`wid
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Width</span>
+        <RiplField label="Width">
             <RiplInputRange v-model="widthPct" :min="20" :max="100" :step="1" @update:model-value="redraw" />
-            <span>Height</span>
+        </RiplField>
+        <RiplField label="Height">
             <RiplInputRange v-model="heightPct" :min="20" :max="100" :step="1" @update:model-value="redraw" />
-            <span>Border Radius</span>
+        </RiplField>
+        <RiplField label="Border Radius">
             <RiplInputRange v-model="borderRadiusVal" :min="0" :max="40" :step="1" @update:model-value="redraw" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/elements/text.md
+++ b/apps/website/src/docs/core/elements/text.md
@@ -14,15 +14,16 @@ A **Text** element renders a text string at a given position. Unlike other built
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Font Size</span>
+        <RiplField label="Font Size">
             <RiplInputRange v-model="fontSize" :min="12" :max="48" :step="1" @update:model-value="redraw" />
+        </RiplField>
+        <RiplField label="Align">
             <RiplSelect v-model="textAlign" @change="redraw">
                 <option value="left">Left</option>
                 <option value="center">Center</option>
                 <option value="right">Right</option>
             </RiplSelect>
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code

--- a/apps/website/src/docs/core/getting-started/tutorial.md
+++ b/apps/website/src/docs/core/getting-started/tutorial.md
@@ -62,10 +62,9 @@ circle.render(context);
 == Demo
 <ripl-example @context-changed="changeContextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Radius</span>
-            <RiplInputRange v-model.number="changePropsRadius" :min="changePropsMin" :max="changePropsMax" step="1" style="flex: 1;"/>
-        </RiplControlGroup>
+        <RiplField label="Radius">
+            <RiplInputRange v-model.number="changePropsRadius" :min="changePropsMin" :max="changePropsMax" :step="1" />
+        </RiplField>
     </template>
 </ripl-example>
 :::

--- a/apps/website/src/docs/core/troubleshooting/performance.md
+++ b/apps/website/src/docs/core/troubleshooting/performance.md
@@ -108,10 +108,9 @@ Use the demo below to benchmark Ripl's rendering performance. Adjust the element
 == Demo
 <ripl-example @context-changed="contextChanged">
     <template #footer>
-        <RiplControlGroup>
-            <span>Elements</span>
+        <RiplField label="Elements">
             <RiplInputRange v-model="elementCount" :min="100" :max="5000" :step="100" />
-        </RiplControlGroup>
+        </RiplField>
     </template>
 </ripl-example>
 == Code


### PR DESCRIPTION
Demo controls were scattered — some in the pane header competing with the context switcher, most in a footer that had no layout to put them in — and several 3D demo scenes had objects passing through each other.

## The problem

**The footer had no layout at all.** It was padding and a border:

```scss
.ripl-example__footer {
    padding: 1rem;
    border-top: 1px solid var(--vp-c-divider);
}
```

No `display: flex`, no `gap`, no wrapping — while the header beside it was a full wrapping flex row. So roughly 40 demo blocks improvised: bare `<span>` labels, `style="flex:1"` on sliders, and two stacked `RiplControlGroup`s to fake a second row (which rendered with no gap between them). Because `RiplInputRange` is `width: 100%`, a slider with no flex hint claimed the entire row and pushed its own label onto the line above. Three 3D pages gave up on the footer entirely and put their controls in `#header`.

**Two label classes were referenced but defined nowhere.** `ripl-example__label` (materials, textures) and `teapot-demo__label` (teapot) appear only in markup — no stylesheet in the repo defines either, so those labels had always rendered as unstyled body text:

```html
<label class="ripl-example__label">Shine</label>
```

**Several selects had no label at all** — the realtime speed select, the path shape select, the polyline renderer select, the text align select, the scales scale select, both interpolator morph selects, and the animation seek slider.

**The 3D scenes.** The materials demo interpenetrated: three spheres of radius `0.9` at a centre spacing of `1.6`, so each pair overlapped by 0.2 world units — which the demo's own wireframe toggle makes obvious.

```ts
createSphere({ x: -1.6, radius: 0.9, ... }),
createSphere({ x: 0,    radius: 0.9, ... }),
createSphere({ x: 1.6,  radius: 0.9, ... }),
```

The playground's 2D example overlapped too: the circle spanned 20px into *both* neighbouring rects, which shared its y-band.

## Three bugs found on the way

- **The WebGPU docs demo never ran.** `createCamera(context, …)` referenced an identifier that is never declared in that `<script setup>` — the handler's parameter is `ctx` — so `contextChanged` threw a `ReferenceError` before either shape was added and the page showed an empty canvas. It *also* positioned both shapes with `translateX`, which is `Element`'s 2D transform applied in screen pixels *after* projection (`Shape3D.getModelMatrix()` composes only `x`/`y`/`z`), so once the crash was fixed both shapes would have landed on the origin. That mistake was in the copy-pasteable Code tab too, teaching the wrong API.
- **`cornerRadius` is not a `Rect` option** — it is `borderRadius` — so the playground's 2D shapes never had rounded corners.
- **`RiplColorInput` emitted on `change`**, so dragging inside the native picker produced nothing until it was dismissed, while the colour page promises output "in real time".

## The fix

Give the footer a wrapping flex row and size a stacked `RiplField` at `flex: 1 1 12rem`, so labelled controls share a row on desktop and stack on mobile. `align-items: flex-end` lines a group of buttons up with a field's *control* rather than its label.

`RiplField` needed no changes: its non-`inline` mode already stacks label over control, its `--ripl-panel-*` tokens already carry non-drawer fallbacks, and its `:deep()` rules already stretch `RiplSelect`/`RiplInputRange` to the field width. Every labelled control across ~24 doc pages moves onto it, and the standalone demos under `src/demos/` get the same treatment where they had the same defects.

For the 3D scenes I rejected the obvious approach. My first pass used a 1-D "vertical clearance" between the sphere and the ring in the two lighting rigs, concluded they nearly touched, and lowered the torus. That was wrong twice over: the ring sits at radius 1.7–1.8 in XZ, so it actually clears the sphere by ~0.9 units and never overlapped, and lowering it pushed its near edge *outside* the camera frustum. The same flat reasoning had also under-estimated the materials demo, because an orbiting camera brings the outer spheres closer and inflates their angular size.

So the geometry is now solved against an exact camera-space frustum test sampled over a full 360° orbit — sphere-to-plane distances exact, swept shapes sampled on their silhouette — for both the docs pane (4:3 below 640px is the tighter case) and the playground's near-square preview. The material showcase became a 2×2 grid because no single row both clears and fits that narrower frame.

`check-demo-controls` locks the convention in. It is wired into CI as its own step, not just the website build: `apps/website` is not a lerna package, so the website build never runs on a pull request — without that step the guard would only fire on deploy, after merge.

## Verification

- `yarn lint`, `yarn typecheck` — clean.
- `yarn test` — 238 files, 3297 passed, 2 skipped.
- `check-chart-options` (25 pages), `check-config-coverage` (316 options across 25 charts), `check-demo-controls` (166 files) — all pass.
- **Browser, via Playwright against the dev server at 375/768/1280px.** 27 demo pages × 3 widths = 81 page-widths, 0 problems. The assertions are measured, not eyeballed: footer `scrollWidth` vs `clientWidth`, page-level horizontal overflow, every footer control's accessible name, any control left in a header, and uncaught page errors. Plus 10 standalone demo/playground pages × 3 widths for toolbar overflow.
- **The 3D geometry** passes the frustum test above on all 8 scenes with positive margin and positive surface gaps.
- **The guard was proven to fire on the real tree** for each of its three rules — a `#header` slot, a retired label class, and an unwrapped control in a footer — not only in a scratch fixture.
- **Interaction checks** after the shared-component edits: the colour picker now updates from an `input` event alone (it did not before), sliders still drive their demos, and the button group reports `aria-pressed`.

Not run: the chart visual-regression baselines. They are rendered on a specific Linux Chromium and comparing against them in this sandbox proves nothing; this change touches no chart rendering code, only website components and demo markup.

## Follow-ups this PR deliberately leaves undone

- The trading dashboard's page overflows by 23px at 375px. I measured this on the pre-change tree — it is pre-existing and it is the card grid, i.e. page layout rather than controls.
- The drawing demo's colour picker still has no programmatic name (it has a visible "Color" heading above it). Fixing it needs a new prop on a shared component.
- The playground's own editor header overflows at 375px; the playground chrome was out of scope.
- `check-demo-controls` masks fenced code and comments, but prose that names a retired label class in plain body text still fails the build.

No breaking changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj6ybN5ngssXUi4v1VTtVH)_