### PR TITLE
Let charts be highlighted from code, not only by the pointer

### DIFF
--- a/apps/website/src/.vitepress/config.mts
+++ b/apps/website/src/.vitepress/config.mts
@@ -643,6 +643,10 @@ export default defineConfig({
                             link: '/charts/advanced/panning-and-zooming',
                         },
                         {
+                            text: 'Programmatic Interaction',
+                            link: '/charts/advanced/programmatic-interaction',
+                        },
+                        {
                             text: 'Rendering Targets',
                             link: '/charts/advanced/rendering-targets',
                         },

--- a/apps/website/src/charts/advanced/custom-charts.md
+++ b/apps/website/src/charts/advanced/custom-charts.md
@@ -220,6 +220,37 @@ For legend-driven highlighting (hovering a legend item dims the other series), r
 this.registerHighlightGroups(this._groups);
 ```
 
+### Making Marks Addressable
+
+Registering a mark is what lets that same treatment be replayed from code, as every built-in chart's
+`highlightX` method does (see [Programmatic Interaction](/charts/advanced/programmatic-interaction)).
+Call `registerMark` beside the interaction wiring, once per mark per render:
+
+```ts
+this.registerMark('segment', key, mark, series.id);
+```
+
+- The first argument is the mark family — the name behind your public method: `'bar'`, `'segment'`, `'node'`, `'cell'`.
+- The key should be the key your events already report, so a caller can hand back what an event gave them.
+- The fourth argument is the series id, and is optional. Supply it on a multi-series chart and the mark becomes addressable both bare (every series at that key) and narrowed to `{ key, series }`.
+- Registering one element under several keys is fine, and is how a bare axis label lights a whole heatmap row: each cell is registered under `"<x> <y>"`, under `x`, and under `y`.
+- The registry is cleared at the top of every `render()`, so registration belongs in the render path, never the constructor.
+
+Then expose a typed method per mark family, resolving the accessor form of the selector where your
+datum type is known and delegating to `replayMark`:
+
+<!-- eslint-skip -->
+```ts
+public highlightSegment(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+    return this.replayMark('segment', this.resolveMarkSelector(selector, this.options.data), options);
+}
+```
+
+`replayMark` returns `false` — having changed nothing — when no live mark matches, and is silent by
+design: it emits no interaction events, so a chart highlighted from inside its own event handler
+cannot feed itself. Charts extending `CartesianChart` get the `crosshair` and axis-tooltip handling
+for free; if you override `replayMark` or `clearHighlight` there, call `super`.
+
 ## Checklist
 
 - Factory function exported; consumers never call `new`.

--- a/apps/website/src/charts/advanced/programmatic-interaction.md
+++ b/apps/website/src/charts/advanced/programmatic-interaction.md
@@ -1,0 +1,397 @@
+---
+title: Programmatic Interaction
+description: Drive a chart's hover treatment from code — highlight a mark, a row of cells or a whole series, with its tooltip and crosshair, then clear it again.
+outline: "deep"
+---
+
+# Programmatic Interaction
+
+Every chart already knows how to highlight one of its marks: hover a bar and it lights up, the rest of the chart dims, and the bar's tooltip opens. That treatment is a pointer away, and otherwise out of reach.
+
+The `highlightX` methods replay it from code. They run the same path the pointer does — the same highlight state, the same chart-wide dim, the same tooltip — so a chart can be driven by something other than the mouse: a hovered row in a table beside it, a search result, keyboard navigation, a second chart showing the same records, a guided tour, or an export that needs one mark called out.
+
+## Quick Start
+
+```ts
+import {
+    createBarChart,
+} from '@ripl/charts';
+
+const chart = createBarChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+});
+
+// Light the March bar, dim everything else, open its tooltip.
+chart.highlightBar('mar', { tooltip: true });
+
+// Put the chart back.
+chart.clearHighlight();
+```
+
+Every method returns a `boolean`: `true` when at least one live mark matched and the chart changed, `false` when nothing did — an unknown key, a mark that is mid-exit, a marker on a series drawn with `markers: false`.
+
+## The Naming Convention
+
+A chart's highlight methods mirror its events. The mark family in the event name is the mark family in the method name, so if you know what to subscribe to you already know what to call:
+
+| Event | Method | Charts |
+| --- | --- | --- |
+| `barenter` / `barleave` / `barclick` | `highlightBar` | Bar, Trend, Radial Bar |
+| `markerenter` / … | `highlightMarker` | Line, Area, Trend, Scatter, Radar, Polar Scatter |
+| `segmententer` / … | `highlightSegment` | Pie, Polar Area, Funnel, Chord |
+| `nodeenter` / … | `highlightNode` | Treemap, Sunburst, Packed Circle, Sankey, Arc Diagram, Force-Directed |
+| `linkenter` / … | `highlightLink` | Sankey, Chord, Arc Diagram, Force-Directed |
+| `cellenter` / … | `highlightCell` | Heatmap |
+
+The pairing goes further than the name: **the key you pass is the key the event reports**. A bar event carries the category as `xValue`, and that is exactly what `highlightBar` takes, so a key read off an event can be handed straight back:
+
+```ts
+const chart = createBarChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+});
+
+chart.on('barclick', event => {
+    // `xValue` is the same key `highlightBar` selects by.
+    chart.highlightBar(event.data.xValue, { tooltip: true });
+});
+```
+
+Each chart's page lists its events and their payloads; the [Method Reference](#method-reference) below names the field that doubles as the selector for every chart.
+
+## Selecting a Mark
+
+A selector takes three forms, and every chart accepts all three.
+
+### By key
+
+The bare key selects the mark at that key. On a multi-series chart it selects that key in *every* series, so one call lights the whole category:
+
+```ts
+const chart = createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+        { id: 'costs', value: 'costs', label: 'Costs' },
+    ],
+});
+
+// The March point on both series.
+chart.highlightMarker('mar');
+```
+
+### Narrowed to a series
+
+Pass a `{ key, series }` ref to select one of them. The `series` is the series `id` — the same `seriesId` the mark's events report:
+
+```ts
+const chart = createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+        { id: 'costs', value: 'costs', label: 'Costs' },
+    ],
+});
+
+chart.highlightMarker({ key: 'mar', series: 'revenue' });
+```
+
+### By position in the data
+
+An accessor receives the chart's own dataset and returns a key or a ref, so a mark can be addressed by where it sits in the data without tracking keys at all:
+
+```ts
+const chart = createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+});
+
+// The third datum, whatever its key happens to be.
+chart.highlightMarker(data => data[2].month);
+
+// The most recent one.
+chart.highlightMarker(data => data[data.length - 1].month);
+```
+
+The accessor is called with whichever array the chart's marks are built from: `data` on most charts, `nodes` or `links` on the network charts. It runs at call time, against the data the chart currently holds.
+
+### The other ref shapes
+
+Marks that are not addressed by a single key take a ref shaped to what they are, and the same three forms apply to it:
+
+```ts
+const chart = createSankeyChart('#container', {
+    nodes,
+    links,
+});
+
+// A link is named by the nodes it joins.
+chart.highlightLink({ source: 'coal', target: 'grid' });
+chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+```
+
+- **Links** (Sankey, Chord, Arc Diagram, Force-Directed) take `{ source, target }` — the node ids at each end — or the `"source->target"` string it flattens to.
+- **Heatmap cells** take `{ x, y }`, the pair of axis labels the chart reports as `xLabel`/`yLabel`.
+- **Histogram bins** are derived from the data rather than carrying a key, so `highlightBin` takes a numeric index (or an accessor returning one), counting up in the order the bars are drawn.
+- **The gauge** has a single arc, so `highlightValue` takes no selector — only options.
+
+### Matching more than one mark
+
+Some selectors deliberately match several marks, and all of them light together:
+
+```ts
+const chart = createHeatmapChart('#container', {
+    data,
+    keyX: 'hour',
+    keyY: 'day',
+    value: 'value',
+});
+
+// One cell.
+chart.highlightCell({ x: '9am', y: 'Mon' }, { tooltip: true });
+
+// A bare label lights that whole row (or column).
+chart.highlightCell('Mon', { tooltip: true });
+```
+
+When a selector matches several marks and `tooltip` is on, they share a single tooltip anchored at the first match, with each mark's content on its own line.
+
+## Tooltips and Crosshairs
+
+A highlight is only the mark's highlight state unless you ask for more. Both options default to `false`:
+
+```ts
+const chart = createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+    crosshair: true,
+});
+
+chart.highlightMarker('mar', {
+    tooltip: true,
+    crosshair: true,
+});
+```
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `tooltip` | `boolean` | `false` | Opens the mark's tooltip, anchored where hovering it would place it |
+| `crosshair` | `boolean` | `false` | Places the crosshair on the mark |
+
+`tooltip` follows the chart's own `tooltip` configuration: with the default `trigger: 'item'` it is the mark's own tooltip, and on a cartesian chart configured with `trigger: 'axis'` it is the shared axis tooltip listing every series at that position — exactly what hovering there would show. A chart with tooltips turned off shows nothing.
+
+`crosshair` only means something on the charts that draw one: **line, area, trend, scatter, stock, box plot and histogram**. Only the axes the chart's `crosshair` option was configured for are drawn, and on every other chart the flag is ignored rather than an error, so the same call is safe across chart types. See [Crosshair](/charts/shared-options#crosshair) in Shared Options for the configuration itself.
+
+## A Command, Not a Mode
+
+A programmatic highlight is one-shot. It survives until something replaces it:
+
+- **A render clears it.** `render()` drops the highlight before it redraws, so a resize, an `update()`, a legend toggle, or a pan/zoom gesture leaves the chart in its rest state. Marks are addressed by key, and a render is free to have destroyed the mark at that key, so the highlight cannot meaningfully outlive it.
+- **The pointer takes it over.** Hovering any mark releases the programmatic highlight first, then applies its own, so a hover never has to fight it. Only that chart's highlight is released — two charts on the same page never clear each other.
+- **A second call replaces the first.** Each chart holds at most one programmatic highlight; calling again clears the previous one before applying the new.
+- **`clearHighlight()` ends it.**
+
+If a highlight should persist across data updates, hold the selection in your own state and re-apply it once the render has settled:
+
+```ts
+const chart = createBarChart('#container', {
+    data: months,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+    autoRender: false,
+});
+
+let selected: string | null = null;
+
+async function setData(next: typeof months) {
+    chart.update({ data: next });
+
+    // `render()` resolves once the entry/update transitions have settled.
+    await chart.render();
+
+    if (selected) {
+        chart.highlightBar(selected, { tooltip: true });
+    }
+}
+```
+
+`autoRender: false` is what makes this tidy: `update()` then renders only when you ask, so there is one render to wait on and one place to re-apply.
+
+## No Events Are Emitted
+
+A programmatic highlight is silent. It emits no `*enter`, `*leave` or `*click` event, and `highlightSeries` emits nothing either.
+
+That is deliberate, because the most common thing to do with these methods is call them from inside an event handler — linking two charts on a shared key:
+
+```ts
+const overview = createLineChart('#overview', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+});
+
+const detail = createBarChart('#detail', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+    ],
+});
+
+overview.on('markerenter', event => detail.highlightBar(event.data.xValue, { tooltip: true }));
+overview.on('markerleave', () => detail.clearHighlight());
+```
+
+If the highlight emitted a `barenter` of its own, the mirrored subscription in the other direction would bounce the two charts off each other forever. Staying silent also keeps `chart.on(...)` honest: an interaction event means a user did something, which is what makes those events worth logging as analytics. You never need the echo anyway — you know when you called `highlightBar`.
+
+## Highlighting a Series
+
+`highlightSeries(id)` dims everything except one series, exactly as hovering its legend entry does:
+
+```ts
+const chart = createLineChart('#container', {
+    data,
+    key: 'month',
+    series: [
+        { id: 'revenue', value: 'revenue', label: 'Revenue' },
+        { id: 'costs', value: 'costs', label: 'Costs' },
+    ],
+});
+
+chart.highlightSeries('revenue');
+```
+
+The id is whatever the chart puts in its legend: a series `id` on the multi-series charts, and the segment key on the charts whose legend lists segments (pie, polar area, funnel, treemap and friends), where it isolates that segment.
+
+**The legend follows.** The matching legend entry stays lit while every other entry — swatch and label alike — dims with the plot, so a highlight driven from your own UI reads in the legend too. An entry toggled off stays visibly inactive underneath the dim.
+
+It takes no `tooltip` or `crosshair` options: a whole series has no single point to anchor them to. It returns `true` when the id matched, and `false` on a chart with no highlightable series (box plot, histogram, heatmap, stock, gantt and gauge each highlight marks only).
+
+The same one-shot rules apply — the next render restores the chart — with one exception worth knowing: `clearHighlight()` only clears highlights *you* asked for. A legend hover in progress is left alone.
+
+## Clearing a Highlight
+
+`clearHighlight()` restores everything a programmatic highlight changed: the highlighted marks, the chart-wide dim, the legend, and any tooltip or crosshair it opened. The marks are written back immediately rather than transitioned, so the chart is at rest the moment the call returns — useful when the next thing you do is export it.
+
+```ts
+const chart = createPieChart('#container', {
+    data,
+    key: 'browser',
+    value: 'share',
+    label: 'browser',
+});
+
+chart.highlightSegment('Chrome', { tooltip: true });
+chart.clearHighlight();
+
+// Safe to call at any time; a no-op when nothing is highlighted.
+chart.clearHighlight();
+```
+
+## Method Reference
+
+Every chart, and what its methods select. Selectors also accept an accessor returning the same value, and the multi-series charts additionally accept `{ key, series }`.
+
+### Cartesian
+
+| Chart | Method | Selects |
+| --- | --- | --- |
+| [Line](/charts/line) | `highlightMarker(selector, options?)` | The category key (`xValue`), in every series or one |
+| [Bar](/charts/bar) | `highlightBar(selector, options?)` | The category key (`xValue`), in every series or one |
+| [Area](/charts/area) | `highlightMarker(selector, options?)` | The category key (`xValue`), in every series or one |
+| [Trend](/charts/trend) | `highlightBar(selector, options?)` | The category key, across the bar series only |
+| [Trend](/charts/trend) | `highlightMarker(selector, options?)` | The category key, across the line and area series |
+| [Scatter](/charts/scatter) | `highlightMarker(selector, options?)` | The item's key, in every series or one |
+| [Stock](/charts/stock) | `highlightCandle(selector, options?)` | The candle's key |
+| [Box Plot](/charts/box-plot) | `highlightBox(selector, options?)` | The box's category |
+| [Histogram](/charts/histogram) | `highlightBin(index, options?)` | The bin's index, left to right |
+
+### Radial & Polar
+
+| Chart | Method | Selects |
+| --- | --- | --- |
+| [Pie/Donut](/charts/pie) | `highlightSegment(selector, options?)` | The segment's key |
+| [Polar Area](/charts/polar-area) | `highlightSegment(selector, options?)` | The segment's key |
+| [Radial Bar](/charts/radial-bar) | `highlightBar(selector, options?)` | The ring's key |
+| [Radar](/charts/radar) | `highlightMarker(selector, options?)` | The point's axis label (`axisLabel`), in every series or one |
+| [Polar Scatter](/charts/polar-scatter) | `highlightMarker(selector, options?)` | The item's `index` as a string, in every series or one |
+| [Gauge](/charts/gauge) | `highlightValue(options?)` | The value arc — no selector |
+
+### Hierarchical
+
+| Chart | Method | Selects |
+| --- | --- | --- |
+| [Treemap](/charts/treemap) | `highlightNode(selector, options?)` | The cell's key |
+| [Sunburst](/charts/sunburst) | `highlightNode(selector, options?)` | The node's id |
+| [Packed Circle](/charts/packed-circle) | `highlightNode(selector, options?)` | The circle's key |
+
+### Network & Flow
+
+| Chart | Method | Selects |
+| --- | --- | --- |
+| [Funnel](/charts/funnel) | `highlightSegment(selector, options?)` | The segment's key |
+| [Sankey](/charts/sankey) | `highlightNode(selector, options?)` | The node's id |
+| [Sankey](/charts/sankey) | `highlightLink(selector, options?)` | `{ source, target }` node ids, or the link's id |
+| [Chord](/charts/chord) | `highlightSegment(selector, options?)` | The group's label |
+| [Chord](/charts/chord) | `highlightLink(selector, options?)` | `{ source, target }` group labels, or the ribbon's id |
+| [Arc Diagram](/charts/arc-diagram) | `highlightNode(selector, options?)` | The node's id |
+| [Arc Diagram](/charts/arc-diagram) | `highlightLink(selector, options?)` | `{ source, target }` node ids |
+| [Force-Directed](/charts/force-directed) | `highlightNode(selector, options?)` | The node's id |
+| [Force-Directed](/charts/force-directed) | `highlightLink(selector, options?)` | `{ source, target }` node ids |
+
+### Specialized
+
+| Chart | Method | Selects |
+| --- | --- | --- |
+| [Heatmap](/charts/heatmap) | `highlightCell(selector, options?)` | `{ x, y }` axis labels, or one label for its whole row/column |
+| [Gantt](/charts/gantt) | `highlightTask(selector, options?)` | The task's id |
+| [Realtime](/charts/realtime) | — | Series only, via `highlightSeries(id)` |
+
+`highlightSeries(id)` and `clearHighlight()` are on the `Chart` base class, so every chart in the table has them as well.
+
+## Types
+
+The selector and option types are exported from `@ripl/charts` for typing your own helpers around these calls:
+
+<!-- eslint-skip -->
+```ts
+import type {
+    CellRef,
+    HighlightOptions,
+    LinkRef,
+    MarkRef,
+    MarkSelector,
+} from '@ripl/charts';
+
+// A key, a ref, or an accessor over the chart's data. The second parameter is the ref shape.
+type MarkTarget = MarkSelector<MyDatum, MarkRef>; // { key, series? } — the default
+type LinkTarget = MarkSelector<MyLink, LinkRef>;  // { source, target }
+type CellTarget = MarkSelector<MyDatum, CellRef>; // { x, y }
+
+function focus(chart: BarChart<MyDatum>, target: MarkTarget, options?: HighlightOptions) {
+    return chart.highlightBar(target, options);
+}
+```
+
+## Custom Charts
+
+A chart you build yourself gets the same treatment by registering its marks as it renders them. See [Interaction](/charts/advanced/custom-charts#interaction) in Custom Charts for `registerMark` and the typed method to expose beside it.

--- a/apps/website/src/charts/advanced/programmatic-interaction.md
+++ b/apps/website/src/charts/advanced/programmatic-interaction.md
@@ -73,7 +73,9 @@ Each chart's page lists the events it emits and their payloads; the [Method Refe
 
 ## Selecting a Mark
 
-A selector takes three forms, and every chart accepts all three.
+A selector takes three forms. Most charts accept all three; the exceptions are noted below and in the
+[Method Reference](#method-reference) — `highlightBin` takes a bin index rather than a key, and
+`highlightValue` takes no selector at all, since a gauge draws a single mark.
 
 ### By Key
 

--- a/apps/website/src/charts/advanced/programmatic-interaction.md
+++ b/apps/website/src/charts/advanced/programmatic-interaction.md
@@ -70,7 +70,7 @@ Each chart's page lists its events and their payloads; the [Method Reference](#m
 
 A selector takes three forms, and every chart accepts all three.
 
-### By key
+### By Key
 
 The bare key selects the mark at that key. On a multi-series chart it selects that key in *every* series, so one call lights the whole category:
 
@@ -88,7 +88,7 @@ const chart = createLineChart('#container', {
 chart.highlightMarker('mar');
 ```
 
-### Narrowed to a series
+### Narrowed to a Series
 
 Pass a `{ key, series }` ref to select one of them. The `series` is the series `id` — the same `seriesId` the mark's events report:
 
@@ -105,7 +105,7 @@ const chart = createLineChart('#container', {
 chart.highlightMarker({ key: 'mar', series: 'revenue' });
 ```
 
-### By position in the data
+### By Position in the Data
 
 An accessor receives the chart's own dataset and returns a key or a ref, so a mark can be addressed by where it sits in the data without tracking keys at all:
 
@@ -127,7 +127,7 @@ chart.highlightMarker(data => data[data.length - 1].month);
 
 The accessor is called with whichever array the chart's marks are built from: `data` on most charts, `nodes` or `links` on the network charts. It runs at call time, against the data the chart currently holds.
 
-### The other ref shapes
+### The Other Ref Shapes
 
 Marks that are not addressed by a single key take a ref shaped to what they are, and the same three forms apply to it:
 
@@ -147,7 +147,7 @@ chart.highlightLink(links => ({ source: links[0].source, target: links[0].target
 - **Histogram bins** are derived from the data rather than carrying a key, so `highlightBin` takes a numeric index (or an accessor returning one), counting up in the order the bars are drawn.
 - **The gauge** has a single arc, so `highlightValue` takes no selector — only options.
 
-### Matching more than one mark
+### Matching More Than One Mark
 
 Some selectors deliberately match several marks, and all of them light together:
 
@@ -157,6 +157,8 @@ const chart = createHeatmapChart('#container', {
     keyX: 'hour',
     keyY: 'day',
     value: 'value',
+    xCategories: ['9am', '10am', '11am'],
+    yCategories: ['Mon', 'Tue', 'Wed'],
 });
 
 // One cell.

--- a/apps/website/src/charts/advanced/programmatic-interaction.md
+++ b/apps/website/src/charts/advanced/programmatic-interaction.md
@@ -46,6 +46,11 @@ A chart's highlight methods mirror its events. The mark family in the event name
 | `nodeenter` / … | `highlightNode` | Treemap, Sunburst, Packed Circle, Sankey, Arc Diagram, Force-Directed |
 | `linkenter` / … | `highlightLink` | Sankey, Chord, Arc Diagram, Force-Directed |
 | `cellenter` / … | `highlightCell` | Heatmap |
+| `boxenter` / … | `highlightBox` | Box Plot |
+| `binenter` / … | `highlightBin` | Histogram |
+| `candleenter` / … | `highlightCandle` | Stock |
+| `taskenter` / … | `highlightTask` | Gantt |
+| `valueenter` / … | `highlightValue` | Gauge |
 
 The pairing goes further than the name: **the key you pass is the key the event reports**. A bar event carries the category as `xValue`, and that is exactly what `highlightBar` takes, so a key read off an event can be handed straight back:
 
@@ -64,7 +69,7 @@ chart.on('barclick', event => {
 });
 ```
 
-Each chart's page lists its events and their payloads; the [Method Reference](#method-reference) below names the field that doubles as the selector for every chart.
+Each chart's page lists the events it emits and their payloads; the [Method Reference](#method-reference) below lists what every chart's methods select.
 
 ## Selecting a Mark
 
@@ -282,7 +287,7 @@ const chart = createLineChart('#container', {
 chart.highlightSeries('revenue');
 ```
 
-The id is whatever the chart puts in its legend: a series `id` on the multi-series charts, and the segment key on the charts whose legend lists segments (pie, polar area, funnel, treemap and friends), where it isolates that segment.
+The id is whatever the chart puts in its legend: a series `id` on the multi-series charts, and the segment key on the charts whose legend lists segments — pie, polar area, radial bar, funnel, treemap, packed circle, sunburst — where it isolates that segment.
 
 **The legend follows.** The matching legend entry stays lit while every other entry — swatch and label alike — dims with the plot, so a highlight driven from your own UI reads in the legend too. An entry toggled off stays visibly inactive underneath the dim.
 
@@ -377,6 +382,7 @@ The selector and option types are exported from `@ripl/charts` for typing your o
 <!-- eslint-skip -->
 ```ts
 import type {
+    BarChart,
     CellRef,
     HighlightOptions,
     LinkRef,

--- a/apps/website/src/charts/arc-diagram.md
+++ b/apps/website/src/charts/arc-diagram.md
@@ -252,3 +252,31 @@ chart.on('linkenter', event => console.log(event.data)); // event.data: ArcDiagr
 chart.on('linkleave', event => console.log(event.data)); // event.data: ArcDiagramLinkEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
+of the diagram dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form.
+Arcs carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it joins — in
+the order the events above report them — or the `"source->target"` string that flattens to. Either
+method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens the
+mark's tooltip where hovering would; an arc diagram draws no crosshair, so `crosshair` is ignored
+here.
+
+```ts
+const chart = createArcDiagramChart('#container', { nodes, links });
+
+// Light one node, then the arc joining it to another.
+chart.highlightNode('a', { tooltip: true });
+chart.highlightLink({ source: 'a', target: 'b' }, { tooltip: true });
+
+// The first arc in the dataset.
+chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last, including across the two
+methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
+pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()` restores
+it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/arc-diagram.md
+++ b/apps/website/src/charts/arc-diagram.md
@@ -255,13 +255,13 @@ chart.on('linkleave', event => console.log(event.data)); // event.data: ArcDiagr
 
 ## Programmatic Interaction
 
-`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
-of the diagram dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form.
-Arcs carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it joins — in
-the order the events above report them — or the `"source->target"` string that flattens to. Either
-method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens the
-mark's tooltip where hovering would; an arc diagram draws no crosshair, so `crosshair` is ignored
-here.
+`highlightNode` and `highlightLink` put a mark into the same hover state the pointer would — it
+brightens out of its rest tint — without waiting for one. A node takes its id or the `{ key }` ref
+form. Arcs carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it
+joins — in the order the events above report them — or the `"source->target"` string that flattens
+to. Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }`
+opens the mark's tooltip where hovering would; an arc diagram draws no crosshair, so `crosshair` is
+ignored here.
 
 ```ts
 const chart = createArcDiagramChart('#container', { nodes, links });
@@ -278,5 +278,5 @@ chart.clearHighlight();
 
 One highlight is active at a time — a matching call replaces the last, including across the two
 methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
-pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()` restores
-it explicitly; both methods return `false` when the selector matched nothing live.
+pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()`
+restores it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/area.md
+++ b/apps/website/src/charts/area.md
@@ -592,13 +592,13 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: AreaCh
 
 ## Programmatic Interaction
 
-`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
-series dims — without waiting for a pointer. A bare key is the category the point sits on, so it
-lights that point in every series at once; `{ key, series }` narrows it to one, and an accessor
-receives the chart's data when it is easier to address a point by position. `{ tooltip: true }` opens
-the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and
-`{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers: false` have
-nothing to highlight.
+`highlightMarker` puts a point into the same hover state the pointer would — the marker grows and
+takes its highlight color — without waiting for one. A bare key is the category the point sits on,
+so it lights that point in every series at once; `{ key, series }` narrows it to one, and an
+accessor receives the chart's data when it is easier to address a point by position. `{ tooltip:
+true }` opens the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is
+`'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers:
+false` have nothing to highlight.
 
 ```ts
 const chart = createAreaChart('#container', { data, key: 'month', series });

--- a/apps/website/src/charts/area.md
+++ b/apps/website/src/charts/area.md
@@ -595,10 +595,10 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: AreaCh
 `highlightMarker` puts a point into the same hover state the pointer would — the marker grows and
 takes its highlight color — without waiting for one. A bare key is the category the point sits on,
 so it lights that point in every series at once; `{ key, series }` narrows it to one, and an
-accessor receives the chart's data when it is easier to address a point by position. `{ tooltip:
-true }` opens the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is
-`'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers:
-false` have nothing to highlight.
+accessor receives the chart's data when it is easier to address a point by position.
+`{ tooltip: true }` opens the tooltip where hovering would (the shared axis tooltip when
+`tooltip.trigger` is `'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series
+drawn with `markers: false` have nothing to highlight.
 
 ```ts
 const chart = createAreaChart('#container', { data, key: 'month', series });

--- a/apps/website/src/charts/area.md
+++ b/apps/website/src/charts/area.md
@@ -589,3 +589,32 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: AreaCh
 chart.on('markerleave', event => console.log(event.data)); // event.data: AreaChartMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
+series dims — without waiting for a pointer. A bare key is the category the point sits on, so it
+lights that point in every series at once; `{ key, series }` narrows it to one, and an accessor
+receives the chart's data when it is easier to address a point by position. `{ tooltip: true }` opens
+the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and
+`{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers: false` have
+nothing to highlight.
+
+```ts
+const chart = createAreaChart('#container', { data, key: 'month', series });
+
+// Light February in every series, with its tooltip and the crosshair.
+chart.highlightMarker('Feb', { tooltip: true, crosshair: true });
+
+// Only the desktop series' point, then the same point addressed by position.
+chart.highlightMarker({ key: 'Feb', series: 'desktop' });
+chart.highlightMarker(data => data[1].month);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `marker*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('desktop')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/bar.md
+++ b/apps/website/src/charts/bar.md
@@ -503,8 +503,8 @@ chart.on('barleave', event => console.log(event.data)); // event.data: BarChartB
 
 ## Programmatic Interaction
 
-`highlightBar` applies the treatment hovering a bar does — that bar lifts and the rest of the chart
-dims — without waiting for a pointer. A bare key is the category the bar sits on, so it lights that
+`highlightBar` puts a bar into the same hover state the pointer would — its fill goes to full
+strength — without waiting for one. A bare key is the category the bar sits on, so it lights that
 category in every series at once; `{ key, series }` narrows it to one series' bar, and an accessor
 receives the chart's data when it is easier to address a bar by position. `{ tooltip: true }` opens
 the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`). A bar

--- a/apps/website/src/charts/bar.md
+++ b/apps/website/src/charts/bar.md
@@ -500,3 +500,31 @@ chart.on('barenter', event => console.log(event.data)); // event.data: BarChartB
 chart.on('barleave', event => console.log(event.data)); // event.data: BarChartBarEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightBar` applies the treatment hovering a bar does — that bar lifts and the rest of the chart
+dims — without waiting for a pointer. A bare key is the category the bar sits on, so it lights that
+category in every series at once; `{ key, series }` narrows it to one series' bar, and an accessor
+receives the chart's data when it is easier to address a bar by position. `{ tooltip: true }` opens
+the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`). A bar
+chart draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createBarChart('#container', { data, key: 'month', series });
+
+// Light every series' bar for February, and open its tooltip.
+chart.highlightBar('Feb', { tooltip: true });
+
+// Only the sales bar, then the same bar addressed by position.
+chart.highlightBar({ key: 'Feb', series: 'sales' });
+chart.highlightBar(data => data[1].month);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `bar*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('sales')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/box-plot.md
+++ b/apps/website/src/charts/box-plot.md
@@ -171,11 +171,11 @@ chart.on('boxleave', event => console.log(event.data)); // event.data: BoxPlotBo
 
 ## Programmatic Interaction
 
-`highlightBox` applies the treatment hovering a box does — it lifts and the rest of the chart dims —
-without waiting for a pointer. A box summarizes a whole category, so the selector is that category:
-its key, the `{ key }` ref form, or an accessor over the chart's data returning either.
-`{ tooltip: true }` opens the box's five-number tooltip where hovering would, and
-`{ crosshair: true }` places the crosshair on it.
+`highlightBox` puts a box into the same hover state the pointer would — its fill softens — without
+waiting for one. A box summarizes a whole category, so the selector is that category: its key, the
+`{ key }` ref form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens
+the box's median/quartile tooltip where hovering would, and `{ crosshair: true }` places the
+crosshair on it.
 
 ```ts
 const chart = createBoxPlotChart('#container', { data, key: 'region', value: 'latency' });
@@ -190,6 +190,6 @@ chart.clearHighlight();
 ```
 
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
-render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
-`box*` events above. `clearHighlight()` restores it explicitly; `highlightBox` returns `false` when
-the selector matched no live box.
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of
+the `box*` events above. `clearHighlight()` restores it explicitly; `highlightBox` returns `false`
+when the selector matched no live box.

--- a/apps/website/src/charts/box-plot.md
+++ b/apps/website/src/charts/box-plot.md
@@ -168,3 +168,28 @@ chart.on('boxenter', event => console.log(event.data)); // event.data: BoxPlotBo
 chart.on('boxleave', event => console.log(event.data)); // event.data: BoxPlotBoxEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightBox` applies the treatment hovering a box does — it lifts and the rest of the chart dims —
+without waiting for a pointer. A box summarizes a whole category, so the selector is that category:
+its key, the `{ key }` ref form, or an accessor over the chart's data returning either.
+`{ tooltip: true }` opens the box's five-number tooltip where hovering would, and
+`{ crosshair: true }` places the crosshair on it.
+
+```ts
+const chart = createBoxPlotChart('#container', { data, key: 'region', value: 'latency' });
+
+// Light the EU box, with its tooltip and the crosshair.
+chart.highlightBox('EU', { tooltip: true, crosshair: true });
+
+// The category of the first row, whatever it happens to be.
+chart.highlightBox(data => data[0].region);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
+`box*` events above. `clearHighlight()` restores it explicitly; `highlightBox` returns `false` when
+the selector matched no live box.

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -206,12 +206,12 @@ chart.on('linkleave',    event => console.log(event.data)); // event.data: Chord
 
 ## Programmatic Interaction
 
-`highlightSegment` and `highlightLink` apply the treatment hovering a mark does — it lifts and the
-rest of the chart dims — without waiting for a pointer. A group's outer arc takes its label or the
-`{ key }` ref form. A ribbon is drawn once per pair, so it takes its id or a `{ source, target }` ref
-naming the groups it joins, in the order the events above report them. Either method also accepts an
-accessor over the chart's `groups`. `{ tooltip: true }` opens the mark's tooltip where hovering would;
-a chord chart draws no crosshair, so `crosshair` is ignored here.
+`highlightSegment` and `highlightLink` put a mark into the same hover state the pointer would —
+which reads as everything else dimming — without waiting for one. A group's outer arc takes its
+label or the `{ key }` ref form. A ribbon is drawn once per pair, so it takes its id or a `{ source,
+target }` ref naming the groups it joins, in the order the events above report them. Either method
+also accepts an accessor over the chart's `groups`. `{ tooltip: true }` opens the mark's tooltip
+where hovering would; a chord chart draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createChordChart('#container', { groups, matrix });

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -208,10 +208,11 @@ chart.on('linkleave',    event => console.log(event.data)); // event.data: Chord
 
 `highlightSegment` and `highlightLink` put a mark into the same hover state the pointer would —
 which reads as everything else dimming — without waiting for one. A group's outer arc takes its
-label or the `{ key }` ref form. A ribbon is drawn once per pair, so it takes its id or a `{ source,
-target }` ref naming the groups it joins, in the order the events above report them. Either method
-also accepts an accessor over the chart's `groups`. `{ tooltip: true }` opens the mark's tooltip
-where hovering would; a chord chart draws no crosshair, so `crosshair` is ignored here.
+label or the `{ key }` ref form. A ribbon is drawn once per pair, so it takes its id or a
+`{ source, target }` ref naming the groups it joins, in the order the events above report them.
+Either method also accepts an accessor over the chart's `groups`. `{ tooltip: true }` opens the
+mark's tooltip where hovering would; a chord chart draws no crosshair, so `crosshair` is ignored
+here.
 
 ```ts
 const chart = createChordChart('#container', { groups, matrix });

--- a/apps/website/src/charts/chord.md
+++ b/apps/website/src/charts/chord.md
@@ -203,3 +203,30 @@ chart.on('linkenter',    event => console.log(event.data)); // event.data: Chord
 chart.on('linkleave',    event => console.log(event.data)); // event.data: ChordChartLinkEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightSegment` and `highlightLink` apply the treatment hovering a mark does — it lifts and the
+rest of the chart dims — without waiting for a pointer. A group's outer arc takes its label or the
+`{ key }` ref form. A ribbon is drawn once per pair, so it takes its id or a `{ source, target }` ref
+naming the groups it joins, in the order the events above report them. Either method also accepts an
+accessor over the chart's `groups`. `{ tooltip: true }` opens the mark's tooltip where hovering would;
+a chord chart draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createChordChart('#container', { groups, matrix });
+
+// Light one group's arc, then the ribbon joining it to another.
+chart.highlightSegment('Engineering', { tooltip: true });
+chart.highlightLink({ source: 'Engineering', target: 'Design' }, { tooltip: true });
+
+// The first group in the list.
+chart.highlightSegment(groups => groups[0]);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last, including across the two
+methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
+pointer hover restores the chart, and it emits none of the events above. `clearHighlight()` restores
+it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/force-directed.md
+++ b/apps/website/src/charts/force-directed.md
@@ -262,13 +262,13 @@ chart.on('linkleave', event => console.log(event.data)); // event.data: ForceDir
 
 ## Programmatic Interaction
 
-`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
-of the network dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form.
-Links carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it joins — in
-the order the events above report them — or the `"source->target"` string that flattens to. Either
-method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens the
-mark's tooltip where hovering would; a force-directed chart draws no crosshair, so `crosshair` is
-ignored here.
+`highlightNode` and `highlightLink` put a mark into the same hover state the pointer would — it
+brightens out of its rest tint — without waiting for one. A node takes its id or the `{ key }` ref
+form. Links carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it
+joins — in the order the events above report them — or the `"source->target"` string that flattens
+to. Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }`
+opens the mark's tooltip where hovering would; a force-directed chart draws no crosshair, so
+`crosshair` is ignored here.
 
 ```ts
 const chart = createForceDirectedChart('#container', { nodes, links });
@@ -285,6 +285,5 @@ chart.clearHighlight();
 
 One highlight is active at a time — a matching call replaces the last, including across the two
 methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
-pointer hover restores the network, and it emits none of the events above. The simulation itself keeps
-running underneath, so a highlighted node stays lit as it settles. `clearHighlight()` restores it
-explicitly; both methods return `false` when the selector matched nothing live.
+pointer hover restores the network, and it emits none of the events above. `clearHighlight()`
+restores it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/force-directed.md
+++ b/apps/website/src/charts/force-directed.md
@@ -259,3 +259,32 @@ chart.on('linkenter', event => console.log(event.data)); // event.data: ForceDir
 chart.on('linkleave', event => console.log(event.data)); // event.data: ForceDirectedLinkEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
+of the network dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form.
+Links carry no id of their own, so one takes a `{ source, target }` ref naming the nodes it joins — in
+the order the events above report them — or the `"source->target"` string that flattens to. Either
+method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens the
+mark's tooltip where hovering would; a force-directed chart draws no crosshair, so `crosshair` is
+ignored here.
+
+```ts
+const chart = createForceDirectedChart('#container', { nodes, links });
+
+// Light one node, then the link joining it to another.
+chart.highlightNode('a', { tooltip: true });
+chart.highlightLink({ source: 'a', target: 'b' }, { tooltip: true });
+
+// The first node in the dataset.
+chart.highlightNode(nodes => nodes[0].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last, including across the two
+methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
+pointer hover restores the network, and it emits none of the events above. The simulation itself keeps
+running underneath, so a highlighted node stays lit as it settles. `clearHighlight()` restores it
+explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/funnel.md
+++ b/apps/website/src/charts/funnel.md
@@ -191,9 +191,9 @@ chart.on('segmentleave', event => console.log(event.data)); // event.data: Funne
 
 ## Programmatic Interaction
 
-`highlightSegment` applies the treatment hovering a stage does — it lifts out of its rest tint and the
-rest of the funnel dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
-form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
+`highlightSegment` puts a stage into the same hover state the pointer would — it lifts out of its
+rest tint to full color — without waiting for one. Pass the segment's key, the `{ key }` ref form,
+or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
 tooltip where hovering would; a funnel draws no crosshair, so `crosshair` is ignored here.
 
 ```ts

--- a/apps/website/src/charts/funnel.md
+++ b/apps/website/src/charts/funnel.md
@@ -188,3 +188,27 @@ chart.on('segmententer', event => console.log(event.data)); // event.data: Funne
 chart.on('segmentleave', event => console.log(event.data)); // event.data: FunnelChartSegmentEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightSegment` applies the treatment hovering a stage does — it lifts out of its rest tint and the
+rest of the funnel dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
+form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
+tooltip where hovering would; a funnel draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createFunnelChart('#container', { data, key: 'stage', value: 'count', label: 'label' });
+
+// Light the sign-up stage and open its tooltip.
+chart.highlightSegment('signed-up', { tooltip: true });
+
+// The stage the funnel ends on.
+chart.highlightSegment(data => data[data.length - 1].stage);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `segment*` events above. `clearHighlight()` restores it explicitly;
+`highlightSegment` returns `false` when the selector matched no live segment.

--- a/apps/website/src/charts/gantt.md
+++ b/apps/website/src/charts/gantt.md
@@ -291,11 +291,11 @@ chart.on('taskleave', event => console.log(event.data)); // event.data: GanttCha
 
 ## Programmatic Interaction
 
-`highlightTask` applies the treatment hovering a task bar does — it lifts and the rest of the chart
-dims — without waiting for a pointer. Pass the task's key, exactly as the chart reports it in the
-events above, the `{ key }` ref form, or an accessor over the chart's data returning either.
-`{ tooltip: true }` opens the task's tooltip where hovering would; a gantt chart draws no crosshair,
-so `crosshair` is ignored here.
+`highlightTask` puts a task bar into the same hover state the pointer would — it lifts out of its
+rest tint to full color — without waiting for one. Pass the task's key, exactly as the chart reports
+it in the events above, the `{ key }` ref form, or an accessor over the chart's data returning
+either. `{ tooltip: true }` opens the task's tooltip where hovering would; a gantt chart draws no
+crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createGanttChart('#container', {
@@ -316,6 +316,6 @@ chart.clearHighlight();
 ```
 
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
-render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
-`task*` events above. `clearHighlight()` restores it explicitly; `highlightTask` returns `false` when
-the selector matched no live task bar.
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of
+the `task*` events above. `clearHighlight()` restores it explicitly; `highlightTask` returns `false`
+when the selector matched no live task bar.

--- a/apps/website/src/charts/gantt.md
+++ b/apps/website/src/charts/gantt.md
@@ -288,3 +288,34 @@ chart.on('taskenter', event => console.log(event.data)); // event.data: GanttCha
 chart.on('taskleave', event => console.log(event.data)); // event.data: GanttChartTaskEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightTask` applies the treatment hovering a task bar does — it lifts and the rest of the chart
+dims — without waiting for a pointer. Pass the task's key, exactly as the chart reports it in the
+events above, the `{ key }` ref form, or an accessor over the chart's data returning either.
+`{ tooltip: true }` opens the task's tooltip where hovering would; a gantt chart draws no crosshair,
+so `crosshair` is ignored here.
+
+```ts
+const chart = createGanttChart('#container', {
+    data,
+    key: 'id',
+    label: 'name',
+    start: 'start',
+    end: 'end',
+});
+
+// Light the build task and open its tooltip.
+chart.highlightTask('build', { tooltip: true });
+
+// The first task in the dataset.
+chart.highlightTask(data => data[0].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
+`task*` events above. `clearHighlight()` restores it explicitly; `highlightTask` returns `false` when
+the selector matched no live task bar.

--- a/apps/website/src/charts/gauge.md
+++ b/apps/website/src/charts/gauge.md
@@ -201,10 +201,10 @@ chart.on('valueleave', event => console.log(event.data)); // event.data: GaugeCh
 
 ## Programmatic Interaction
 
-A gauge draws a single value arc, so there is nothing to select: `highlightValue` applies the
-treatment hovering that arc does — it lifts out of its track — and takes only the options.
-`{ tooltip: true }` opens the arc's tooltip where hovering would; a gauge draws no crosshair, so
-`crosshair` is ignored here.
+A gauge draws a single value arc, so there is nothing to select: `highlightValue` puts that arc into
+the same hover state the pointer would — full color rather than its rest tint — and takes only the
+options. `{ tooltip: true }` opens the arc's tooltip where hovering would; a gauge draws no
+crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createGaugeChart('#container', { value: 72, min: 0, max: 100 });
@@ -215,6 +215,6 @@ chart.highlightValue({ tooltip: true });
 chart.clearHighlight();
 ```
 
-The highlight is one-shot: the next render (a resize, an `update`) or the next pointer hover restores
-the gauge, and it emits none of the `value*` events above. `clearHighlight()` restores it explicitly;
-`highlightValue` returns `false` when there is no live arc to light.
+The highlight is one-shot: the next render (a resize, an `update`) or the next pointer hover
+restores the gauge, and it emits none of the `value*` events above. `clearHighlight()` restores it
+explicitly; `highlightValue` returns `false` when there is no live arc to light.

--- a/apps/website/src/charts/gauge.md
+++ b/apps/website/src/charts/gauge.md
@@ -198,3 +198,23 @@ chart.on('valueenter', event => console.log(event.data)); // event.data: GaugeCh
 chart.on('valueleave', event => console.log(event.data)); // event.data: GaugeChartValueEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+A gauge draws a single value arc, so there is nothing to select: `highlightValue` applies the
+treatment hovering that arc does — it lifts out of its track — and takes only the options.
+`{ tooltip: true }` opens the arc's tooltip where hovering would; a gauge draws no crosshair, so
+`crosshair` is ignored here.
+
+```ts
+const chart = createGaugeChart('#container', { value: 72, min: 0, max: 100 });
+
+// Light the value arc and open its tooltip.
+chart.highlightValue({ tooltip: true });
+
+chart.clearHighlight();
+```
+
+The highlight is one-shot: the next render (a resize, an `update`) or the next pointer hover restores
+the gauge, and it emits none of the `value*` events above. `clearHighlight()` restores it explicitly;
+`highlightValue` returns `false` when there is no live arc to light.

--- a/apps/website/src/charts/getting-started.md
+++ b/apps/website/src/charts/getting-started.md
@@ -211,5 +211,6 @@ import {
 - **[Theming](/charts/advanced/theming)**: light/dark/colorblind themes and custom palettes
 - **[Annotations](/charts/advanced/annotations)**: reference lines, bands, and point markers
 - **[Panning & Zooming](/charts/advanced/panning-and-zooming)**: interactive navigation and the overview strip
+- **[Programmatic Interaction](/charts/advanced/programmatic-interaction)**: highlight a mark, a series or a row of cells from code, tooltip and all
 - **[Custom Charts](/charts/advanced/custom-charts)**: build your own chart type on the `Chart` base class
 - **[Charts API Reference](/docs/api/@ripl/charts/)**: full TypeScript API documentation

--- a/apps/website/src/charts/heatmap.md
+++ b/apps/website/src/charts/heatmap.md
@@ -275,7 +275,14 @@ it lights that whole row or column. An accessor over the chart's data can return
 line apart — and a heatmap draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
-const chart = createHeatmapChart('#container', { data, keyX: 'hour', keyY: 'day', value: 'value' });
+const chart = createHeatmapChart('#container', {
+    data,
+    keyX: 'hour',
+    keyY: 'day',
+    value: 'value',
+    xCategories,
+    yCategories,
+});
 
 // One cell, with its tooltip.
 chart.highlightCell({ x: '9am', y: 'Mon' }, { tooltip: true });

--- a/apps/website/src/charts/heatmap.md
+++ b/apps/website/src/charts/heatmap.md
@@ -270,7 +270,7 @@ chart.on('cellleave', event => console.log(event.data)); // event.data: HeatmapC
 `highlightCell` puts a cell into the same hover state the pointer would — it softens against the
 rest of the grid — without waiting for one. A `{ x, y }` ref names the single cell at that pair of
 axis labels, the pair reported as `xLabel`/`yLabel` on the events above; a bare label matches either
-axis instead, so it lights that whole row or column. An accessor over the chart's data can return
+axis instead, so it takes that whole row or column. An accessor over the chart's data can return
 either form. `{ tooltip: true }` opens a tooltip on the match — several cells share one, their
 contents joined a line apart — and a heatmap draws no crosshair, so `crosshair` is ignored here.
 

--- a/apps/website/src/charts/heatmap.md
+++ b/apps/website/src/charts/heatmap.md
@@ -264,3 +264,30 @@ chart.on('cellenter', event => console.log(event.data)); // event.data: HeatmapC
 chart.on('cellleave', event => console.log(event.data)); // event.data: HeatmapChartCellEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightCell` applies the treatment hovering a cell does — it lifts and the rest of the grid dims —
+without waiting for a pointer. A `{ x, y }` ref names the single cell at that pair of axis labels, the
+pair reported as `xLabel`/`yLabel` on the events above; a bare label matches either axis instead, so
+it lights that whole row or column. An accessor over the chart's data can return either form.
+`{ tooltip: true }` opens a tooltip on the match — several cells share one, their contents joined a
+line apart — and a heatmap draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createHeatmapChart('#container', { data, keyX: 'hour', keyY: 'day', value: 'value' });
+
+// One cell, with its tooltip.
+chart.highlightCell({ x: '9am', y: 'Mon' }, { tooltip: true });
+
+// Every cell on the Monday row, then the cell the first row describes.
+chart.highlightCell('Mon');
+chart.highlightCell(data => ({ x: data[0].hour, y: data[0].day }));
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`) or the next pointer hover restores the grid, and it emits none of the
+`cell*` events above. `clearHighlight()` restores it explicitly; `highlightCell` returns `false` when
+no live cell matched.

--- a/apps/website/src/charts/heatmap.md
+++ b/apps/website/src/charts/heatmap.md
@@ -267,12 +267,12 @@ chart.on('cellleave', event => console.log(event.data)); // event.data: HeatmapC
 
 ## Programmatic Interaction
 
-`highlightCell` applies the treatment hovering a cell does — it lifts and the rest of the grid dims —
-without waiting for a pointer. A `{ x, y }` ref names the single cell at that pair of axis labels, the
-pair reported as `xLabel`/`yLabel` on the events above; a bare label matches either axis instead, so
-it lights that whole row or column. An accessor over the chart's data can return either form.
-`{ tooltip: true }` opens a tooltip on the match — several cells share one, their contents joined a
-line apart — and a heatmap draws no crosshair, so `crosshair` is ignored here.
+`highlightCell` puts a cell into the same hover state the pointer would — it softens against the
+rest of the grid — without waiting for one. A `{ x, y }` ref names the single cell at that pair of
+axis labels, the pair reported as `xLabel`/`yLabel` on the events above; a bare label matches either
+axis instead, so it lights that whole row or column. An accessor over the chart's data can return
+either form. `{ tooltip: true }` opens a tooltip on the match — several cells share one, their
+contents joined a line apart — and a heatmap draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createHeatmapChart('#container', {
@@ -296,5 +296,5 @@ chart.clearHighlight();
 
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
 render (a resize, an `update`) or the next pointer hover restores the grid, and it emits none of the
-`cell*` events above. `clearHighlight()` restores it explicitly; `highlightCell` returns `false` when
-no live cell matched.
+`cell*` events above. `clearHighlight()` restores it explicitly; `highlightCell` returns `false`
+when no live cell matched.

--- a/apps/website/src/charts/histogram.md
+++ b/apps/website/src/charts/histogram.md
@@ -191,9 +191,9 @@ chart.on('binleave', event => console.log(event.data)); // event.data: Histogram
 `highlightBin` puts a bin bar into the same hover state the pointer would — its fill goes to full
 strength — without waiting for one. Bins are derived from the data rather than carrying keys of
 their own, so a bin is addressed by index: `0` is the leftmost bar and the index counts up across
-the value axis. An accessor over the chart's data can compute that index instead. `{ tooltip: true
-}` opens the bin's tooltip where hovering would, and `{ crosshair: true }` places the crosshair on
-it.
+the value axis. An accessor over the chart's data can compute that index instead.
+`{ tooltip: true }` opens the bin's tooltip where hovering would, and `{ crosshair: true }` places
+the crosshair on it.
 
 ```ts
 const chart = createHistogramChart('#container', { data, value: 'amount', bins: 12 });

--- a/apps/website/src/charts/histogram.md
+++ b/apps/website/src/charts/histogram.md
@@ -185,3 +185,28 @@ chart.on('binenter', event => console.log(event.data)); // event.data: Histogram
 chart.on('binleave', event => console.log(event.data)); // event.data: HistogramBinEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightBin` applies the treatment hovering a bin bar does — it lifts and the rest of the chart dims
+— without waiting for a pointer. Bins are derived from the data rather than carrying keys of their
+own, so a bin is addressed by index: `0` is the leftmost bar and the index counts up across the value
+axis. An accessor over the chart's data can compute that index instead. `{ tooltip: true }` opens the
+bin's tooltip where hovering would, and `{ crosshair: true }` places the crosshair on it.
+
+```ts
+const chart = createHistogramChart('#container', { data, value: 'amount', bins: 12 });
+
+// Light the leftmost bin, with its tooltip and the crosshair.
+chart.highlightBin(0, { tooltip: true, crosshair: true });
+
+// The last of the twelve bins.
+chart.highlightBin(11);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
+`bin*` events above. `clearHighlight()` restores it explicitly; `highlightBin` returns `false` when
+the index falls outside the histogram, which it can after `bins` or the data changes.

--- a/apps/website/src/charts/histogram.md
+++ b/apps/website/src/charts/histogram.md
@@ -188,11 +188,12 @@ chart.on('binleave', event => console.log(event.data)); // event.data: Histogram
 
 ## Programmatic Interaction
 
-`highlightBin` applies the treatment hovering a bin bar does — it lifts and the rest of the chart dims
-— without waiting for a pointer. Bins are derived from the data rather than carrying keys of their
-own, so a bin is addressed by index: `0` is the leftmost bar and the index counts up across the value
-axis. An accessor over the chart's data can compute that index instead. `{ tooltip: true }` opens the
-bin's tooltip where hovering would, and `{ crosshair: true }` places the crosshair on it.
+`highlightBin` puts a bin bar into the same hover state the pointer would — its fill goes to full
+strength — without waiting for one. Bins are derived from the data rather than carrying keys of
+their own, so a bin is addressed by index: `0` is the leftmost bar and the index counts up across
+the value axis. An accessor over the chart's data can compute that index instead. `{ tooltip: true
+}` opens the bin's tooltip where hovering would, and `{ crosshair: true }` places the crosshair on
+it.
 
 ```ts
 const chart = createHistogramChart('#container', { data, value: 'amount', bins: 12 });
@@ -207,6 +208,6 @@ chart.clearHighlight();
 ```
 
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
-render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of the
-`bin*` events above. `clearHighlight()` restores it explicitly; `highlightBin` returns `false` when
-the index falls outside the histogram, which it can after `bins` or the data changes.
+render (a resize, an `update`) or the next pointer hover restores the chart, and it emits none of
+the `bin*` events above. `clearHighlight()` restores it explicitly; `highlightBin` returns `false`
+when the index falls outside the histogram, which it can after `bins` or the data changes.

--- a/apps/website/src/charts/line.md
+++ b/apps/website/src/charts/line.md
@@ -728,13 +728,13 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: LineCh
 
 ## Programmatic Interaction
 
-`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
-series dims — without waiting for a pointer. A bare key is the category the point sits on, so it
-lights that point in every series at once; `{ key, series }` narrows it to one, and an accessor
-receives the chart's data when it is easier to address a point by position. `{ tooltip: true }` opens
-the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and
-`{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers: false` have
-nothing to highlight.
+`highlightMarker` puts a point into the same hover state the pointer would — the marker grows and
+takes its highlight color — without waiting for one. A bare key is the category the point sits on,
+so it lights that point in every series at once; `{ key, series }` narrows it to one, and an
+accessor receives the chart's data when it is easier to address a point by position. `{ tooltip:
+true }` opens the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is
+`'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers:
+false` have nothing to highlight.
 
 ```ts
 const chart = createLineChart('#container', { data, key: 'month', series });

--- a/apps/website/src/charts/line.md
+++ b/apps/website/src/charts/line.md
@@ -731,10 +731,10 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: LineCh
 `highlightMarker` puts a point into the same hover state the pointer would — the marker grows and
 takes its highlight color — without waiting for one. A bare key is the category the point sits on,
 so it lights that point in every series at once; `{ key, series }` narrows it to one, and an
-accessor receives the chart's data when it is easier to address a point by position. `{ tooltip:
-true }` opens the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is
-`'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers:
-false` have nothing to highlight.
+accessor receives the chart's data when it is easier to address a point by position.
+`{ tooltip: true }` opens the tooltip where hovering would (the shared axis tooltip when
+`tooltip.trigger` is `'axis'`), and `{ crosshair: true }` places the crosshair on the marker. Series
+drawn with `markers: false` have nothing to highlight.
 
 ```ts
 const chart = createLineChart('#container', { data, key: 'month', series });

--- a/apps/website/src/charts/line.md
+++ b/apps/website/src/charts/line.md
@@ -725,3 +725,32 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: LineCh
 chart.on('markerleave', event => console.log(event.data)); // event.data: LineChartMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
+series dims — without waiting for a pointer. A bare key is the category the point sits on, so it
+lights that point in every series at once; `{ key, series }` narrows it to one, and an accessor
+receives the chart's data when it is easier to address a point by position. `{ tooltip: true }` opens
+the tooltip where hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and
+`{ crosshair: true }` places the crosshair on the marker. Series drawn with `markers: false` have
+nothing to highlight.
+
+```ts
+const chart = createLineChart('#container', { data, key: 'month', series });
+
+// Light February in every series, with its tooltip and the crosshair.
+chart.highlightMarker('Feb', { tooltip: true, crosshair: true });
+
+// Only the revenue series' point, then the same point addressed by position.
+chart.highlightMarker({ key: 'Feb', series: 'revenue' });
+chart.highlightMarker(data => data[1].month);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `marker*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('revenue')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/packed-circle.md
+++ b/apps/website/src/charts/packed-circle.md
@@ -209,3 +209,27 @@ chart.on('nodeenter', event => console.log(event.data)); // event.data: PackedCi
 chart.on('nodeleave', event => console.log(event.data)); // event.data: PackedCircleChartNodeEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` applies the treatment hovering a circle does — it lifts out of its rest tint and the
+rest of the chart dims — without waiting for a pointer. Pass the circle's key, the `{ key }` ref form,
+or an accessor over the chart's data returning either. `{ tooltip: true }` opens the circle's tooltip
+where hovering would; a packed circle chart draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createPackedCircleChart('#container', { data, key: 'name', value: 'size', label: 'name' });
+
+// Light the Alpha circle and open its tooltip.
+chart.highlightNode('Alpha', { tooltip: true });
+
+// The first circle in the dataset.
+chart.highlightNode(data => data[0].name);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `node*` events above. `clearHighlight()` restores it explicitly; `highlightNode`
+returns `false` when the selector matched no live circle.

--- a/apps/website/src/charts/packed-circle.md
+++ b/apps/website/src/charts/packed-circle.md
@@ -212,9 +212,9 @@ chart.on('nodeleave', event => console.log(event.data)); // event.data: PackedCi
 
 ## Programmatic Interaction
 
-`highlightNode` applies the treatment hovering a circle does — it lifts out of its rest tint and the
-rest of the chart dims — without waiting for a pointer. Pass the circle's key, the `{ key }` ref form,
-or an accessor over the chart's data returning either. `{ tooltip: true }` opens the circle's tooltip
+`highlightNode` puts a circle into the same hover state the pointer would — it lifts out of its rest
+tint to full color — without waiting for one. Pass the circle's key, the `{ key }` ref form, or an
+accessor over the chart's data returning either. `{ tooltip: true }` opens the circle's tooltip
 where hovering would; a packed circle chart draws no crosshair, so `crosshair` is ignored here.
 
 ```ts

--- a/apps/website/src/charts/pie.md
+++ b/apps/website/src/charts/pie.md
@@ -286,3 +286,27 @@ chart.on('segmententer', event => console.log(event.data)); // event.data: PieCh
 chart.on('segmentleave', event => console.log(event.data)); // event.data: PieChartSegmentEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightSegment` applies the treatment hovering a slice does — it lifts out of its rest tint and
+every other slice dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
+form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
+tooltip where hovering would; a pie draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createPieChart('#container', { data, key: 'id', value: 'value', label: 'label' });
+
+// Light the South Africa slice and open its tooltip.
+chart.highlightSegment('za', { tooltip: true });
+
+// The largest slice, whichever it is.
+chart.highlightSegment(data => data[0].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `segment*` events above. `clearHighlight()` restores it explicitly;
+`highlightSegment` returns `false` when the selector matched no live segment.

--- a/apps/website/src/charts/pie.md
+++ b/apps/website/src/charts/pie.md
@@ -289,10 +289,11 @@ chart.on('segmentleave', event => console.log(event.data)); // event.data: PieCh
 
 ## Programmatic Interaction
 
-`highlightSegment` applies the treatment hovering a slice does — it lifts out of its rest tint and
-every other slice dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
-form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
-tooltip where hovering would; a pie draws no crosshair, so `crosshair` is ignored here.
+`highlightSegment` puts a slice into the same hover state the pointer would — every slice shares one
+rest tint, so it reads as the others dimming — without waiting for one. Pass the segment's key, the
+`{ key }` ref form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens
+the segment's tooltip where hovering would; a pie draws no crosshair, so `crosshair` is ignored
+here.
 
 ```ts
 const chart = createPieChart('#container', { data, key: 'id', value: 'value', label: 'label' });

--- a/apps/website/src/charts/polar-area.md
+++ b/apps/website/src/charts/polar-area.md
@@ -287,3 +287,27 @@ chart.on('segmententer', event => console.log(event.data)); // event.data: Polar
 chart.on('segmentleave', event => console.log(event.data)); // event.data: PolarAreaChartSegmentEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightSegment` applies the treatment hovering a segment does — it lifts out of its rest tint and
+every other segment dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
+form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
+tooltip where hovering would; a polar area chart draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createPolarAreaChart('#container', { data, key: 'id', value: 'value', label: 'label' });
+
+// Light the Defense segment and open its tooltip.
+chart.highlightSegment('defense', { tooltip: true });
+
+// The first segment in the dataset.
+chart.highlightSegment(data => data[0].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `segment*` events above. `clearHighlight()` restores it explicitly;
+`highlightSegment` returns `false` when the selector matched no live segment.

--- a/apps/website/src/charts/polar-area.md
+++ b/apps/website/src/charts/polar-area.md
@@ -290,10 +290,11 @@ chart.on('segmentleave', event => console.log(event.data)); // event.data: Polar
 
 ## Programmatic Interaction
 
-`highlightSegment` applies the treatment hovering a segment does — it lifts out of its rest tint and
-every other segment dims — without waiting for a pointer. Pass the segment's key, the `{ key }` ref
-form, or an accessor over the chart's data returning either. `{ tooltip: true }` opens the segment's
-tooltip where hovering would; a polar area chart draws no crosshair, so `crosshair` is ignored here.
+`highlightSegment` puts a segment into the same hover state the pointer would — every segment shares
+one rest tint, so it reads as the others dimming — without waiting for one. Pass the segment's key,
+the `{ key }` ref form, or an accessor over the chart's data returning either. `{ tooltip: true }`
+opens the segment's tooltip where hovering would; a polar area chart draws no crosshair, so
+`crosshair` is ignored here.
 
 ```ts
 const chart = createPolarAreaChart('#container', { data, key: 'id', value: 'value', label: 'label' });

--- a/apps/website/src/charts/polar-scatter.md
+++ b/apps/website/src/charts/polar-scatter.md
@@ -319,9 +319,9 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: PolarS
 highlight color — without waiting for one. The chart has no key accessor, since every series plots
 the whole dataset, so markers are addressed by the item's position in `data` as a string — the
 `index` the events above report. A bare index lights that item in every series; `{ key, series }`
-narrows it to one, and an accessor over the chart's data can find the index for you. `{ tooltip:
-true }` opens the marker's tooltip where hovering would; a polar scatter chart draws no crosshair,
-so `crosshair` is ignored here.
+narrows it to one, and an accessor over the chart's data can find the index for you.
+`{ tooltip: true }` opens the marker's tooltip where hovering would; a polar scatter chart draws no
+crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createPolarScatterChart('#container', { data, series, max: 100 });

--- a/apps/website/src/charts/polar-scatter.md
+++ b/apps/website/src/charts/polar-scatter.md
@@ -315,13 +315,13 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: PolarS
 
 ## Programmatic Interaction
 
-`highlightMarker` applies the treatment hovering a marker does — it grows and every other series dims
-— without waiting for a pointer. The chart has no key accessor, since every series plots the whole
-dataset, so markers are addressed by the item's position in `data` as a string — the `index` the
-events above report. A bare index lights that item in every series; `{ key, series }` narrows it to
-one, and an accessor over the chart's data can find the index for you. `{ tooltip: true }` opens the
-marker's tooltip where hovering would; a polar scatter chart draws no crosshair, so `crosshair` is
-ignored here.
+`highlightMarker` puts a marker into the same hover state the pointer would — it grows and takes its
+highlight color — without waiting for one. The chart has no key accessor, since every series plots
+the whole dataset, so markers are addressed by the item's position in `data` as a string — the
+`index` the events above report. A bare index lights that item in every series; `{ key, series }`
+narrows it to one, and an accessor over the chart's data can find the index for you. `{ tooltip:
+true }` opens the marker's tooltip where hovering would; a polar scatter chart draws no crosshair,
+so `crosshair` is ignored here.
 
 ```ts
 const chart = createPolarScatterChart('#container', { data, series, max: 100 });

--- a/apps/website/src/charts/polar-scatter.md
+++ b/apps/website/src/charts/polar-scatter.md
@@ -312,3 +312,32 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: PolarS
 chart.on('markerleave', event => console.log(event.data)); // event.data: PolarScatterMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightMarker` applies the treatment hovering a marker does — it grows and every other series dims
+— without waiting for a pointer. The chart has no key accessor, since every series plots the whole
+dataset, so markers are addressed by the item's position in `data` as a string — the `index` the
+events above report. A bare index lights that item in every series; `{ key, series }` narrows it to
+one, and an accessor over the chart's data can find the index for you. `{ tooltip: true }` opens the
+marker's tooltip where hovering would; a polar scatter chart draws no crosshair, so `crosshair` is
+ignored here.
+
+```ts
+const chart = createPolarScatterChart('#container', { data, series, max: 100 });
+
+// Light the third reading in every series, with its tooltip.
+chart.highlightMarker('2', { tooltip: true });
+
+// Only the wind series' marker, then the first gust above 90.
+chart.highlightMarker({ key: '2', series: 'wind' });
+chart.highlightMarker(data => String(data.findIndex(item => item.gust > 90)));
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `marker*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('wind')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/polar-scatter.md
+++ b/apps/website/src/charts/polar-scatter.md
@@ -329,9 +329,9 @@ const chart = createPolarScatterChart('#container', { data, series, max: 100 });
 // Light the third reading in every series, with its tooltip.
 chart.highlightMarker('2', { tooltip: true });
 
-// Only the wind series' marker, then the first gust above 90.
+// Only the wind series' marker, then the most recent reading.
 chart.highlightMarker({ key: '2', series: 'wind' });
-chart.highlightMarker(data => String(data.findIndex(item => item.gust > 90)));
+chart.highlightMarker(data => String(data.length - 1));
 
 chart.clearHighlight();
 ```

--- a/apps/website/src/charts/radar.md
+++ b/apps/website/src/charts/radar.md
@@ -292,12 +292,12 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: RadarC
 
 ## Programmatic Interaction
 
-`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
-series dims — without waiting for a pointer. Markers are keyed by their axis label, the same
-`axisLabel` the events above report, so a bare label lights that axis in every series;
-`{ key, series }` narrows it to one series' point, and an accessor can compute the label rather than
-name it. `{ tooltip: true }` opens the point's tooltip where hovering would; a radar draws no crosshair,
-so `crosshair` is ignored here.
+`highlightMarker` puts a point into the same hover state the pointer would — the marker grows —
+without waiting for one. Markers are keyed by their axis label, the same `axisLabel` the events
+above report, so a bare label lights that axis in every series; `{ key, series }` narrows it to one
+series' point, and an accessor can compute the label rather than name it. `{ tooltip: true }` opens
+the point's tooltip where hovering would; a radar draws no crosshair, so `crosshair` is ignored
+here.
 
 ```ts
 const chart = createRadarChart('#container', { data, categories, series });

--- a/apps/website/src/charts/radar.md
+++ b/apps/website/src/charts/radar.md
@@ -295,8 +295,8 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: RadarC
 `highlightMarker` applies the treatment hovering a point does — that marker grows and every other
 series dims — without waiting for a pointer. Markers are keyed by their axis label, the same
 `axisLabel` the events above report, so a bare label lights that axis in every series;
-`{ key, series }` narrows it to one series' point, and an accessor receives the chart's data.
-`{ tooltip: true }` opens the point's tooltip where hovering would; a radar chart draws no crosshair,
+`{ key, series }` narrows it to one series' point, and an accessor can compute the label rather than
+name it. `{ tooltip: true }` opens the point's tooltip where hovering would; a radar draws no crosshair,
 so `crosshair` is ignored here.
 
 ```ts
@@ -305,9 +305,9 @@ const chart = createRadarChart('#container', { data, categories, series });
 // Light the Speed axis on every series, with its tooltip.
 chart.highlightMarker('Speed', { tooltip: true });
 
-// Only player 1's point, then the axis the third row describes.
+// Only player 1's point, then the last axis, whatever it is called.
 chart.highlightMarker({ key: 'Speed', series: 'player1' });
-chart.highlightMarker(data => data[2].axis);
+chart.highlightMarker(() => categories[categories.length - 1]);
 
 chart.clearHighlight();
 ```

--- a/apps/website/src/charts/radar.md
+++ b/apps/website/src/charts/radar.md
@@ -289,3 +289,31 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: RadarC
 chart.on('markerleave', event => console.log(event.data)); // event.data: RadarChartMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightMarker` applies the treatment hovering a point does — that marker grows and every other
+series dims — without waiting for a pointer. Markers are keyed by their axis label, the same
+`axisLabel` the events above report, so a bare label lights that axis in every series;
+`{ key, series }` narrows it to one series' point, and an accessor receives the chart's data.
+`{ tooltip: true }` opens the point's tooltip where hovering would; a radar chart draws no crosshair,
+so `crosshair` is ignored here.
+
+```ts
+const chart = createRadarChart('#container', { data, categories, series });
+
+// Light the Speed axis on every series, with its tooltip.
+chart.highlightMarker('Speed', { tooltip: true });
+
+// Only player 1's point, then the axis the third row describes.
+chart.highlightMarker({ key: 'Speed', series: 'player1' });
+chart.highlightMarker(data => data[2].axis);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `marker*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('player1')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/radial-bar.md
+++ b/apps/website/src/charts/radial-bar.md
@@ -231,3 +231,27 @@ chart.on('barenter', event => console.log(event.data)); // event.data: RadialBar
 chart.on('barleave', event => console.log(event.data)); // event.data: RadialBarChartBarEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightBar` applies the treatment hovering a ring does — it lifts out of its rest tint and the rest
+of the chart dims — without waiting for a pointer. Pass the ring's key, the `{ key }` ref form, or an
+accessor over the chart's data returning either. `{ tooltip: true }` opens the ring's tooltip where
+hovering would; a radial bar chart draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createRadialBarChart('#container', { data, key: 'language', value: 'share', max: 100 });
+
+// Light the Python ring and open its tooltip.
+chart.highlightBar('Python', { tooltip: true });
+
+// The outermost ring, whichever language leads.
+chart.highlightBar(data => data[0].language);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `bar*` events above. `clearHighlight()` restores it explicitly; `highlightBar`
+returns `false` when the selector matched no live ring.

--- a/apps/website/src/charts/radial-bar.md
+++ b/apps/website/src/charts/radial-bar.md
@@ -234,8 +234,8 @@ chart.on('barleave', event => console.log(event.data)); // event.data: RadialBar
 
 ## Programmatic Interaction
 
-`highlightBar` applies the treatment hovering a ring does — it lifts out of its rest tint and the rest
-of the chart dims — without waiting for a pointer. Pass the ring's key, the `{ key }` ref form, or an
+`highlightBar` puts a ring into the same hover state the pointer would — it lifts out of its rest
+tint to full color — without waiting for one. Pass the ring's key, the `{ key }` ref form, or an
 accessor over the chart's data returning either. `{ tooltip: true }` opens the ring's tooltip where
 hovering would; a radial bar chart draws no crosshair, so `crosshair` is ignored here.
 

--- a/apps/website/src/charts/realtime.md
+++ b/apps/website/src/charts/realtime.md
@@ -388,3 +388,23 @@ pixels. `event.target` and `event.stopPropagation()` are also available.
 <!-- events:start -->
 This chart emits no events.
 <!-- events:end -->
+
+## Programmatic Interaction
+
+A realtime chart has no marks to address — its points enter and leave with the window — so the one
+programmatic control is `highlightSeries`, which dims every other series exactly as hovering its
+legend entry does. It takes a series id and no options: a series highlight has no anchor, so there is
+nothing for a tooltip or crosshair to attach to.
+
+```ts
+const chart = createRealtimeChart('#container', { series });
+
+// Dim everything but the CPU trace.
+chart.highlightSeries('cpu');
+
+chart.clearHighlight();
+```
+
+The highlight is one-shot and every `push` re-renders, so on a live feed it lasts only until the next
+sample arrives — stop pushing if it needs to hold. It emits no interaction events. `clearHighlight()`
+restores the chart explicitly, and `highlightSeries` returns `false` when the id matched no series.

--- a/apps/website/src/charts/realtime.md
+++ b/apps/website/src/charts/realtime.md
@@ -393,8 +393,8 @@ This chart emits no events.
 
 A realtime chart has no marks to address — its points enter and leave with the window — so the one
 programmatic control is `highlightSeries`, which dims every other series exactly as hovering its
-legend entry does. It takes a series id and no options: a series highlight has no anchor, so there is
-nothing for a tooltip or crosshair to attach to.
+legend entry does. It takes a series id and no options: a series highlight has no anchor, so there
+is nothing for a tooltip or crosshair to attach to.
 
 ```ts
 const chart = createRealtimeChart('#container', { series });
@@ -405,6 +405,7 @@ chart.highlightSeries('cpu');
 chart.clearHighlight();
 ```
 
-The highlight is one-shot and every `push` re-renders, so on a live feed it lasts only until the next
-sample arrives — stop pushing if it needs to hold. It emits no interaction events. `clearHighlight()`
-restores the chart explicitly, and `highlightSeries` returns `false` when the id matched no series.
+The highlight is one-shot and every `push` re-renders, so on a live feed it lasts only until the
+next sample arrives — stop pushing if it needs to hold. It emits no interaction events.
+`clearHighlight()` restores the chart explicitly, and `highlightSeries` returns `false` when the id
+matched no series.

--- a/apps/website/src/charts/sankey.md
+++ b/apps/website/src/charts/sankey.md
@@ -265,3 +265,30 @@ chart.on('linkenter', event => console.log(event.data)); // event.data: SankeyCh
 chart.on('linkleave', event => console.log(event.data)); // event.data: SankeyChartLinkEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
+of the diagram dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form; a
+flow takes its id (`"<source>-<target>"`) or a `{ source, target }` ref naming the nodes it joins.
+Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens
+the mark's tooltip where hovering would; a sankey diagram draws no crosshair, so `crosshair` is
+ignored here.
+
+```ts
+const chart = createSankeyChart('#container', { nodes, links });
+
+// Light one node, then the flow leaving it.
+chart.highlightNode('signup', { tooltip: true });
+chart.highlightLink({ source: 'signup', target: 'purchase' }, { tooltip: true });
+
+// The largest flow, whichever it is.
+chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last, including across the two
+methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
+pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()` restores
+it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/sankey.md
+++ b/apps/website/src/charts/sankey.md
@@ -271,9 +271,9 @@ chart.on('linkleave', event => console.log(event.data)); // event.data: SankeyCh
 `highlightNode` and `highlightLink` put a mark into the same hover state the pointer would — it
 brightens out of its rest tint — without waiting for one. A node takes its id or the `{ key }` ref
 form; a flow takes its id (`"<source>-<target>"`) or a `{ source, target }` ref naming the nodes it
-joins. Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true
-}` opens the mark's tooltip where hovering would; a sankey diagram draws no crosshair, so
-`crosshair` is ignored here.
+joins. Either method also accepts an accessor over the chart's `nodes` or `links`.
+`{ tooltip: true }` opens the mark's tooltip where hovering would; a sankey diagram draws no
+crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createSankeyChart('#container', { nodes, links });

--- a/apps/website/src/charts/sankey.md
+++ b/apps/website/src/charts/sankey.md
@@ -268,12 +268,12 @@ chart.on('linkleave', event => console.log(event.data)); // event.data: SankeyCh
 
 ## Programmatic Interaction
 
-`highlightNode` and `highlightLink` apply the treatment hovering a mark does — it lifts and the rest
-of the diagram dims — without waiting for a pointer. A node takes its id or the `{ key }` ref form; a
-flow takes its id (`"<source>-<target>"`) or a `{ source, target }` ref naming the nodes it joins.
-Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true }` opens
-the mark's tooltip where hovering would; a sankey diagram draws no crosshair, so `crosshair` is
-ignored here.
+`highlightNode` and `highlightLink` put a mark into the same hover state the pointer would — it
+brightens out of its rest tint — without waiting for one. A node takes its id or the `{ key }` ref
+form; a flow takes its id (`"<source>-<target>"`) or a `{ source, target }` ref naming the nodes it
+joins. Either method also accepts an accessor over the chart's `nodes` or `links`. `{ tooltip: true
+}` opens the mark's tooltip where hovering would; a sankey diagram draws no crosshair, so
+`crosshair` is ignored here.
 
 ```ts
 const chart = createSankeyChart('#container', { nodes, links });
@@ -290,5 +290,5 @@ chart.clearHighlight();
 
 One highlight is active at a time — a matching call replaces the last, including across the two
 methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
-pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()` restores
-it explicitly; both methods return `false` when the selector matched nothing live.
+pointer hover restores the diagram, and it emits none of the events above. `clearHighlight()`
+restores it explicitly; both methods return `false` when the selector matched nothing live.

--- a/apps/website/src/charts/scatter.md
+++ b/apps/website/src/charts/scatter.md
@@ -519,8 +519,8 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: Scatte
 highlight color — without waiting for one. A bare key is the item's `key`, so it lights that item in
 every series at once; `{ key, series }` narrows it to one, and an accessor receives the chart's data
 when it is easier to address a bubble by position. `{ tooltip: true }` opens the tooltip where
-hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and `{ crosshair: true
-}` places the crosshair on the bubble.
+hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and
+`{ crosshair: true }` places the crosshair on the bubble.
 
 ```ts
 const chart = createScatterChart('#container', { data, key: 'id', series });

--- a/apps/website/src/charts/scatter.md
+++ b/apps/website/src/charts/scatter.md
@@ -512,3 +512,31 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: Scatte
 chart.on('markerleave', event => console.log(event.data)); // event.data: ScatterChartMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightMarker` applies the treatment hovering a bubble does — that bubble grows and the rest of the
+chart dims — without waiting for a pointer. A bare key is the item's `key`, so it lights that item in
+every series at once; `{ key, series }` narrows it to one, and an accessor receives the chart's data
+when it is easier to address a bubble by position. `{ tooltip: true }` opens the tooltip where
+hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and `{ crosshair: true }`
+places the crosshair on the bubble.
+
+```ts
+const chart = createScatterChart('#container', { data, key: 'id', series });
+
+// Light item `a` in every series, with its tooltip and the crosshair.
+chart.highlightMarker('a', { tooltip: true, crosshair: true });
+
+// Only the sales series' bubble, then the same item addressed by position.
+chart.highlightMarker({ key: 'a', series: 'sales' });
+chart.highlightMarker(data => data[2].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `marker*` events above. `clearHighlight()` restores it explicitly, and
+`highlightSeries('sales')` dims every other series exactly as hovering its legend entry does. Both
+methods return `false` when nothing matched.

--- a/apps/website/src/charts/scatter.md
+++ b/apps/website/src/charts/scatter.md
@@ -515,12 +515,12 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: Scatte
 
 ## Programmatic Interaction
 
-`highlightMarker` applies the treatment hovering a bubble does — that bubble grows and the rest of the
-chart dims — without waiting for a pointer. A bare key is the item's `key`, so it lights that item in
+`highlightMarker` puts a bubble into the same hover state the pointer would — it grows and takes its
+highlight color — without waiting for one. A bare key is the item's `key`, so it lights that item in
 every series at once; `{ key, series }` narrows it to one, and an accessor receives the chart's data
 when it is easier to address a bubble by position. `{ tooltip: true }` opens the tooltip where
-hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and `{ crosshair: true }`
-places the crosshair on the bubble.
+hovering would (the shared axis tooltip when `tooltip.trigger` is `'axis'`), and `{ crosshair: true
+}` places the crosshair on the bubble.
 
 ```ts
 const chart = createScatterChart('#container', { data, key: 'id', series });

--- a/apps/website/src/charts/shared-options.md
+++ b/apps/website/src/charts/shared-options.md
@@ -456,5 +456,11 @@ Shared by every chart, regardless of type:
 | --- | --- |
 | `update(options)` | Merges partial options over the current ones and re-renders (when `autoRender` is enabled) |
 | `render()` | Renders explicitly; resolves once entry/update transitions have settled |
+| `highlightSeries(id)` | Dims every series but one, as hovering its legend entry does; returns whether the id matched |
+| `clearHighlight()` | Restores whatever a programmatic highlight changed; a no-op when nothing is highlighted |
 | `export()` | Exports the rendered chart from its context |
 | `destroy()` | Tears the chart down and releases its scene, renderer and listeners |
+
+Each chart also exposes a `highlightX` method per mark family it draws, replaying a mark's hover
+treatment — highlight, dim, tooltip, crosshair — from code. See
+[Programmatic Interaction](/charts/advanced/programmatic-interaction).

--- a/apps/website/src/charts/stock.md
+++ b/apps/website/src/charts/stock.md
@@ -253,9 +253,9 @@ chart.on('candleleave', event => console.log(event.data)); // event.data: StockC
 
 `highlightCandle` puts a candle into the same hover state the pointer would — its body softens to
 the hover fill — without waiting for one. Pass the candle's key, exactly as the chart reports it in
-the events above, the `{ key }` ref form, or an accessor over the chart's data returning either. `{
-tooltip: true }` opens the candle's tooltip where hovering would, and `{ crosshair: true }` places
-the crosshair on it.
+the events above, the `{ key }` ref form, or an accessor over the chart's data returning either.
+`{ tooltip: true }` opens the candle's tooltip where hovering would, and `{ crosshair: true }`
+places the crosshair on it.
 
 ```ts
 const chart = createStockChart('#container', {

--- a/apps/website/src/charts/stock.md
+++ b/apps/website/src/charts/stock.md
@@ -248,3 +248,36 @@ chart.on('candleenter', event => console.log(event.data)); // event.data: StockC
 chart.on('candleleave', event => console.log(event.data)); // event.data: StockChartCandleEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightCandle` applies the treatment hovering a candle's body does — it lifts and the rest of the
+chart dims — without waiting for a pointer. Pass the candle's key, exactly as the chart reports it in
+the events above, the `{ key }` ref form, or an accessor over the chart's data returning either.
+`{ tooltip: true }` opens the candle's tooltip where hovering would, and `{ crosshair: true }` places
+the crosshair on it.
+
+```ts
+const chart = createStockChart('#container', {
+    data,
+    key: 'date',
+    open: 'open',
+    high: 'high',
+    low: 'low',
+    close: 'close',
+});
+
+// Light one session, with its tooltip and the crosshair.
+chart.highlightCandle('2024-01-03', { tooltip: true, crosshair: true });
+
+// The most recent candle in the dataset.
+chart.highlightCandle(data => data[data.length - 1].date);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a pan or zoom) or the next pointer hover restores the chart, and it
+emits none of the `candle*` events above. `clearHighlight()` restores it explicitly;
+`highlightCandle` returns `false` when the selector matched no live candle, which includes a key
+scrolled outside the visible range.

--- a/apps/website/src/charts/stock.md
+++ b/apps/website/src/charts/stock.md
@@ -251,10 +251,10 @@ chart.on('candleleave', event => console.log(event.data)); // event.data: StockC
 
 ## Programmatic Interaction
 
-`highlightCandle` applies the treatment hovering a candle's body does — it lifts and the rest of the
-chart dims — without waiting for a pointer. Pass the candle's key, exactly as the chart reports it in
-the events above, the `{ key }` ref form, or an accessor over the chart's data returning either.
-`{ tooltip: true }` opens the candle's tooltip where hovering would, and `{ crosshair: true }` places
+`highlightCandle` puts a candle into the same hover state the pointer would — its body softens to
+the hover fill — without waiting for one. Pass the candle's key, exactly as the chart reports it in
+the events above, the `{ key }` ref form, or an accessor over the chart's data returning either. `{
+tooltip: true }` opens the candle's tooltip where hovering would, and `{ crosshair: true }` places
 the crosshair on it.
 
 ```ts
@@ -279,5 +279,6 @@ chart.clearHighlight();
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
 render (a resize, an `update`, a pan or zoom) or the next pointer hover restores the chart, and it
 emits none of the `candle*` events above. `clearHighlight()` restores it explicitly;
-`highlightCandle` returns `false` when the selector matched no live candle, which includes a key
-scrolled outside the visible range.
+`highlightCandle` returns `false` when the selector matched no live candle. Candles are clipped to
+the plot, so highlighting one the navigator has scrolled past shows nothing until it is back in
+view.

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -242,11 +242,11 @@ chart.on('nodeleave', event => console.log(event.data)); // event.data: Sunburst
 
 ## Programmatic Interaction
 
-`highlightNode` applies the treatment hovering an arc does — it lifts and every other arc dims —
-without waiting for a pointer. Pass the node's id, the `{ key }` ref form, or an accessor over the
-chart's root nodes returning either. Only that node lights, not its branch — widening the highlight to
-a whole subtree is what a legend hover does. `{ tooltip: true }` opens the arc's tooltip where
-hovering would; a sunburst draws no crosshair, so `crosshair` is ignored here.
+`highlightNode` puts an arc into the same hover state the pointer would — which reads as every other
+arc dimming — without waiting for one. Pass the node's id, the `{ key }` ref form, or an accessor
+over the chart's root nodes returning either. Only that node lights, not its branch — widening the
+highlight to a whole subtree is what a legend hover does. `{ tooltip: true }` opens the arc's
+tooltip where hovering would; a sunburst draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createSunburstChart('#container', { data });
@@ -263,5 +263,4 @@ chart.clearHighlight();
 One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
 render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
 emits none of the `node*` events above. `clearHighlight()` restores it explicitly; `highlightNode`
-returns `false` when the selector matched no live arc, which includes a node outside the current
-`maxDepth`.
+returns `false` when the selector matched no live arc.

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -244,9 +244,9 @@ chart.on('nodeleave', event => console.log(event.data)); // event.data: Sunburst
 
 `highlightNode` puts an arc into the same hover state the pointer would — which reads as every other
 arc dimming — without waiting for one. Pass the node's id, the `{ key }` ref form, or an accessor
-over the chart's root nodes returning either. Only that node lights, not its branch — widening the
-highlight to a whole subtree is what a legend hover does. `{ tooltip: true }` opens the arc's
-tooltip where hovering would; a sunburst draws no crosshair, so `crosshair` is ignored here.
+over the chart's root nodes returning either. Only that node is picked out, not its branch —
+widening the highlight to a whole subtree is what a legend hover does. `{ tooltip: true }` opens the
+arc's tooltip where hovering would; a sunburst draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createSunburstChart('#container', { data });

--- a/apps/website/src/charts/sunburst.md
+++ b/apps/website/src/charts/sunburst.md
@@ -239,3 +239,29 @@ chart.on('nodeenter', event => console.log(event.data)); // event.data: Sunburst
 chart.on('nodeleave', event => console.log(event.data)); // event.data: SunburstChartNodeEvent<TData>
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` applies the treatment hovering an arc does — it lifts and every other arc dims —
+without waiting for a pointer. Pass the node's id, the `{ key }` ref form, or an accessor over the
+chart's root nodes returning either. Only that node lights, not its branch — widening the highlight to
+a whole subtree is what a legend hover does. `{ tooltip: true }` opens the arc's tooltip where
+hovering would; a sunburst draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createSunburstChart('#container', { data });
+
+// Light the Frontend arc and open its tooltip.
+chart.highlightNode('frontend', { tooltip: true });
+
+// A root node, addressed by position in the tree.
+chart.highlightNode(nodes => nodes[1].id);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `node*` events above. `clearHighlight()` restores it explicitly; `highlightNode`
+returns `false` when the selector matched no live arc, which includes a node outside the current
+`maxDepth`.

--- a/apps/website/src/charts/treemap.md
+++ b/apps/website/src/charts/treemap.md
@@ -189,10 +189,10 @@ chart.on('nodeleave', event => console.log(event.data)); // event.data: TreemapC
 
 ## Programmatic Interaction
 
-`highlightNode` applies the treatment hovering a cell does — it lifts out of its rest tint and the
-rest of the chart dims — without waiting for a pointer. Pass the cell's key, the `{ key }` ref form,
-or an accessor over the chart's data returning either. `{ tooltip: true }` opens the cell's tooltip
-where hovering would; a treemap draws no crosshair, so `crosshair` is ignored here.
+`highlightNode` puts a cell into the same hover state the pointer would — it lifts out of its rest
+tint to full color — without waiting for one. Pass the cell's key, the `{ key }` ref form, or an
+accessor over the chart's data returning either. `{ tooltip: true }` opens the cell's tooltip where
+hovering would; a treemap draws no crosshair, so `crosshair` is ignored here.
 
 ```ts
 const chart = createTreemapChart('#container', { data, key: 'name', value: 'share', label: 'name' });

--- a/apps/website/src/charts/treemap.md
+++ b/apps/website/src/charts/treemap.md
@@ -186,3 +186,27 @@ chart.on('nodeenter', event => console.log(event.data)); // event.data: TreemapC
 chart.on('nodeleave', event => console.log(event.data)); // event.data: TreemapChartNodeEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightNode` applies the treatment hovering a cell does — it lifts out of its rest tint and the
+rest of the chart dims — without waiting for a pointer. Pass the cell's key, the `{ key }` ref form,
+or an accessor over the chart's data returning either. `{ tooltip: true }` opens the cell's tooltip
+where hovering would; a treemap draws no crosshair, so `crosshair` is ignored here.
+
+```ts
+const chart = createTreemapChart('#container', { data, key: 'name', value: 'share', label: 'name' });
+
+// Light the Chrome cell and open its tooltip.
+chart.highlightNode('Chrome', { tooltip: true });
+
+// The first cell in the dataset, wherever the layout put it.
+chart.highlightNode(data => data[0].name);
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last — and it is one-shot: the next
+render (a resize, an `update`, a legend toggle) or the next pointer hover restores the chart, and it
+emits none of the `node*` events above. `clearHighlight()` restores it explicitly; `highlightNode`
+returns `false` when the selector matched no live cell.

--- a/apps/website/src/charts/trend.md
+++ b/apps/website/src/charts/trend.md
@@ -503,3 +503,31 @@ chart.on('markerenter', event => console.log(event.data)); // event.data: TrendC
 chart.on('markerleave', event => console.log(event.data)); // event.data: TrendChartMarkerEvent
 ```
 <!-- events:end -->
+
+## Programmatic Interaction
+
+`highlightBar` and `highlightMarker` apply the treatment hovering a mark does — it lifts and the rest
+of the chart dims — without waiting for a pointer. The two split the chart by series type: bars are
+matched by `highlightBar`, line and area points by `highlightMarker`, so a category with both can be
+lit either way. A bare key lights that category across every series of the relevant type;
+`{ key, series }` narrows it to one, and an accessor receives the chart's data. `{ tooltip: true }`
+opens the mark's tooltip and `{ crosshair: true }` places the crosshair on it.
+
+```ts
+const chart = createTrendChart('#container', { data, key: 'month', series });
+
+// Light the orders bar for February.
+chart.highlightBar('Feb', { tooltip: true });
+
+// Light the line and area points at the same key, with the crosshair.
+chart.highlightMarker('Feb', { tooltip: true, crosshair: true });
+chart.highlightMarker({ key: 'Feb', series: 'target' });
+
+chart.clearHighlight();
+```
+
+One highlight is active at a time — a matching call replaces the last, including across the two
+methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
+pointer hover restores the chart, and it emits none of the events above. `clearHighlight()` restores
+it explicitly, and `highlightSeries('orders')` dims every other series exactly as hovering its legend
+entry does. All three methods return `false` when nothing matched.

--- a/apps/website/src/charts/trend.md
+++ b/apps/website/src/charts/trend.md
@@ -510,8 +510,8 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: TrendC
 to a full-strength fill, points grown — without waiting for one. The two split the chart by series
 type: bars are matched by `highlightBar`, line and area points by `highlightMarker`, so a category
 with both can be lit either way. A bare key lights that category across every series of the relevant
-type; `{ key, series }` narrows it to one, and an accessor receives the chart's data. `{ tooltip:
-true }` opens the mark's tooltip and `{ crosshair: true }` places the crosshair on it.
+type; `{ key, series }` narrows it to one, and an accessor receives the chart's data.
+`{ tooltip: true }` opens the mark's tooltip and `{ crosshair: true }` places the crosshair on it.
 
 ```ts
 const chart = createTrendChart('#container', { data, key: 'month', series });

--- a/apps/website/src/charts/trend.md
+++ b/apps/website/src/charts/trend.md
@@ -506,12 +506,12 @@ chart.on('markerleave', event => console.log(event.data)); // event.data: TrendC
 
 ## Programmatic Interaction
 
-`highlightBar` and `highlightMarker` apply the treatment hovering a mark does — it lifts and the rest
-of the chart dims — without waiting for a pointer. The two split the chart by series type: bars are
-matched by `highlightBar`, line and area points by `highlightMarker`, so a category with both can be
-lit either way. A bare key lights that category across every series of the relevant type;
-`{ key, series }` narrows it to one, and an accessor receives the chart's data. `{ tooltip: true }`
-opens the mark's tooltip and `{ crosshair: true }` places the crosshair on it.
+`highlightBar` and `highlightMarker` put a mark into the same hover state the pointer would — bars
+to a full-strength fill, points grown — without waiting for one. The two split the chart by series
+type: bars are matched by `highlightBar`, line and area points by `highlightMarker`, so a category
+with both can be lit either way. A bare key lights that category across every series of the relevant
+type; `{ key, series }` narrows it to one, and an accessor receives the chart's data. `{ tooltip:
+true }` opens the mark's tooltip and `{ crosshair: true }` places the crosshair on it.
 
 ```ts
 const chart = createTrendChart('#container', { data, key: 'month', series });
@@ -529,5 +529,5 @@ chart.clearHighlight();
 One highlight is active at a time — a matching call replaces the last, including across the two
 methods — and it is one-shot: the next render (a resize, an `update`, a legend toggle) or the next
 pointer hover restores the chart, and it emits none of the events above. `clearHighlight()` restores
-it explicitly, and `highlightSeries('orders')` dims every other series exactly as hovering its legend
-entry does. All three methods return `false` when nothing matched.
+it explicitly, and `highlightSeries('orders')` dims every other series exactly as hovering its
+legend entry does. All three methods return `false` when nothing matched.

--- a/packages/charts/src/charts/arc-diagram.ts
+++ b/packages/charts/src/charts/arc-diagram.ts
@@ -1,5 +1,8 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    LinkRef,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -67,6 +70,7 @@ import {
     arrayJoin,
     functionIdentity,
     numberExtent,
+    typeIsString,
 } from '@ripl/utilities';
 
 /** Opacity applied to a node's fill at rest (full opacity on hover). */
@@ -220,6 +224,8 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
             onLeave: event => this.emit('nodeleave', event),
             onClick: event => this.emit('nodeclick', event),
         });
+
+        this.registerMark('node', node.id, circle);
     }
 
     private _attachLinkHover(arc: Polyline, link: ArcDiagramLink, content: string, color: string) {
@@ -247,6 +253,49 @@ export class ArcDiagramChart<TData = unknown> extends Chart<ArcDiagramChartOptio
             onLeave: event => this.emit('linkleave', event),
             onClick: event => this.emit('linkclick', event),
         });
+
+        this.registerMark('link', `${link.source}->${link.target}`, arc);
+    }
+
+    /**
+     * Highlights a node's dot, dimming the rest of the chart exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no node events.
+     *
+     * @param selector - The node's id, a `{ key }` ref, or an accessor over the chart's nodes.
+     * @param options - What to show alongside the node's highlight state.
+     * @returns `true` when a live node matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('alice', { tooltip: true });
+     * chart.highlightNode(nodes => nodes[0].id);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<ArcDiagramNode<TData>>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.nodes), options);
+    }
+
+    /**
+     * Highlights the arc joining two nodes, dimming the rest of the chart exactly as hovering it
+     * does. Arcs carry no id of their own, so they are addressed by the nodes they join, in the order
+     * the chart reports them in its link events.
+     *
+     * @param selector - A `{ source, target }` ref naming the nodes the arc joins, the `"source->target"` string it flattens to, or an accessor over the chart's links.
+     * @param options - What to show alongside the arc's highlight state.
+     * @returns `true` when a live arc matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightLink({ source: 'alice', target: 'bob' }, { tooltip: true });
+     * chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+     * ```
+     */
+    public highlightLink(selector: MarkSelector<ArcDiagramLink, LinkRef>, options?: HighlightOptions): boolean {
+        const ref = this.resolveMarkSelector(selector, this.options.links);
+        const key = typeIsString(ref) ? ref : `${ref.source}->${ref.target}`;
+
+        return this.replayMark('link', key, options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/area.ts
+++ b/packages/charts/src/charts/area.ts
@@ -12,6 +12,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ChartDataLabelsInput,
     ValueFormatInput,
 } from '../core/options';
@@ -297,7 +302,29 @@ export class AreaChart<TData = unknown> extends CartesianChart<AreaChartOptions<
             dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
             addContent: elements => this.addPlotContent(elements),
             emit: (phase, event) => this._emitMarker(phase, event),
+            registerMark: (kind, key, element, series) => this.registerMark(kind, key, element, series),
         };
+    }
+
+    /**
+     * Highlights the marker(s) at a category key, dimming the rest of the chart exactly as hovering
+     * one does. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no marker events. Markers hidden with `markers: false` are not highlightable.
+     *
+     * @param selector - The marker's category key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the marker's highlight state.
+     * @returns `true` when at least one live marker matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('Feb', { tooltip: true, crosshair: true });
+     * chart.highlightMarker(data => data[2].month);
+     * chart.highlightMarker({ key: 'Feb', series: 'traffic' });
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/bar.ts
+++ b/packages/charts/src/charts/bar.ts
@@ -13,6 +13,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ChartDataLabelsInput,
     ValueFormatInput,
 } from '../core/options';
@@ -317,7 +322,28 @@ export class BarChart<TData = unknown> extends CartesianChart<BarChartOptions<TD
             dataLabels: normalizeDataLabels(this.options.labels, { anchor: this._isHorizontal ? 'right' : 'top' }),
             addContent: elements => this.addPlotContent(elements),
             emit: (phase, event) => this._emitBar(phase, event),
+            registerMark: (kind, key, element, series) => this.registerMark(kind, key, element, series),
         };
+    }
+
+    /**
+     * Highlights the bar(s) at a category key, dimming the rest of the chart exactly as hovering one
+     * does. The highlight is a one-shot command: the next render (a resize, an {@link Chart.update},
+     * a legend toggle) or the next pointer hover restores the chart, and it emits no bar events.
+     *
+     * @param selector - The bar's category key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the bar's highlight state.
+     * @returns `true` when at least one live bar matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightBar('Jan', { tooltip: true });
+     * chart.highlightBar(data => data[2].month);
+     * chart.highlightBar({ key: 'Jan', series: 'sales' });
+     * ```
+     */
+    public highlightBar(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('bar', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/box-plot.ts
+++ b/packages/charts/src/charts/box-plot.ts
@@ -11,6 +11,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ValueFormatInput,
 } from '../core/options';
 
@@ -184,6 +189,27 @@ export class BoxPlotChart<TData = unknown> extends CartesianChart<BoxPlotChartOp
             onLeave: point => this.emit('boxleave', payload(point)),
             onClick: point => this.emit('boxclick', payload(point)),
         });
+
+        this.registerMark('box', category, rect);
+    }
+
+    /**
+     * Highlights the box summarizing a category, applying the same treatment hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}) or the
+     * next pointer hover restores the chart, and it emits no box events.
+     *
+     * @param selector - The box's category, or an accessor over the chart's data returning one.
+     * @param options - What to show alongside the box's highlight state.
+     * @returns `true` when a live box matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightBox('Team A', { tooltip: true, crosshair: true });
+     * chart.highlightBox(data => data[0].team);
+     * ```
+     */
+    public highlightBox(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('box', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     /** Computes the final geometry of every box element (the target the entry/update transitions animate to). */

--- a/packages/charts/src/charts/chord.ts
+++ b/packages/charts/src/charts/chord.ts
@@ -1,5 +1,8 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    LinkRef,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -68,6 +71,7 @@ import {
 
 import {
     arrayJoin,
+    typeIsString,
 } from '@ripl/utilities';
 
 /** Fill opacity for a ribbon at rest. */
@@ -302,6 +306,47 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
         });
 
         this.init();
+    }
+
+    /**
+     * Highlights a group's outer arc, dimming the rest of the chart exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no segment events.
+     *
+     * @param selector - The group's label, a `{ key }` ref, or an accessor over the chart's groups.
+     * @param options - What to show alongside the arc's highlight state.
+     * @returns `true` when a live arc matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightSegment('Europe', { tooltip: true });
+     * chart.highlightSegment(groups => groups[0]);
+     * ```
+     */
+    public highlightSegment(selector: MarkSelector<string>, options?: HighlightOptions): boolean {
+        return this.replayMark('segment', this.resolveMarkSelector(selector, this.options.groups), options);
+    }
+
+    /**
+     * Highlights the ribbon joining two groups, dimming the rest of the chart exactly as hovering it
+     * does. A ribbon is drawn once per pair, so the ref names the groups the way the chart reports
+     * them in its link events.
+     *
+     * @param selector - The ribbon's id, a `{ source, target }` ref naming the groups it joins, or an accessor over the chart's groups.
+     * @param options - What to show alongside the ribbon's highlight state.
+     * @returns `true` when a live ribbon matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightLink({ source: 'Europe', target: 'Asia' }, { tooltip: true });
+     * chart.highlightLink(groups => ({ source: groups[0], target: groups[1] }));
+     * ```
+     */
+    public highlightLink(selector: MarkSelector<string, LinkRef>, options?: HighlightOptions): boolean {
+        const ref = this.resolveMarkSelector(selector, this.options.groups);
+        const key = typeIsString(ref) ? ref : `${ref.source}->${ref.target}`;
+
+        return this.replayMark('link', key, options);
     }
 
     public async render() {
@@ -546,11 +591,13 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
                 label: arc.label,
                 value: arc.value,
             },
-            onHighlight: hovered => this.highlightSeries(hovered ? arc.id : null),
+            onHighlight: hovered => this.applySeriesHighlight(hovered ? arc.id : null),
             onEnter: event => this.emit('segmententer', event),
             onLeave: event => this.emit('segmentleave', event),
             onClick: event => this.emit('segmentclick', event),
         });
+
+        this.registerMark('segment', arc.label, segment);
     }
 
     private _attachRibbonHover(ribbonEl: Ribbon, ribbon: ChordRibbon, cx: number, cy: number) {
@@ -577,6 +624,9 @@ export class ChordChart extends Chart<ChordChartOptions, ChordChartEventMap> {
             onLeave: event => this.emit('linkleave', event),
             onClick: event => this.emit('linkclick', event),
         });
+
+        this.registerMark('link', ribbon.id, ribbonEl);
+        this.registerMark('link', `${ribbon.sourceLabel}->${ribbon.targetLabel}`, ribbonEl);
     }
 
 }

--- a/packages/charts/src/charts/force-directed.ts
+++ b/packages/charts/src/charts/force-directed.ts
@@ -1,5 +1,8 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    LinkRef,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -74,6 +77,7 @@ import {
     functionIdentity,
     numberExtent,
     numberMaxOf,
+    typeIsString,
 } from '@ripl/utilities';
 
 /** Opacity applied to a node's fill at rest (full opacity on hover). */
@@ -244,6 +248,8 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
             onLeave: point => this.emit('nodeleave', payload(point)),
             onClick: point => this.emit('nodeclick', payload(point)),
         });
+
+        this.registerMark('node', node.id, circle);
     }
 
     private _attachLinkHover(line: Line, link: ForceNetworkLink, content: string) {
@@ -272,6 +278,49 @@ export class ForceDirectedChart<TData = unknown> extends Chart<ForceDirectedChar
             onLeave: point => this.emit('linkleave', payload(point)),
             onClick: point => this.emit('linkclick', payload(point)),
         });
+
+        this.registerMark('link', `${link.source}->${link.target}`, line);
+    }
+
+    /**
+     * Highlights a node, dimming the rest of the chart exactly as hovering it does. The highlight is
+     * a one-shot command: the next render (a resize, an {@link Chart.update}, a legend toggle) or the
+     * next pointer hover restores the chart, and it emits no node events.
+     *
+     * @param selector - The node's id, a `{ key }` ref, or an accessor over the chart's nodes.
+     * @param options - What to show alongside the node's highlight state.
+     * @returns `true` when a live node matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('hub', { tooltip: true });
+     * chart.highlightNode(nodes => nodes[0].id);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<ForceNetworkNode<TData>>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.nodes), options);
+    }
+
+    /**
+     * Highlights the link between two nodes, dimming the rest of the chart exactly as hovering it
+     * does. Links carry no id of their own, so they are addressed by the nodes they join, in the
+     * order the chart reports them in its link events.
+     *
+     * @param selector - A `{ source, target }` ref naming the nodes the link joins, the `"source->target"` string it flattens to, or an accessor over the chart's links.
+     * @param options - What to show alongside the link's highlight state.
+     * @returns `true` when a live link matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightLink({ source: 'a', target: 'b' }, { tooltip: true });
+     * chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+     * ```
+     */
+    public highlightLink(selector: MarkSelector<ForceNetworkLink, LinkRef>, options?: HighlightOptions): boolean {
+        const ref = this.resolveMarkSelector(selector, this.options.links);
+        const key = typeIsString(ref) ? ref : `${ref.source}->${ref.target}`;
+
+        return this.replayMark('link', key, options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/funnel.ts
+++ b/packages/charts/src/charts/funnel.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -142,6 +144,25 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
         });
 
         this.init();
+    }
+
+    /**
+     * Highlights the segment at a key, lifting it out of its rest tint exactly as hovering it does.
+     * The highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a
+     * legend toggle) or the next pointer hover restores the chart, and it emits no segment events.
+     *
+     * @param selector - The segment's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the segment's highlight state.
+     * @returns `true` when a live segment matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightSegment('Signed up', { tooltip: true });
+     * chart.highlightSegment(data => data[1].stage);
+     * ```
+     */
+    public highlightSegment(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('segment', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {
@@ -377,6 +398,8 @@ export class FunnelChart<TData = unknown> extends Chart<FunnelChartOptions<TData
             onLeave: event => this.emit('segmentleave', event),
             onClick: event => this.emit('segmentclick', event),
         });
+
+        this.registerMark('segment', item.key, rect);
     }
 
 }

--- a/packages/charts/src/charts/gantt.ts
+++ b/packages/charts/src/charts/gantt.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -795,6 +797,27 @@ export class GanttChart<TData = unknown> extends Chart<GanttChartOptions<TData>,
             onLeave: point => this.emit('taskleave', payload(point)),
             onClick: point => this.emit('taskclick', payload(point)),
         });
+
+        this.registerMark('task', task.id, bar);
+    }
+
+    /**
+     * Highlights a task's bar, applying the same treatment hovering it does. The highlight is a
+     * one-shot command: the next render (a resize, an {@link Chart.update}) or the next pointer
+     * hover restores the chart, and it emits no task events.
+     *
+     * @param selector - The task's key, as the chart reports it in its task events, or an accessor over the chart's data returning one.
+     * @param options - What to show alongside the task's highlight state.
+     * @returns `true` when a live task bar matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightTask('build', { tooltip: true });
+     * chart.highlightTask(data => data[0].id);
+     * ```
+     */
+    public highlightTask(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('task', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
 }

--- a/packages/charts/src/charts/gauge.ts
+++ b/packages/charts/src/charts/gauge.ts
@@ -1,5 +1,6 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
 } from '../core/chart';
 
 import {
@@ -516,6 +517,27 @@ export class GaugeChart extends Chart<GaugeChartOptions, GaugeChartEventMap> {
             onLeave: point => this.emit('valueleave', payload(point)),
             onClick: point => this.emit('valueclick', payload(point)),
         });
+
+        this.registerMark('value', 'value', arc);
+    }
+
+    /**
+     * Highlights the value arc, applying the same treatment hovering it does. A gauge has a single
+     * arc, so there is nothing to select. The highlight is a one-shot command: the next render (a
+     * resize, an {@link Chart.update}) or the next pointer hover restores the gauge, and it emits no
+     * value events.
+     *
+     * @param options - What to show alongside the arc's highlight state.
+     * @returns `true` when the value arc is live, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightValue({ tooltip: true });
+     * chart.clearHighlight();
+     * ```
+     */
+    public highlightValue(options?: HighlightOptions): boolean {
+        return this.replayMark('value', 'value', options);
     }
 
 }

--- a/packages/charts/src/charts/heatmap.ts
+++ b/packages/charts/src/charts/heatmap.ts
@@ -4,6 +4,9 @@ import type {
 
 import type {
     BaseChartOptions,
+    CellRef,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -85,6 +88,7 @@ import {
     typeIsArray,
     typeIsFunction,
     typeIsObject,
+    typeIsString,
 } from '@ripl/utilities';
 
 /** Options for configuring a {@link HeatmapChart}. */
@@ -194,6 +198,31 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
         this._yAxis = axes.yAxis;
 
         this.init();
+    }
+
+    /**
+     * Highlights one or more cells, dimming the rest of the grid exactly as hovering a cell does. A
+     * `{ x, y }` ref names the single cell at that pair of axis labels — the pair the chart reports
+     * as `xLabel`/`yLabel` on its cell events — while a bare label matches either axis, lighting that
+     * whole row or column. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}) or the next pointer hover restores the chart, and it emits no cell events.
+     *
+     * @param selector - A `{ x, y }` ref naming one cell, a bare axis label selecting its row or column, or an accessor over the chart's data returning either.
+     * @param options - What to show alongside the cell's highlight state. Several matched cells share one tooltip, their contents joined a line apart.
+     * @returns `true` when at least one live cell matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightCell({ x: '9', y: 'Mon' }, { tooltip: true });
+     * chart.highlightCell('Mon');
+     * chart.highlightCell(data => ({ x: data[0].hour, y: data[0].day }));
+     * ```
+     */
+    public highlightCell(selector: MarkSelector<TData, CellRef>, options?: HighlightOptions): boolean {
+        const ref = this.resolveMarkSelector(selector, this.options.data);
+        const key = typeIsString(ref) ? ref : `${ref.x} ${ref.y}`;
+
+        return this.replayMark('cell', key, options);
     }
 
     public async render() {
@@ -570,6 +599,15 @@ export class HeatmapChart<TData = unknown> extends Chart<HeatmapChartOptions<TDa
             onLeave: point => this.emit('cellleave', payload(point)),
             onClick: point => this.emit('cellclick', payload(point)),
         });
+
+        // Joined with a space rather than a hyphen: the cell ids above already collide for hyphenated labels.
+        this.registerMark('cell', `${cell.xLabel} ${cell.yLabel}`, rect);
+        this.registerMark('cell', cell.xLabel, rect);
+
+        // A matrix sharing its categories across both axes would otherwise register its diagonal twice.
+        if (cell.yLabel !== cell.xLabel) {
+            this.registerMark('cell', cell.yLabel, rect);
+        }
     }
 
 }

--- a/packages/charts/src/charts/histogram.ts
+++ b/packages/charts/src/charts/histogram.ts
@@ -11,6 +11,10 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+} from '../core/chart';
+
+import type {
     ValueFormatInput,
 } from '../core/options';
 
@@ -57,6 +61,7 @@ import {
 
 import {
     arrayJoin,
+    typeIsFunction,
 } from '@ripl/utilities';
 
 /** The opacity applied to a bin's fill at rest (full opacity on hover). */
@@ -127,6 +132,29 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
         });
 
         this.init();
+    }
+
+    /**
+     * Highlights a bin bar, dimming the rest of the chart exactly as hovering it does. Bins are
+     * derived from the data rather than carrying a key of their own, so they are addressed by
+     * position: `0` is the leftmost bin and the index counts up across the value axis, in the same
+     * order the bars are drawn. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}) or the next pointer hover restores the chart, and it emits no bin events.
+     *
+     * @param selector - The bin's index, or an accessor over the chart's data returning one.
+     * @param options - What to show alongside the bar's highlight state; `crosshair` places the crosshair on it.
+     * @returns `true` when a live bin matched, `false` when the index falls outside the histogram.
+     *
+     * @example
+     * ```ts
+     * chart.highlightBin(0, { tooltip: true, crosshair: true });
+     * chart.highlightBin(data => data.length - 1);
+     * ```
+     */
+    public highlightBin(selector: number | ((data: TData[]) => number), options?: HighlightOptions): boolean {
+        const index = typeIsFunction(selector) ? selector(this.options.data) : selector;
+
+        return this.replayMark('bin', String(index), options);
     }
 
     /** Wires hover highlight + tooltip + interaction events onto a bin bar. */
@@ -264,6 +292,7 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
 
         const items = histogram.map((current, index) => ({
             id: `bin-${index}`,
+            index,
             bin: current,
         }));
 
@@ -295,6 +324,7 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
             });
 
             this._attachBinHover(rect, item.bin);
+            this.registerMark('bin', String(item.index), rect);
             this.addPlotContent(rect);
 
             return rect;
@@ -302,6 +332,7 @@ export class HistogramChart<TData = unknown> extends CartesianChart<HistogramCha
 
         updates.forEach(([item, rect]) => {
             rect.data = targetState(item.bin);
+            this.registerMark('bin', String(item.index), rect);
         });
 
         this._bars = [

--- a/packages/charts/src/charts/line.ts
+++ b/packages/charts/src/charts/line.ts
@@ -12,6 +12,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ChartDataLabelsInput,
     ValueFormatInput,
 } from '../core/options';
@@ -255,7 +260,29 @@ export class LineChart<TData = unknown> extends CartesianChart<LineChartOptions<
             dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
             addContent: elements => this.addPlotContent(elements),
             emit: (phase, event) => this._emitMarker(phase, event),
+            registerMark: (kind, key, element, series) => this.registerMark(kind, key, element, series),
         };
+    }
+
+    /**
+     * Highlights the marker(s) at a category key, dimming the rest of the chart exactly as hovering
+     * one does. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no marker events. Markers hidden with `markers: false` are not highlightable.
+     *
+     * @param selector - The marker's category key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the marker's highlight state.
+     * @returns `true` when at least one live marker matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('Feb', { tooltip: true, crosshair: true });
+     * chart.highlightMarker(data => data[2].month);
+     * chart.highlightMarker({ key: 'Feb', series: 'sales' });
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/packed-circle.ts
+++ b/packages/charts/src/charts/packed-circle.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -189,6 +191,27 @@ export class PackedCircleChart<TData = unknown> extends Chart<PackedCircleChartO
             onLeave: point => this.emit('nodeleave', payload(point)),
             onClick: point => this.emit('nodeclick', payload(point)),
         });
+
+        this.registerMark('node', node.key, circle);
+    }
+
+    /**
+     * Highlights the circle at a key, lifting it out of its rest tint exactly as hovering it does.
+     * The highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a
+     * legend toggle) or the next pointer hover restores the chart, and it emits no node events.
+     *
+     * @param selector - The circle's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the circle's highlight state.
+     * @returns `true` when a live circle matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('typescript', { tooltip: true });
+     * chart.highlightNode(data => data[0].language);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/pie.ts
+++ b/packages/charts/src/charts/pie.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -166,6 +168,25 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
         });
 
         this.init();
+    }
+
+    /**
+     * Highlights the segment at a key, dimming every other segment exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no segment events.
+     *
+     * @param selector - The segment's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the segment's highlight state.
+     * @returns `true` when a live segment matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightSegment('Chrome', { tooltip: true });
+     * chart.highlightSegment(data => data[0].browser);
+     * ```
+     */
+    public highlightSegment(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('segment', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {
@@ -490,11 +511,14 @@ export class PieChart<TData = unknown> extends Chart<PieChartOptions<TData>, Pie
                 key,
             },
             // Every segment shares one rest tint, so the hover reads as the others dimming rather than this one lifting.
-            onHighlight: hovered => this.highlightSeries(hovered ? key : null),
+            onHighlight: hovered => this.applySeriesHighlight(hovered ? key : null),
             onEnter: event => this.emit('segmententer', event),
             onLeave: event => this.emit('segmentleave', event),
             onClick: event => this.emit('segmentclick', event),
         });
+
+        // The arc carries the hover treatment but no id of its own, so register it under its group's key.
+        this.registerMark('segment', key, arc);
     }
 
 }

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -397,6 +399,25 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
         }));
     }
 
+    /**
+     * Highlights the segment at a key, dimming every other segment exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no segment events.
+     *
+     * @param selector - The segment's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the segment's highlight state.
+     * @returns `true` when a live segment matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightSegment('Mon', { tooltip: true });
+     * chart.highlightSegment(data => data[0].day);
+     * ```
+     */
+    public highlightSegment(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('segment', this.resolveMarkSelector(selector, this.options.data), options);
+    }
+
     public async render() {
         return super.render((scene, renderer) => {
             const {
@@ -736,11 +757,14 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
                 label,
                 key,
             },
-            onHighlight: hovered => this.highlightSeries(hovered ? key : null),
+            onHighlight: hovered => this.applySeriesHighlight(hovered ? key : null),
             onEnter: event => this.emit('segmententer', event),
             onLeave: event => this.emit('segmentleave', event),
             onClick: event => this.emit('segmentclick', event),
         });
+
+        // The arc carries the hover treatment but no id of its own, so register it under its group's key.
+        this.registerMark('segment', key, arc);
     }
 }
 

--- a/packages/charts/src/charts/polar-area.ts
+++ b/packages/charts/src/charts/polar-area.ts
@@ -763,7 +763,6 @@ export class PolarAreaChart<TData = unknown> extends Chart<PolarAreaChartOptions
             onClick: event => this.emit('segmentclick', event),
         });
 
-        // The arc carries the hover treatment but no id of its own, so register it under its group's key.
         this.registerMark('segment', key, arc);
     }
 }

--- a/packages/charts/src/charts/polar-scatter.ts
+++ b/packages/charts/src/charts/polar-scatter.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -142,6 +144,8 @@ export interface PolarScatterMarkerEvent {
     sizeValue: number;
     /** The id of the series the marker belongs to. */
     seriesId: string;
+    /** The index of the marker's item in the chart's data, which is how {@link PolarScatterChart.highlightMarker} addresses it. */
+    index: number;
 }
 
 /** Events emitted by a {@link PolarScatterChart} that consumers can subscribe to via `chart.on(...)`. */
@@ -378,6 +382,31 @@ export class PolarScatterChart<TData = unknown> extends Chart<PolarScatterChartO
             onLeave: point => this.emit('markerleave', payload(point)),
             onClick: point => this.emit('markerclick', payload(point)),
         });
+
+        this.registerMark('marker', String(values.index), marker, values.seriesId);
+    }
+
+    /**
+     * Highlights the marker(s) at a data index, dimming the rest of the chart exactly as hovering one
+     * does. The chart has no key accessor — every series plots the whole dataset — so markers are
+     * addressed by the item's position in `data`, as a string, which is the `index` its marker events
+     * report. A bare index lights that item in every series; narrow it with `{ key, series }`. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no marker events.
+     *
+     * @param selector - The item's index as a string, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the marker's highlight state.
+     * @returns `true` when at least one live marker matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('2', { tooltip: true });
+     * chart.highlightMarker(data => String(data.findIndex(item => item.bearing === 120)));
+     * chart.highlightMarker({ key: '2', series: 'readings' });
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {
@@ -474,6 +503,7 @@ export class PolarScatterChart<TData = unknown> extends Chart<PolarScatterChartO
                         radiusValue,
                         sizeValue,
                         seriesId: srs.id,
+                        index,
                     } as PolarScatterMarkerEvent,
                     state: {
                         cx: px,

--- a/packages/charts/src/charts/radar.ts
+++ b/packages/charts/src/charts/radar.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -691,6 +693,29 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
         ].flat());
     }
 
+    /**
+     * Highlights the point marker(s) on an axis, growing them exactly as hovering one does. Markers
+     * are keyed by their axis label — the same `axisLabel` the chart reports in its marker events —
+     * so a bare label lights that axis in every series; narrow it with `{ key, series }` to light one
+     * series' point. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no marker events.
+     *
+     * @param selector - The point's axis label, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the marker's highlight state.
+     * @returns `true` when at least one live marker matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('Speed', { tooltip: true });
+     * chart.highlightMarker({ key: 'Speed', series: 'model-a' });
+     * chart.highlightMarker(data => data[2].axis);
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
+    }
+
     public async render() {
         return super.render(async () => {
             const {
@@ -776,6 +801,8 @@ export class RadarChart<TData = unknown> extends Chart<RadarChartOptions<TData>,
             onLeave: point => this.emit('markerleave', payload(point)),
             onClick: point => this.emit('markerclick', payload(point)),
         });
+
+        this.registerMark('marker', pd.axisLabel, marker, seriesId);
     }
 
 }

--- a/packages/charts/src/charts/radial-bar.ts
+++ b/packages/charts/src/charts/radial-bar.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -192,6 +194,27 @@ export class RadialBarChart<TData = unknown> extends Chart<RadialBarChartOptions
             onLeave: point => this.emit('barleave', payload(point)),
             onClick: point => this.emit('barclick', payload(point)),
         });
+
+        this.registerMark('bar', values.key, arc);
+    }
+
+    /**
+     * Highlights the ring at a key, lifting it out of its rest tint exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no bar events.
+     *
+     * @param selector - The ring's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the ring's highlight state.
+     * @returns `true` when a live ring matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightBar('Running', { tooltip: true });
+     * chart.highlightBar(data => data[0].activity);
+     * ```
+     */
+    public highlightBar(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('bar', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/charts/realtime.ts
+++ b/packages/charts/src/charts/realtime.ts
@@ -406,6 +406,8 @@ export class RealtimeChart extends Chart<RealtimeChartOptions> {
             ...updatedGroups,
         ];
 
+        this.registerHighlightGroups(this._seriesGroups);
+
         // Transition all groups (only polylines with ≥2 points)
         const transitions = this._seriesGroups.map(group => {
             const polylines = group.getElementsByType('polyline') as Polyline[];

--- a/packages/charts/src/charts/sankey.ts
+++ b/packages/charts/src/charts/sankey.ts
@@ -1,5 +1,8 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    LinkRef,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -81,6 +84,7 @@ import {
     functionIdentity,
     numberMaxOf,
     numberSum,
+    typeIsString,
 } from '@ripl/utilities';
 
 /** A directional flow between two nodes in a Sankey diagram. */
@@ -427,6 +431,46 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
         return widest > 0 ? widest + NODE_LABEL_GAP : 0;
     }
 
+    /**
+     * Highlights a node, dimming the rest of the chart exactly as hovering it does. The highlight is
+     * a one-shot command: the next render (a resize, an {@link Chart.update}, a legend toggle) or the
+     * next pointer hover restores the chart, and it emits no node events.
+     *
+     * @param selector - The node's id, a `{ key }` ref, or an accessor over the chart's nodes.
+     * @param options - What to show alongside the node's highlight state.
+     * @returns `true` when a live node matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('process', { tooltip: true });
+     * chart.highlightNode(nodes => nodes[0].id);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<SankeyNode<TData>>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.nodes), options);
+    }
+
+    /**
+     * Highlights the flow between two nodes, dimming the rest of the chart exactly as hovering it
+     * does.
+     *
+     * @param selector - The link's id (`"<source>-<target>"`), a `{ source, target }` ref naming the nodes it joins, or an accessor over the chart's links.
+     * @param options - What to show alongside the link's highlight state.
+     * @returns `true` when a live link matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightLink({ source: 'a', target: 'b' }, { tooltip: true });
+     * chart.highlightLink(links => ({ source: links[0].source, target: links[0].target }));
+     * ```
+     */
+    public highlightLink(selector: MarkSelector<SankeyLink, LinkRef>, options?: HighlightOptions): boolean {
+        const ref = this.resolveMarkSelector(selector, this.options.links);
+        const key = typeIsString(ref) ? ref : `${ref.source}->${ref.target}`;
+
+        return this.replayMark('link', key, options);
+    }
+
     public async render() {
         return super.render(async (scene, renderer) => {
             const {
@@ -719,6 +763,9 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
             onLeave: point => this.emit('linkleave', payload(point)),
             onClick: point => this.emit('linkclick', payload(point)),
         });
+
+        this.registerMark('link', link.id, linkEl);
+        this.registerMark('link', `${link.source.id}->${link.target.id}`, linkEl);
     }
 
     private _attachNodeHover(rect: Rect, node: LayoutNode<TData>, anchorX: number, anchorY: number) {
@@ -749,6 +796,8 @@ export class SankeyChart<TData = unknown> extends Chart<SankeyChartOptions<TData
             onLeave: point => this.emit('nodeleave', payload(point)),
             onClick: point => this.emit('nodeclick', payload(point)),
         });
+
+        this.registerMark('node', node.id, rect);
     }
 
 }

--- a/packages/charts/src/charts/scatter.ts
+++ b/packages/charts/src/charts/scatter.ts
@@ -12,6 +12,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ChartDataLabelsInput,
     ValueFormatInput,
 } from '../core/options';
@@ -259,6 +264,7 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
 
             return {
                 id: `${id}-${getKey(item)}`,
+                key: getKey(item),
                 seriesId: id,
                 xValue,
                 yValue,
@@ -283,7 +289,8 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
         };
     }
 
-    private _attachBubbleHover(bubble: Circle, values: { seriesId: string;
+    private _attachBubbleHover(bubble: Circle, values: { key: string;
+        seriesId: string;
         xValue: number;
         yValue: number;
         sizeValue: number; }, content: string, state: CircleState) {
@@ -321,6 +328,29 @@ export class ScatterChart<TData = unknown> extends CartesianChart<ScatterChartOp
             onLeave: point => this.emit('markerleave', payload(point)),
             onClick: point => this.emit('markerclick', payload(point)),
         });
+
+        this.registerMark('marker', values.key, bubble, values.seriesId);
+    }
+
+    /**
+     * Highlights the bubble(s) at a data key, dimming the rest of the chart exactly as hovering one
+     * does. A bare key lights that item in every series; narrow it with `{ key, series }`. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no marker events.
+     *
+     * @param selector - The item's key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the bubble's highlight state.
+     * @returns `true` when at least one live bubble matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('a', { tooltip: true, crosshair: true });
+     * chart.highlightMarker(data => data[2].id);
+     * chart.highlightMarker({ key: 'a', series: 'people' });
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     private _tooltipText(values: { label: string;

--- a/packages/charts/src/charts/stock.ts
+++ b/packages/charts/src/charts/stock.ts
@@ -11,6 +11,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ValueFormatInput,
 } from '../core/options';
 
@@ -278,6 +283,27 @@ export class StockChart<TData = unknown> extends CartesianChart<StockChartOption
                 fill: color,
             },
         });
+
+        this.registerMark('candle', values.key, body);
+    }
+
+    /**
+     * Highlights a candlestick, applying the same treatment hovering its body does. The highlight is
+     * a one-shot command: the next render (a resize, an {@link Chart.update}, a pan/zoom) or the next
+     * pointer hover restores the chart, and it emits no candle events.
+     *
+     * @param selector - The candle's key, as the chart reports it in its candle events, or an accessor over the chart's data returning one.
+     * @param options - What to show alongside the candle's highlight state.
+     * @returns `true` when a live candle matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightCandle('2026-01-03', { tooltip: true, crosshair: true });
+     * chart.highlightCandle(data => data[data.length - 1].date);
+     * ```
+     */
+    public highlightCandle(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('candle', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     private _getCandlestickValues(item: TData): CandlestickValues {

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -1,5 +1,7 @@
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -359,8 +361,8 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
     }
 
     /** Legend items are top-level nodes, so a legend hover addresses the whole branch by its series owner. */
-    protected override highlightSeries(id: string | null) {
-        super.highlightSeries(id === null ? null : `series:${id}`);
+    protected override applySeriesHighlight(id: string | null): boolean {
+        return super.applySeriesHighlight(id === null ? null : `series:${id}`);
     }
 
     private _attachSegmentHover(segment: Arc, arc: FlattenedArc<TData>) {
@@ -379,7 +381,7 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
                 data: arc.data,
             },
             // Hovering a segment isolates that node alone, unlike the legend hover the override widens.
-            onHighlight: hovered => super.highlightSeries(hovered ? `node:${arc.id}` : null),
+            onHighlight: hovered => super.applySeriesHighlight(hovered ? `node:${arc.id}` : null),
             onEnter: event => this.emit('nodeenter', event),
             onLeave: event => this.emit('nodeleave', event),
             onClick: event => this.emit('nodeclick', event),

--- a/packages/charts/src/charts/sunburst.ts
+++ b/packages/charts/src/charts/sunburst.ts
@@ -210,6 +210,27 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
         this.init();
     }
 
+    /**
+     * Highlights a segment by node id, dimming every other segment exactly as hovering it does. Only
+     * that node lights, not its branch — a legend hover is what widens the highlight to a whole
+     * subtree. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no node events.
+     *
+     * @param selector - The node's id, a `{ key }` ref, or an accessor over the chart's root nodes.
+     * @param options - What to show alongside the segment's highlight state.
+     * @returns `true` when a live segment matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('ops', { tooltip: true });
+     * chart.highlightNode(nodes => nodes[0].id);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<SunburstNode<TData>>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.data), options);
+    }
+
     public async render() {
         return super.render(async (scene, renderer) => {
             const { data, padWidth = DEFAULT_SEGMENT_PAD_WIDTH } = this.options;
@@ -386,6 +407,8 @@ export class SunburstChart<TData = unknown> extends Chart<SunburstChartOptions<T
             onLeave: event => this.emit('nodeleave', event),
             onClick: event => this.emit('nodeclick', event),
         });
+
+        this.registerMark('node', arc.id, segment);
     }
 
 }

--- a/packages/charts/src/charts/treemap.ts
+++ b/packages/charts/src/charts/treemap.ts
@@ -4,6 +4,8 @@ import type {
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkSelector,
 } from '../core/chart';
 
 import {
@@ -218,6 +220,25 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
         });
 
         this.init();
+    }
+
+    /**
+     * Highlights the cell at a key, lifting it out of its rest tint exactly as hovering it does. The
+     * highlight is a one-shot command: the next render (a resize, an {@link Chart.update}, a legend
+     * toggle) or the next pointer hover restores the chart, and it emits no node events.
+     *
+     * @param selector - The cell's key, a `{ key }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the cell's highlight state.
+     * @returns `true` when a live cell matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightNode('Rent', { tooltip: true });
+     * chart.highlightNode(data => data[0].name);
+     * ```
+     */
+    public highlightNode(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('node', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {
@@ -468,6 +489,8 @@ export class TreemapChart<TData = unknown> extends Chart<TreemapChartOptions<TDa
             onLeave: point => this.emit('nodeleave', payload(point)),
             onClick: point => this.emit('nodeclick', payload(point)),
         });
+
+        this.registerMark('node', node.key, rect);
     }
 
 }

--- a/packages/charts/src/charts/trend.ts
+++ b/packages/charts/src/charts/trend.ts
@@ -11,6 +11,11 @@ import {
 } from '../core/cartesian';
 
 import type {
+    HighlightOptions,
+    MarkSelector,
+} from '../core/chart';
+
+import type {
     ChartDataLabelsInput,
     LineStyleInput,
     ValueFormatInput,
@@ -297,7 +302,50 @@ export class TrendChart<TData = unknown> extends CartesianChart<TrendChartOption
             dataLabels: normalizeDataLabels(this.options.labels, { anchor: 'top' }),
             addContent: elements => this.addPlotContent(elements),
             emit,
+            registerMark: (kind, key, element, series) => this.registerMark(kind, key, element, series),
         };
+    }
+
+    /**
+     * Highlights the bar(s) at a category key, dimming the rest of the chart exactly as hovering one
+     * does. Only bar series are matched — use {@link TrendChart.highlightMarker} for the line and area
+     * points at the same key. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no bar events.
+     *
+     * @param selector - The bar's category key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the bar's highlight state.
+     * @returns `true` when at least one live bar matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightBar('Q3', { tooltip: true });
+     * chart.highlightBar({ key: 'Q3', series: 'revenue' });
+     * ```
+     */
+    public highlightBar(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('bar', this.resolveMarkSelector(selector, this.options.data), options);
+    }
+
+    /**
+     * Highlights the line/area marker(s) at a category key, dimming the rest of the chart exactly as
+     * hovering one does. Only line and area series are matched — use {@link TrendChart.highlightBar}
+     * for the bars at the same key. The highlight is a one-shot command: the next render (a resize, an
+     * {@link Chart.update}, a legend toggle) or the next pointer hover restores the chart, and it
+     * emits no marker events. Markers hidden with `markers: false` are not highlightable.
+     *
+     * @param selector - The marker's category key, a `{ key, series }` ref, or an accessor over the chart's data.
+     * @param options - What to show alongside the marker's highlight state.
+     * @returns `true` when at least one live marker matched, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightMarker('Q3', { tooltip: true, crosshair: true });
+     * chart.highlightMarker({ key: 'Q3', series: 'margin' });
+     * ```
+     */
+    public highlightMarker(selector: MarkSelector<TData>, options?: HighlightOptions): boolean {
+        return this.replayMark('marker', this.resolveMarkSelector(selector, this.options.data), options);
     }
 
     public async render() {

--- a/packages/charts/src/components/legend.ts
+++ b/packages/charts/src/components/legend.ts
@@ -23,10 +23,12 @@ import type {
 } from '../core/animation';
 
 import {
+    ANIMATION_REFERENCE,
     exitElement,
 } from '../core/animation';
 
 import type {
+    Element,
     Group,
     Rect,
     Text,
@@ -84,6 +86,8 @@ const DEFAULT_FONT_SIZE = 11;
 const DEFAULT_PADDING = SPACING.md;
 const INACTIVE_COLOR = '#cccccc';
 const INACTIVE_LABEL_COLOR = '#999999';
+const INACTIVE_OPACITY = 0.5;
+const HIGHLIGHT_DIM_OPACITY = 0.3;
 
 interface ItemPlacement {
     item: LegendItem;
@@ -115,6 +119,8 @@ export class Legend extends ChartComponent {
     private _onToggle?: (item: LegendItem, active: boolean) => void;
     private _onHighlight?: (id: string | null) => void;
     private _labelWidthCache = new Map<string, number>();
+    private _animation?: ResolvedAnimation;
+    private _highlightedId: string | null = null;
 
     constructor(options: LegendOptions) {
         super(options);
@@ -155,6 +161,67 @@ export class Legend extends ChartComponent {
     /** Updates the legend items, replacing the previous set. */
     public update(items: LegendItem[]) {
         this._items = items;
+    }
+
+    /**
+     * Dims every entry except the one at `id` — swatch and label alike — so a highlighted series
+     * reads in the legend as well as in the plot, or restores them all when `id` is `null`. The dim
+     * scales each entry's own rest opacity, so an entry toggled off stays visibly inactive
+     * underneath the highlight. No-ops when `id` is already the highlighted one, since the pointer
+     * events driving a legend hover repeat it.
+     *
+     * @param id - The {@link LegendItem.id} to isolate, or `null` to restore every entry.
+     */
+    public setHighlight(id: string | null): void {
+        if (id === this._highlightedId) {
+            return;
+        }
+
+        this._highlightedId = id;
+
+        const group = this._group;
+
+        if (!group) {
+            return;
+        }
+
+        const elements = this._items
+            .flatMap(item => [
+                group.getElementById(`legend-swatch-${item.id}`),
+                group.getElementById(`legend-label-${item.id}`),
+            ])
+            .filter((element): element is Element => !!element);
+
+        if (elements.length === 0) {
+            return;
+        }
+
+        const animation = this._animation;
+
+        if (!animation?.enabled) {
+            elements.forEach(element => {
+                element.opacity = this._highlightOpacity(element);
+            });
+
+            this.renderer.start();
+            return;
+        }
+
+        this.renderer.transition(elements, element => ({
+            duration: ANIMATION_REFERENCE.hover,
+            ease: animation.ease,
+            state: {
+                opacity: this._highlightOpacity(element),
+            },
+        }));
+    }
+
+    private _highlightOpacity(element: Element): number {
+        const item = element.data as LegendItem;
+        const dimmed = this._highlightedId !== null && item.id !== this._highlightedId;
+        const rest = element.type === 'rect' && item.active === false ? INACTIVE_OPACITY : 1;
+
+        return dimmed ? rest * HIGHLIGHT_DIM_OPACITY : rest;
     }
 
     private get _fontHeight(): number {
@@ -278,6 +345,11 @@ export class Legend extends ChartComponent {
     }
 
     private _draw(region: ChartArea, animation?: ResolvedAnimation) {
+        this._animation = animation;
+
+        // Every entry is settled at its rest opacity below, so any active dim is gone.
+        this._highlightedId = null;
+
         if (!this._group) {
             this._group = createGroup({
                 id: 'legend',
@@ -324,7 +396,7 @@ export class Legend extends ChartComponent {
         entries.forEach(placement => {
             const { item } = placement;
             const isActive = item.active !== false;
-            const restOpacity = isActive ? 1 : 0.5;
+            const restOpacity = isActive ? 1 : INACTIVE_OPACITY;
 
             const swatch = createRect({
                 id: `legend-swatch-${item.id}`,
@@ -371,7 +443,7 @@ export class Legend extends ChartComponent {
                 this.renderer.transition([swatch, label], element => ({
                     duration: animation.duration,
                     ease: animation.ease,
-                    state: { opacity: element.type === 'rect' && !isActive ? 0.5 : 1 },
+                    state: { opacity: element.type === 'rect' && !isActive ? INACTIVE_OPACITY : 1 },
                 }));
             }
         });
@@ -400,7 +472,7 @@ export class Legend extends ChartComponent {
                     state: {
                         x: target.swatchX,
                         y: target.swatchY,
-                        opacity: isActive ? 1 : 0.5,
+                        opacity: isActive ? 1 : INACTIVE_OPACITY,
                     },
                 });
 
@@ -418,7 +490,7 @@ export class Legend extends ChartComponent {
             } else {
                 swatch.x = target.swatchX;
                 swatch.y = target.swatchY;
-                swatch.opacity = isActive ? 1 : 0.5;
+                swatch.opacity = isActive ? 1 : INACTIVE_OPACITY;
 
                 if (label) {
                     label.x = target.labelX;

--- a/packages/charts/src/components/legend.ts
+++ b/packages/charts/src/components/legend.ts
@@ -28,6 +28,7 @@ import {
 } from '../core/animation';
 
 import type {
+    Ease,
     Element,
     Group,
     Rect,
@@ -44,6 +45,14 @@ import {
     arrayJoin,
     stringUniqueId,
 } from '@ripl/utilities';
+
+/** Timing for the legend's highlight dim, resolved by the host chart so it scales with the chart's animation options. */
+export interface LegendHighlightAnimation {
+    /** Duration of the dim, in milliseconds; a non-positive value settles the entries immediately. */
+    duration: number;
+    /** Easing applied to the dim. */
+    ease: Ease;
+}
 
 /** A single legend entry with id, label, color, and active state. */
 export interface LegendItem {
@@ -171,9 +180,12 @@ export class Legend extends ChartComponent {
      * events driving a legend hover repeat it.
      *
      * @param id - The {@link LegendItem.id} to isolate, or `null` to restore every entry.
+     * @param animation - Timing for the dim, resolved by the host so it scales with the chart's
+     * animation options; a non-positive duration settles the entries immediately.
      */
-    public setHighlight(id: string | null): void {
-        if (id === this._highlightedId) {
+    public setHighlight(id: string | null, animation?: LegendHighlightAnimation): void {
+        // An immediate call still settles: it exists to cut short a dim another call left in flight.
+        if (id === this._highlightedId && (animation?.duration ?? 1) > 0) {
             return;
         }
 
@@ -196,9 +208,14 @@ export class Legend extends ChartComponent {
             return;
         }
 
-        const animation = this._animation;
+        const timing = animation ?? (this._animation?.enabled
+            ? {
+                duration: ANIMATION_REFERENCE.hover,
+                ease: this._animation.ease,
+            }
+            : undefined);
 
-        if (!animation?.enabled) {
+        if (!timing || timing.duration <= 0) {
             elements.forEach(element => {
                 element.opacity = this._highlightOpacity(element);
             });
@@ -208,8 +225,8 @@ export class Legend extends ChartComponent {
         }
 
         this.renderer.transition(elements, element => ({
-            duration: ANIMATION_REFERENCE.hover,
-            ease: animation.ease,
+            duration: timing.duration,
+            ease: timing.ease,
             state: {
                 opacity: this._highlightOpacity(element),
             },

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -10,6 +10,8 @@
 
 import type {
     BaseChartOptions,
+    HighlightOptions,
+    MarkRef,
 } from './chart';
 
 import {
@@ -294,6 +296,12 @@ export abstract class CartesianChart<
     protected crosshair?: Crosshair;
     private _annotations?: ChartAnnotations;
     private _setup: CartesianSetup = {};
+
+    // The live shared axis tooltip, so a programmatic highlight can replay the snapshot a hover would show.
+    private _axisTooltip?: {
+        plot: ChartArea;
+        resolve: (plotX: number, plotY: number) => AxisTooltipSnapshot | null;
+    };
 
     private _navigator?: DOMNavigator;
     private _navigatorConfigKey?: string;
@@ -1234,6 +1242,95 @@ export abstract class CartesianChart<
     }
 
     /**
+     * Places the crosshair at a chart position, exactly as moving the pointer there would (it hides
+     * itself outside the plot bounds it was set up with). Only the axes the crosshair was configured
+     * for are drawn, and it is a silent no-op on charts without one. The next pointer move reclaims
+     * it, so this is for a momentary programmatic placement rather than a persistent one.
+     *
+     * @param x - The x coordinate to place the crosshair at, in chart pixels.
+     * @param y - The y coordinate to place the crosshair at, in chart pixels.
+     */
+    protected showCrosshairAt(x: number, y: number): void {
+        if (!this.crosshair) {
+            return;
+        }
+
+        this.crosshair.show(x, y);
+        // The lines are written directly rather than transitioned, so an idle loop needs waking to paint them.
+        this.renderer.start();
+    }
+
+    /**
+     * Replays a mark's hover treatment (see {@link Chart.replayMark}) and, when asked, adds the
+     * furniture a hover would bring with it: the crosshair on the mark, and — in `trigger: 'axis'`
+     * mode, where the marks themselves are wired without tooltips — the shared multi-row axis tooltip
+     * resolved at the mark's anchor.
+     */
+    protected override replayMark(kind: string, selector: string | MarkRef, options?: HighlightOptions): boolean {
+        if (!super.replayMark(kind, selector, options)) {
+            return false;
+        }
+
+        const anchor = this.activeMarks[0]?.anchor();
+
+        if (!anchor) {
+            return true;
+        }
+
+        if (options?.crosshair) {
+            this.showCrosshairAt(anchor.x, anchor.y);
+        }
+
+        if (options?.tooltip) {
+            this._showAxisTooltipAt(anchor.x, anchor.y);
+        }
+
+        return true;
+    }
+
+    /**
+     * Restores everything a programmatic highlight changed (see {@link Chart.clearHighlight}), plus
+     * the crosshair and shared axis tooltip it placed. Pointer-driven furniture is left alone: the
+     * crosshair and axis tooltip both track the pointer, so a hover reclaims them on its own.
+     */
+    public override clearHighlight(): void {
+        if (this.activeMarks.length > 0) {
+            this.crosshair?.hide();
+            this.tooltip?.hide();
+        }
+
+        super.clearHighlight();
+    }
+
+    /** Shows the shared axis tooltip's snapshot at a plot position, returning whether there was one to show. */
+    private _showAxisTooltipAt(x: number, y: number): boolean {
+        const axisTooltip = this._axisTooltip;
+
+        if (!axisTooltip) {
+            return false;
+        }
+
+        const { plot } = axisTooltip;
+
+        if (x < plot.x || x > plot.x + plot.width || y < plot.y || y > plot.y + plot.height) {
+            return false;
+        }
+
+        const snapshot = axisTooltip.resolve(x, y);
+
+        if (!snapshot) {
+            return false;
+        }
+
+        this.tooltip?.show(snapshot.x, snapshot.y, [
+            snapshot.title,
+            ...snapshot.rows.map(row => `${row.label}: ${row.value}`),
+        ].join('\n'));
+
+        return true;
+    }
+
+    /**
      * Wires the shared axis tooltip (`tooltip.trigger: 'axis'`) for the current render: while the
      * pointer is inside the plot, the resolver maps its position to the hovered category and the
      * tooltip shows the title plus one row per active series, anchored at the snapshot point.
@@ -1245,37 +1342,23 @@ export abstract class CartesianChart<
      */
     protected setupAxisTooltip(plot: ChartArea, resolve: (plotX: number, plotY: number) => AxisTooltipSnapshot | null): void {
         this.dispose(AXIS_TOOLTIP_EVENTS_KEY);
+        this._axisTooltip = undefined;
 
         if (this.tooltipTrigger !== 'axis' || !this.tooltip) {
             return;
         }
 
-        const contains = (x: number, y: number) => x >= plot.x
-            && x <= plot.x + plot.width
-            && y >= plot.y
-            && y <= plot.y + plot.height;
+        this._axisTooltip = {
+            plot,
+            resolve,
+        };
 
         this.retain(this.scene.context.on('mousemove', event => {
             const { x, y } = event.data;
 
-            if (!contains(x, y)) {
+            if (!this._showAxisTooltipAt(x, y)) {
                 this.tooltip?.hide();
-                return;
             }
-
-            const snapshot = resolve(x, y);
-
-            if (!snapshot) {
-                this.tooltip?.hide();
-                return;
-            }
-
-            const content = [
-                snapshot.title,
-                ...snapshot.rows.map(row => `${row.label}: ${row.value}`),
-            ].join('\n');
-
-            this.tooltip?.show(snapshot.x, snapshot.y, content);
         }), AXIS_TOOLTIP_EVENTS_KEY);
 
         this.retain(this.scene.context.on('mouseleave', () => {

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -663,15 +663,19 @@ export class Chart<
      * @returns `true` when the id matched at least one registered group (always `true` for `null`).
      */
     protected applySeriesHighlight(id: string | null): boolean {
-        this._activeHighlight = id;
-
         if (this._highlightGroups.length === 0) {
+            this._activeHighlight = id;
             return false;
         }
 
+        // Dimming for an id no group owns would leave the whole chart dimmed with nothing tracking the restore.
+        if (id !== null && !this._highlightGroups.some(({ owners }) => highlightOwnersInclude(owners, id))) {
+            return false;
+        }
+
+        this._activeHighlight = id;
         this.legend?.setHighlight(id);
 
-        const matched = id === null || this._highlightGroups.some(({ owners }) => highlightOwnersInclude(owners, id));
         const { duration, ease } = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         this._highlightGroups.forEach(({ group, owners }) => {
@@ -702,7 +706,7 @@ export class Chart<
             });
         });
 
-        return matched;
+        return true;
     }
 
     /**

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -669,6 +669,8 @@ export class Chart<
             return false;
         }
 
+        this.legend?.setHighlight(id);
+
         const matched = id === null || this._highlightGroups.some(({ owners }) => highlightOwnersInclude(owners, id));
         const { duration, ease } = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -80,6 +80,14 @@ import {
     resolveAnimation,
 } from './animation';
 
+import type {
+    MarkInteraction,
+} from './interaction';
+
+import {
+    getMarkInteraction,
+} from './interaction';
+
 import {
     ChartTitle,
 } from '../components/title';
@@ -100,6 +108,7 @@ import {
     typeIsArray,
     typeIsFunction,
     typeIsNumber,
+    typeIsString,
 } from '@ripl/utilities';
 
 if (!factory.createContext) {
@@ -130,6 +139,48 @@ export interface BaseChartOptions {
     theme?: string | Theme;
     /** Accessible description announced by screen readers (sets the rendering element's ARIA label). Defaults to the title text. */
     description?: string;
+}
+
+/** Identifies a mark: its key — the same key the chart reports in its events — optionally narrowed to a series. */
+export interface MarkRef {
+    /** The mark's key, exactly as the chart reports it in the mark's interaction events. */
+    key: string;
+    /** The series the mark belongs to. Omit to select the mark at that key in every series. */
+    series?: string;
+}
+
+/** Identifies a link mark by the nodes it joins. */
+export interface LinkRef {
+    /** Id of the node the link leaves. */
+    source: string;
+    /** Id of the node the link enters. */
+    target: string;
+}
+
+/** Identifies a heatmap cell by its axis labels. */
+export interface CellRef {
+    /** The cell's x-axis label. */
+    x: string;
+    /** The cell's y-axis label. */
+    y: string;
+}
+
+/**
+ * Selects one or more marks: a key, the chart's ref shape narrowing it, or an accessor receiving the
+ * chart's dataset and returning either — so a mark can be addressed by position in the data
+ * (`data => data[2].id`) without the caller tracking keys itself.
+ *
+ * @typeParam TData - The chart's datum type, as passed to its `data` option.
+ * @typeParam TRef - The ref shape the chart's marks are addressed by. Defaults to {@link MarkRef}.
+ */
+export type MarkSelector<TData = unknown, TRef = MarkRef> = string | TRef | ((data: TData[]) => string | TRef);
+
+/** Controls what a programmatic highlight shows alongside the mark's own highlight state. */
+export interface HighlightOptions {
+    /** Also show the mark's tooltip, anchored where hovering it would. Defaults to `false`. */
+    tooltip?: boolean;
+    /** Also place the crosshair on the mark. Only the axes the crosshair was configured for are drawn; ignored on charts without one. Defaults to `false`. */
+    crosshair?: boolean;
 }
 
 /** Opacity applied to non-highlighted series/segments while a legend item is hovered. */
@@ -212,6 +263,9 @@ export class Chart<
         owners: string | string[]; }> = [];
     private _highlightDisposers: Disposable[] = [];
     private _activeHighlight: string | null = null;
+    private _markRegistry: Map<string, Element[]> = new Map();
+    private _activeMarks: MarkInteraction[] = [];
+    private _programmaticSeries: boolean = false;
 
     /** The rendering context the chart's scene draws into. */
     public get context(): Context {
@@ -428,7 +482,7 @@ export class Chart<
                 itemPadding,
                 highlight: legendOpts.highlight,
                 onToggle: (item, active) => this.setItemActive(item.id, active),
-                onHighlight: id => this.highlightSeries(id),
+                onHighlight: id => this.applySeriesHighlight(id),
             });
         } else {
             this.legend.setOptions({
@@ -503,6 +557,10 @@ export class Chart<
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public async render(callback?: (scene: Scene, renderer: Renderer) => Promise<any>) {
+        // A programmatic highlight is a one-shot command, so a render restores the chart before redrawing it.
+        this.clearHighlight();
+        this._markRegistry.clear();
+
         try {
             await callback?.(this.scene, this.renderer);
         } catch (error) {
@@ -549,7 +607,7 @@ export class Chart<
     }
 
     /**
-     * Registers the groups that {@link highlightSeries} dims when a legend entry is hovered. Charts
+     * Registers the groups that {@link Chart.highlightSeries} dims when a legend entry is hovered. Charts
      * call this each render. By default a group belongs to the legend item whose id equals its
      * `group.id` (one-to-one). Pass `resolveId` when a group belongs to a different legend item, or
      * to several, e.g. a cluster legend (many node groups per legend item) or a connector that is
@@ -585,13 +643,14 @@ export class Chart<
             return;
         }
 
-        this.highlightSeries(null);
+        this._programmaticSeries = false;
+        this.applySeriesHighlight(null);
     }
 
     /**
      * Highlights a single series/segment by id (dimming the others), or restores all when `null`.
-     * Wired to legend hover via {@link reserveLegend}. No-ops for charts that never registered
-     * highlight groups.
+     * Wired to legend hover via {@link reserveLegend}, and to {@link Chart.highlightSeries} for the
+     * public one-shot command. No-ops for charts that never registered highlight groups.
      *
      * Dims the leaf elements of each group rather than the group itself: a group's opacity does not
      * cascade multiplicatively, and the leaves carry no explicit `opacity` (so a group-level tween is
@@ -599,14 +658,18 @@ export class Chart<
      * on the element (via a Symbol slot, like `applyHoverHighlight`), tracking the target a render
      * stashed on `.data` where there is one, so hidden elements stay hidden, an element caught
      * mid-fade-in still restores to full, and restoring returns to the true value.
+     *
+     * @param id - The legend item id to isolate, or `null` to restore every group.
+     * @returns `true` when the id matched at least one registered group (always `true` for `null`).
      */
-    protected highlightSeries(id: string | null) {
+    protected applySeriesHighlight(id: string | null): boolean {
         this._activeHighlight = id;
 
         if (this._highlightGroups.length === 0) {
-            return;
+            return false;
         }
 
+        const matched = id === null || this._highlightGroups.some(({ owners }) => highlightOwnersInclude(owners, id));
         const { duration, ease } = this.resolveAnimation(ANIMATION_REFERENCE.hover);
 
         this._highlightGroups.forEach(({ group, owners }) => {
@@ -636,6 +699,158 @@ export class Chart<
                 });
             });
         });
+
+        return matched;
+    }
+
+    /**
+     * Registers a rendered mark so {@link Chart.replayMark} can address it by key. Charts call this
+     * beside the `applyHoverHighlight` call that makes the mark interactive, keying it by the same
+     * value they report in the mark's interaction events. Passing `series` registers the mark twice:
+     * once under the bare key (which selects that key across every series) and once narrowed to the
+     * series. The registry is dropped at the top of every render.
+     *
+     * @param kind - The mark family, matching the chart's highlight method (e.g. `'bar'`, `'marker'`, `'node'`).
+     * @param key - The mark's key, exactly as the chart reports it in the mark's interaction events.
+     * @param element - The element carrying the mark's replayable hover treatment.
+     * @param series - The series the mark belongs to, for multi-series charts.
+     */
+    protected registerMark(kind: string, key: string, element: Element, series?: string): void {
+        this._addMark(`${kind}:${key}`, element);
+
+        if (series !== undefined) {
+            this._addMark(`${kind}:${series}:${key}`, element);
+        }
+    }
+
+    private _addMark(id: string, element: Element): void {
+        const elements = this._markRegistry.get(id);
+
+        if (elements) {
+            elements.push(element);
+            return;
+        }
+
+        this._markRegistry.set(id, [element]);
+    }
+
+    /**
+     * Replays the hover treatment of every mark matching a selector, as the chart's typed highlight
+     * methods do. Accessor selectors are resolved by those methods (with
+     * {@link Chart.resolveMarkSelector}) before they get here, so this stays free of the chart's
+     * datum type. Silent by design: the mark's highlight state, chart-wide dim and tooltip are
+     * applied, but no interaction event is emitted.
+     *
+     * @param kind - The mark family the selector addresses, as passed to {@link Chart.registerMark}.
+     * @param selector - A registered key, or a {@link MarkRef} narrowing it to one series.
+     * @param options - What to show alongside the mark's highlight state.
+     * @returns `true` when at least one live mark matched, `false` when nothing changed.
+     */
+    protected replayMark(kind: string, selector: string | MarkRef, options?: HighlightOptions): boolean {
+        const ref = typeIsString(selector) ? { key: selector } as MarkRef : selector;
+        const id = ref.series === undefined
+            ? `${kind}:${ref.key}`
+            : `${kind}:${ref.series}:${ref.key}`;
+
+        const marks = (this._markRegistry.get(id) ?? [])
+            // A mark mid-exit is detached; transitioning it would never complete and would pin the render loop.
+            .filter(element => !!element.parent)
+            .map(element => getMarkInteraction(element))
+            .filter((mark): mark is MarkInteraction => !!mark);
+
+        if (marks.length === 0) {
+            return false;
+        }
+
+        this.clearHighlight();
+
+        const showTooltip = options?.tooltip ?? false;
+        const content = showTooltip
+            ? marks.map(mark => mark.content()).filter(line => !!line).join('\n') || undefined
+            : undefined;
+
+        marks.forEach((mark, index) => mark.enter({
+            tooltip: showTooltip && index === 0,
+            content: index === 0 ? content : undefined,
+            onTakeover: () => this._releaseHighlight(),
+        }));
+
+        this._activeMarks = marks;
+
+        return true;
+    }
+
+    /**
+     * Resolves a selector's accessor form against the chart's data. Charts call this in their typed
+     * highlight methods, where the datum type is known, before handing the result to
+     * {@link Chart.replayMark}.
+     *
+     * @typeParam TData - The chart's datum type.
+     * @typeParam TRef - The ref shape the chart's marks are addressed by.
+     * @param selector - The selector the caller passed.
+     * @param data - The dataset an accessor selector is called with.
+     * @returns The key or ref the selector resolves to.
+     */
+    protected resolveMarkSelector<TData, TRef>(selector: MarkSelector<TData, TRef>, data: TData[]): string | TRef {
+        return typeIsFunction(selector)
+            ? (selector as (data: TData[]) => string | TRef)(data)
+            : selector as string | TRef;
+    }
+
+    /** The mark handles the active programmatic highlight is holding, in match order. Empty when none is active. */
+    protected get activeMarks(): readonly MarkInteraction[] {
+        return this._activeMarks;
+    }
+
+    /** Drops the bookkeeping for a highlight whose marks have already been restored (e.g. by a pointer taking over). */
+    private _releaseHighlight(): void {
+        this._activeMarks = [];
+
+        if (this._programmaticSeries) {
+            this._programmaticSeries = false;
+            this.applySeriesHighlight(null);
+        }
+    }
+
+    /**
+     * Highlights a series by id — dimming every other series, exactly as hovering its legend entry
+     * does — and returns whether the id matched. The highlight is a one-shot command: the next
+     * render (a resize, an {@link Chart.update}, a legend toggle) restores the chart, and it emits
+     * no interaction events.
+     *
+     * @param id - The series or segment id, as the chart reports it in its events and legend items.
+     * @returns `true` when the id matched a highlightable series, `false` when nothing changed.
+     *
+     * @example
+     * ```ts
+     * chart.highlightSeries('revenue');
+     * chart.clearHighlight();
+     * ```
+     */
+    public highlightSeries(id: string): boolean {
+        this.clearHighlight();
+
+        this._programmaticSeries = this.applySeriesHighlight(id);
+
+        return this._programmaticSeries;
+    }
+
+    /**
+     * Restores everything a programmatic highlight changed — the highlighted marks, the chart-wide
+     * dim and any tooltip it opened — synchronously, leaving no transition behind. Hover highlights
+     * are untouched, and calling it with nothing highlighted is a no-op.
+     */
+    public clearHighlight(): void {
+        const marks = this._activeMarks;
+
+        if (marks.length === 0 && !this._programmaticSeries) {
+            return;
+        }
+
+        this._activeMarks = [];
+        marks.forEach(mark => mark.leave({ duration: 0 }));
+
+        this._releaseHighlight();
     }
 
     /** Exports a snapshot of the chart's rendered context (image, url, or string). See {@link Context.export}. */

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -660,9 +660,11 @@ export class Chart<
      * mid-fade-in still restores to full, and restoring returns to the true value.
      *
      * @param id - The legend item id to isolate, or `null` to restore every group.
+     * @param immediate - Settle the groups and legend at their target opacity without transitioning,
+     * so a caller that exports straight afterwards captures the chart at rest.
      * @returns `true` when the id matched at least one registered group (always `true` for `null`).
      */
-    protected applySeriesHighlight(id: string | null): boolean {
+    protected applySeriesHighlight(id: string | null, immediate: boolean = false): boolean {
         if (this._highlightGroups.length === 0) {
             this._activeHighlight = id;
             return false;
@@ -673,10 +675,14 @@ export class Chart<
             return false;
         }
 
-        this._activeHighlight = id;
-        this.legend?.setHighlight(id);
-
         const { duration, ease } = this.resolveAnimation(ANIMATION_REFERENCE.hover);
+        const timing = {
+            duration: immediate ? 0 : duration,
+            ease,
+        };
+
+        this._activeHighlight = id;
+        this.legend?.setHighlight(id, timing);
 
         this._highlightGroups.forEach(({ group, owners }) => {
             const active = id === null || highlightOwnersInclude(owners, id);
@@ -696,15 +702,26 @@ export class Chart<
                 // Seed a concrete opacity only where there is none, or a fade-in would snap to full.
                 element.opacity ??= rest;
 
+                const state = {
+                    opacity: active ? rest : rest * HIGHLIGHT_DIM_OPACITY,
+                };
+
+                if (immediate) {
+                    // A zero-duration transition lands a frame later, so write the state and paint it.
+                    element.interpolate(state)(1);
+                    return;
+                }
+
                 this.renderer.transition(element, {
-                    duration,
-                    ease,
-                    state: {
-                        opacity: active ? rest : rest * HIGHLIGHT_DIM_OPACITY,
-                    },
+                    ...timing,
+                    state,
                 });
             });
         });
+
+        if (immediate) {
+            this.renderer.start();
+        }
 
         return true;
     }
@@ -856,7 +873,9 @@ export class Chart<
         this._activeMarks = [];
         marks.forEach(mark => mark.leave({ duration: 0 }));
 
-        this._releaseHighlight();
+        // A mark's own chart-wide restore animates, so settle it too or the chart is still moving on return.
+        this._programmaticSeries = false;
+        this.applySeriesHighlight(null, true);
     }
 
     /** Exports a snapshot of the chart's rendered context (image, url, or string). See {@link Context.export}. */

--- a/packages/charts/src/core/interaction.ts
+++ b/packages/charts/src/core/interaction.ts
@@ -5,6 +5,10 @@
  * each registered a fresh `mouseleave` listener *inside* every `mouseenter` handler, a bug that
  * leaked and accumulated listeners on every re-render. This helper registers each listener once
  * and disposes any previous registration when re-applied to a persistent element.
+ *
+ * It also attaches a {@link MarkInteraction} handle to the element, built from the same closures the
+ * listeners use and read back with {@link getMarkInteraction}, so a chart's programmatic highlight
+ * replays exactly what a hover does instead of reimplementing it.
  */
 
 import type {
@@ -14,7 +18,12 @@ import type {
     Element,
     ElementInterpolationState,
     Renderer,
+    Transition,
 } from '@ripl/core';
+
+import {
+    functionNoop,
+} from '@ripl/utilities';
 
 /** Minimal tooltip surface required by the hover helper (decouples it from the Tooltip class). */
 export interface HoverTooltip {
@@ -60,12 +69,50 @@ export interface HoverHighlightOptions {
     };
     /** Resolves the tooltip content (called on enter). */
     content?: () => string;
+    /**
+     * Toggles the chart-wide highlight for this element, called with `true` when it is highlighted
+     * and `false` when it is restored. Unlike `onEnter`/`onLeave` it fires for a programmatic
+     * highlight too, so code-driven highlights dim the rest of the chart exactly as hover does.
+     */
+    onHighlight?: (highlighted: boolean) => void;
     /** Called when the pointer enters the element, with the current pointer position. */
     onEnter?: (point: InteractionPoint) => void;
     /** Called when the pointer leaves the element, with the last known pointer position. */
     onLeave?: (point: InteractionPoint) => void;
     /** Called when the element is clicked, with the pointer position. */
     onClick?: (point: InteractionPoint) => void;
+}
+
+/** Overrides for a single {@link MarkInteraction} enter or leave. */
+export interface MarkInteractionOptions {
+    /** Whether the mark's tooltip is shown (on enter) or hidden (on leave). Defaults to `true`, matching hover. */
+    tooltip?: boolean;
+    /** Tooltip content to show in place of the mark's own — e.g. the joined content of several matched marks. */
+    content?: string;
+    /** Transition duration in milliseconds, overriding the timing the chart's `animation` thunk resolves. `0` applies the state synchronously, scheduling no transition. */
+    duration?: number;
+    /** Called after a pointer has taken this highlight over and the mark has been restored, so the caller can drop its bookkeeping. Only meaningful on {@link MarkInteraction.enter}. */
+    onTakeover?: () => void;
+}
+
+/**
+ * The replayable face of a mark's hover treatment, attached by {@link applyHoverHighlight} and read
+ * back with {@link getMarkInteraction}. The element's own `mouseenter`/`mouseleave` handlers drive
+ * it too, so a programmatic highlight and a hover run the same code path.
+ */
+export interface MarkInteraction {
+    /**
+     * Applies the highlight state, fires the chart-wide highlight and, when asked, shows the mark's
+     * tooltip. Returns `false` — having mutated nothing — when the mark is no longer attached to the
+     * scene, since transitioning a detached element would never complete.
+     */
+    enter(options?: MarkInteractionOptions): boolean;
+    /** Restores the rest state, releases the chart-wide highlight and hides the tooltip. */
+    leave(options?: MarkInteractionOptions): void;
+    /** The mark's tooltip anchor, or `undefined` when it has none. */
+    anchor(): InteractionPoint | undefined;
+    /** The mark's tooltip content, or `undefined` when it has none. */
+    content(): string | undefined;
 }
 
 /**
@@ -87,15 +134,43 @@ export type HoverHighlightStates<TElement extends Element> = {
 };
 
 const HOVER_DISPOSERS = Symbol('hover-disposers');
+const MARK_INTERACTION = Symbol('mark-interaction');
 
 interface HoverHost {
     [HOVER_DISPOSERS]?: { dispose(): void }[];
+    [MARK_INTERACTION]?: MarkInteraction;
+}
+
+/** Programmatic highlights in flight, per renderer, so a pointer entering any mark can take them over. */
+const PROGRAMMATIC_HIGHLIGHTS = new WeakMap<Renderer, Set<() => void>>();
+
+function releaseProgrammaticHighlights(renderer: Renderer): void {
+    const active = PROGRAMMATIC_HIGHLIGHTS.get(renderer);
+
+    if (!active?.size) {
+        return;
+    }
+
+    PROGRAMMATIC_HIGHLIGHTS.delete(renderer);
+    Array.from(active).forEach(release => release());
 }
 
 /**
- * Wires consistent hover behavior (highlight transition + optional tooltip) onto an element.
- * Safe to call repeatedly on the same persistent element across renders; prior listeners are
- * disposed first so handlers never accumulate.
+ * Returns the replayable hover treatment {@link applyHoverHighlight} attached to an element, or
+ * `undefined` when the element has none (it was never made interactive, or its markers are off).
+ *
+ * @param element - The element to read the handle from.
+ * @returns The element's {@link MarkInteraction}, or `undefined`.
+ */
+export function getMarkInteraction(element: Element): MarkInteraction | undefined {
+    return (element as unknown as HoverHost)[MARK_INTERACTION];
+}
+
+/**
+ * Wires consistent hover behavior (highlight transition + optional tooltip) onto an element, and
+ * attaches the {@link MarkInteraction} handle that replays it on demand. Safe to call repeatedly on
+ * the same persistent element across renders; prior listeners are disposed and the previous handle
+ * replaced, so handlers never accumulate.
  */
 export function applyHoverHighlight<TElement extends Element>(
     element: TElement,
@@ -113,6 +188,7 @@ export function applyHoverHighlight<TElement extends Element>(
         tooltip,
         anchor,
         content,
+        onHighlight,
         onEnter,
         onLeave,
         onClick,
@@ -138,43 +214,110 @@ export function applyHoverHighlight<TElement extends Element>(
         }));
     }
 
-    disposers.push(element.on('mouseenter', () => {
-        if (tooltip && anchor && content) {
-            const { x, y } = anchor();
-            tooltip.show(x, y, content());
-        }
+    let activeTransition: Transition | undefined;
+    let release: (() => void) | undefined;
 
-        onEnter?.({ ...pointer });
+    const applyState = (state: StateOf<TElement>, overrides?: MarkInteractionOptions) => {
+        // Timing stays lazy: the thunk resolves per invocation, and only then does the caller override it.
+        const resolved = animation();
+        const duration = overrides?.duration ?? resolved.duration;
 
-        if (!highlight) {
+        activeTransition?.abort();
+        activeTransition = undefined;
+
+        if (duration > 0) {
+            activeTransition = renderer.transition(element, {
+                duration,
+                ease: resolved.ease,
+                state,
+            });
+
+            // Nothing awaits a hover, so swallow the rejection the next `abort()` raises.
+            activeTransition.catch(functionNoop);
+
             return;
         }
 
-        const { duration, ease } = animation();
+        // A zero-duration transition lands a frame later, so write the state and nudge the loop to paint it.
+        element.interpolate(state)(1);
+        renderer.start();
+    };
 
-        renderer.transition(element, {
-            duration,
-            ease,
-            state: highlight,
-        });
+    const detachProgrammatic = () => {
+        if (!release) {
+            return;
+        }
+
+        PROGRAMMATIC_HIGHLIGHTS.get(renderer)?.delete(release);
+        release = undefined;
+    };
+
+    const leaveMark = (overrides?: MarkInteractionOptions) => {
+        detachProgrammatic();
+
+        if (overrides?.tooltip !== false) {
+            tooltip?.hide();
+        }
+
+        onHighlight?.(false);
+
+        if (!restore || !element.parent) {
+            activeTransition?.abort();
+            activeTransition = undefined;
+            return;
+        }
+
+        applyState(restore, overrides);
+    };
+
+    const enterMark = (overrides: MarkInteractionOptions | undefined, programmatic: boolean): boolean => {
+        if (!element.parent) {
+            return false;
+        }
+
+        const text = overrides?.content ?? content?.();
+
+        if (tooltip && anchor && text !== undefined && overrides?.tooltip !== false) {
+            const { x, y } = anchor();
+            tooltip.show(x, y, text);
+        }
+
+        onHighlight?.(true);
+
+        if (highlight) {
+            applyState(highlight, overrides);
+        }
+
+        if (programmatic) {
+            const onTakeover = overrides?.onTakeover;
+
+            detachProgrammatic();
+            release = () => {
+                release = undefined;
+                leaveMark({ duration: 0 });
+                onTakeover?.();
+            };
+
+            const active = PROGRAMMATIC_HIGHLIGHTS.get(renderer) ?? new Set<() => void>();
+
+            active.add(release);
+            PROGRAMMATIC_HIGHLIGHTS.set(renderer, active);
+        }
+
+        return true;
+    };
+
+    disposers.push(element.on('mouseenter', () => {
+        // The pointer owns the chart the moment it reaches a mark, so a code-set highlight steps aside here.
+        releaseProgrammaticHighlights(renderer);
+
+        enterMark(undefined, false);
+        onEnter?.({ ...pointer });
     }));
 
     disposers.push(element.on('mouseleave', () => {
-        tooltip?.hide();
-
+        leaveMark();
         onLeave?.({ ...pointer });
-
-        if (!restore) {
-            return;
-        }
-
-        const { duration, ease } = animation();
-
-        renderer.transition(element, {
-            duration,
-            ease,
-            state: restore,
-        });
     }));
 
     if (onClick) {
@@ -188,6 +331,12 @@ export function applyHoverHighlight<TElement extends Element>(
     }
 
     host[HOVER_DISPOSERS] = disposers;
+    host[MARK_INTERACTION] = {
+        enter: options => enterMark(options, true),
+        leave: options => leaveMark(options),
+        anchor: () => anchor?.(),
+        content: () => content?.(),
+    };
 }
 
 /**
@@ -210,8 +359,9 @@ export function arcCentroidAnchor(arc: Arc): () => InteractionPoint {
 }
 
 /**
- * How a segment reports its hover to the chart around it: the typed event it emits and the
- * chart-wide highlight it drives.
+ * The typed events a segment reports to the chart around it. They stay bound to the pointer
+ * handlers: a programmatic highlight replays the segment's treatment through its
+ * {@link MarkInteraction} handle without emitting any of them.
  *
  * @typeParam TPayload - The chart's interaction event payload, which carries the pointer position.
  */
@@ -224,18 +374,12 @@ export interface SegmentInteractionOptions<TPayload extends InteractionPoint> {
     onLeave?: (event: TPayload) => void;
     /** Emits the chart's click event for the segment. */
     onClick?: (event: TPayload) => void;
-    /**
-     * Toggles the chart-wide highlight for the hovered segment, called with `true` on enter and
-     * `false` on leave. Charts whose segments are already solid at rest use it so the hover reads
-     * as the other segments dimming rather than this one lifting.
-     */
-    onHighlight?: (hovered: boolean) => void;
 }
 
 /**
- * Wires a chart segment's full hover treatment: the tooltip and highlight transition of
- * {@link applyHoverHighlight}, plus the typed enter/leave/click events and the chart-wide highlight
- * every segmented chart emits alongside them.
+ * Wires a chart segment's full hover treatment: the tooltip, highlight transition and chart-wide
+ * highlight of {@link applyHoverHighlight}, plus the typed enter/leave/click events every segmented
+ * chart emits alongside them.
  *
  * @typeParam TElement - The element type the hover is attached to.
  * @typeParam TPayload - The chart's interaction event payload.
@@ -253,7 +397,6 @@ export function applySegmentInteraction<TElement extends Element, TPayload exten
         onEnter,
         onLeave,
         onClick,
-        onHighlight,
         ...hover
     } = options;
 
@@ -265,14 +408,8 @@ export function applySegmentInteraction<TElement extends Element, TPayload exten
 
     applyHoverHighlight(element, {
         ...hover,
-        onEnter: point => {
-            onHighlight?.(true);
-            onEnter?.(eventAt(point));
-        },
-        onLeave: point => {
-            onHighlight?.(false);
-            onLeave?.(eventAt(point));
-        },
+        onEnter: point => onEnter?.(eventAt(point)),
+        onLeave: point => onLeave?.(eventAt(point)),
         onClick: point => onClick?.(eventAt(point)),
     } as HoverHighlightOptions & HoverHighlightStates<TElement>);
 }

--- a/packages/charts/src/core/series/bar-series.ts
+++ b/packages/charts/src/core/series/bar-series.ts
@@ -323,6 +323,8 @@ export class BarSeriesRenderer<TData> extends SeriesRenderer<BarSeriesLike<TData
             onLeave: point => ctx.emit('leave', payload(point)),
             onClick: point => ctx.emit('click', payload(point)),
         });
+
+        ctx.registerMark('bar', key, bar, series.id);
     }
 
     private _createBar(series: BarSeriesLike<TData>, item: TData, ctx: BarSeriesContext<TData>, prepared: BarPrepared<TData>): Rect {

--- a/packages/charts/src/core/series/base.ts
+++ b/packages/charts/src/core/series/base.ts
@@ -164,7 +164,7 @@ export abstract class SeriesRenderer<
         });
     }
 
-    /** Wires the shared hover highlight + tooltip + interaction events onto a point marker. */
+    /** Wires the shared hover highlight + tooltip + interaction events onto a point marker, and registers it as a replayable `'marker'`. */
     protected attachMarkerHover(marker: Circle, ctx: SeriesRenderContext<TData>, spec: {
         seriesId: string;
         key: string;
@@ -203,6 +203,8 @@ export abstract class SeriesRenderer<
             onLeave: point => ctx.emit('leave', payload(point)),
             onClick: point => ctx.emit('click', payload(point)),
         });
+
+        ctx.registerMark('marker', spec.key, marker, spec.seriesId);
     }
 
     /**

--- a/packages/charts/src/core/series/context.ts
+++ b/packages/charts/src/core/series/context.ts
@@ -94,6 +94,13 @@ export interface SeriesRenderContext<TData> {
     dataLabels: ChartDataLabelsOptions;
     /** Adds entering marks to the chart's plot-clipped content container. */
     addContent: (elements: OneOrMore<Element>) => void;
+    /**
+     * Registers a rendered mark with the host chart so its programmatic highlight methods can replay
+     * the mark's hover treatment. Renderers call it beside the hover wiring with their own mark family
+     * (`'marker'` for line/area points, `'bar'` for bars), the mark's category key, and the series it
+     * belongs to — so both the bare key and the `{ key, series }` ref resolve to it.
+     */
+    registerMark: (kind: string, key: string, element: Element, series: string) => void;
     /** Emits a normalized interaction event, which the host maps to its typed event map. */
     emit: (phase: SeriesEventPhase, event: SeriesInteractionEvent) => void;
     /**

--- a/packages/charts/test/axis-tooltip.test.ts
+++ b/packages/charts/test/axis-tooltip.test.ts
@@ -177,6 +177,33 @@ describe('Shared axis tooltip', () => {
         expect(tooltipLines(chart)[0]).toBe('a');
     });
 
+    it('shows the shared snapshot for a programmatic highlight asking for the tooltip', async () => {
+        const chart = createChart({ trigger: 'axis' });
+
+        await chart.render();
+
+        expect(chart.highlightMarker('b', { tooltip: true })).toBe(true);
+
+        expect(tooltipLines(chart)).toEqual([
+            'b',
+            'One: 20',
+            'Two: 60',
+        ]);
+    });
+
+    it('shows the marks\' own contents for the same highlight with the item trigger', async () => {
+        const chart = createChart();
+
+        await chart.render();
+
+        expect(chart.highlightMarker('b', { tooltip: true })).toBe(true);
+
+        expect(tooltipLines(chart)).toEqual([
+            'One: 20',
+            'Two: 60',
+        ]);
+    });
+
 });
 
 interface BarAxisTooltipInternals {

--- a/packages/charts/test/hover-highlight.test.ts
+++ b/packages/charts/test/hover-highlight.test.ts
@@ -28,7 +28,7 @@ polyfillPath2D();
 
 interface ChartInternals {
     scene: Scene;
-    highlightSeries(id: string | null): void;
+    applySeriesHighlight(id: string | null): boolean;
 }
 
 function sceneOf(chart: unknown) {
@@ -263,7 +263,7 @@ describe('sunburst hover owners', () => {
     test('hovering a legend item lights the whole branch', async () => {
         const chart = await createSunburst();
 
-        (chart as unknown as ChartInternals).highlightSeries('T');
+        (chart as unknown as ChartInternals).applySeriesHighlight('T');
         await vi.advanceTimersByTimeAsync(5000);
 
         expect(litNodes(chart, ALL)).toEqual([
@@ -273,6 +273,88 @@ describe('sunburst hover owners', () => {
             'T1b',
             'T2',
         ]);
+
+        chart.destroy();
+    });
+
+    test('a node highlight isolates the node while a series highlight keeps the branch', async () => {
+        const chart = await createSunburst();
+
+        expect(chart.highlightNode('T1')).toBe(true);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(litNodes(chart, ALL)).toEqual(['T1']);
+
+        expect(chart.highlightSeries('T')).toBe(true);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(litNodes(chart, ALL)).toEqual([
+            'T',
+            'T1',
+            'T1a',
+            'T1b',
+            'T2',
+        ]);
+
+        chart.destroy();
+    });
+
+});
+
+describe('legend highlight', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    function legendEntry(chart: unknown, id: string) {
+        return elementById(chart, `legend-swatch-${id}`);
+    }
+
+    test('hovering a legend entry dims the entries it excludes', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(legendEntry(chart, 'a'), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(legendEntry(chart, 'a').opacity).toBe(1);
+        expect(legendEntry(chart, 'b').opacity).toBeCloseTo(0.3);
+        expect(elementById(chart, 'legend-label-b').opacity).toBeCloseTo(0.3);
+
+        hover(legendEntry(chart, 'a'), 'mouseleave');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(legendEntry(chart, 'b').opacity).toBe(1);
+        expect(elementById(chart, 'legend-label-b').opacity).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('a legend hover highlight survives a re-render', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(legendEntry(chart, 'a'), 'mouseenter');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'b').opacity).toBeLessThan(1);
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        // Routing legend hover through the public one-shot would let render()'s clearHighlight drop it.
+        expect(segmentArc(chart, 'b').opacity).toBeLessThan(1);
 
         chart.destroy();
     });

--- a/packages/charts/test/interaction.test.ts
+++ b/packages/charts/test/interaction.test.ts
@@ -7,6 +7,7 @@ import {
 
 import {
     applyHoverHighlight,
+    getMarkInteraction,
 } from '../src/core/interaction';
 
 /**
@@ -16,20 +17,41 @@ import {
  */
 describe('applyHoverHighlight', () => {
 
-    function bind(animation: () => { duration: number;
-        ease: (t: number) => number; }) {
+    function createElement() {
         const handlers: Record<string, () => void> = {};
-        const transition = vi.fn();
+        const interpolator = vi.fn();
 
         const element = {
+            parent: {} as unknown,
             on: (event: string, handler: () => void) => {
                 handlers[event] = handler;
                 return { dispose: vi.fn() };
             },
+            interpolate: vi.fn(() => interpolator),
         };
 
+        return {
+            element,
+            handlers,
+            interpolator,
+        };
+    }
+
+    function bind(animation: () => { duration: number;
+        ease: (t: number) => number; }) {
+        const { element, handlers, interpolator } = createElement();
+        const abort = vi.fn();
+        const transition = vi.fn(() => ({
+            abort,
+            catch: vi.fn(),
+        }));
+        const start = vi.fn();
+
         applyHoverHighlight(element as never, {
-            renderer: { transition } as never,
+            renderer: {
+                transition,
+                start,
+            } as never,
             animation,
             highlight: { radius: 12 } as never,
             restore: { radius: 10 } as never,
@@ -38,7 +60,10 @@ describe('applyHoverHighlight', () => {
         return {
             handlers,
             transition,
+            abort,
+            start,
             element,
+            interpolator,
         };
     }
 
@@ -70,6 +95,75 @@ describe('applyHoverHighlight', () => {
 
         expect(transition).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({ duration: 120 }));
         expect(transition).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({ duration: 340 }));
+    });
+
+    test('replaces the stored handle when re-applied to a persistent element', () => {
+        const { element } = createElement();
+        const options = {
+            renderer: {
+                transition: vi.fn(() => ({
+                    abort: vi.fn(),
+                    catch: vi.fn(),
+                })),
+                start: vi.fn(),
+            } as never,
+            animation: () => ({
+                duration: 200,
+                ease: (t: number) => t,
+            }),
+            highlight: { radius: 12 } as never,
+            restore: { radius: 10 } as never,
+        };
+
+        applyHoverHighlight(element as never, options);
+        const first = getMarkInteraction(element as never);
+
+        applyHoverHighlight(element as never, options);
+        const second = getMarkInteraction(element as never);
+
+        expect(first).toBeDefined();
+        expect(second).toBeDefined();
+        expect(second).not.toBe(first);
+    });
+
+    test('restores by aborting the retained transition and writing the state, with no transition of its own', () => {
+        const {
+            element,
+            transition,
+            abort,
+            interpolator,
+        } = bind(() => ({
+            duration: 300,
+            ease: t => t,
+        }));
+
+        const interaction = getMarkInteraction(element as never)!;
+
+        interaction.enter();
+        transition.mockClear();
+        interaction.leave({ duration: 0 });
+
+        // A zero-duration transition lands a frame later, and the in-flight tween would overwrite it.
+        expect(transition).not.toHaveBeenCalled();
+        expect(abort).toHaveBeenCalled();
+        expect(element.interpolate).toHaveBeenCalledWith({ radius: 10 });
+        expect(interpolator).toHaveBeenCalledWith(1);
+    });
+
+    test('no-ops when the element is detached from the scene', () => {
+        const { element, transition } = bind(() => ({
+            duration: 300,
+            ease: t => t,
+        }));
+
+        // Transitioning a detached element never advances, pinning the renderer's loop forever.
+        element.parent = undefined;
+
+        const interaction = getMarkInteraction(element as never)!;
+
+        expect(interaction.enter()).toBe(false);
+        expect(transition).not.toHaveBeenCalled();
+        expect(element.interpolate).not.toHaveBeenCalled();
     });
 
 });

--- a/packages/charts/test/mark-registry.test.ts
+++ b/packages/charts/test/mark-registry.test.ts
@@ -1,0 +1,983 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
+    createArcDiagramChart,
+    createAreaChart,
+    createBarChart,
+    createBoxPlotChart,
+    createChordChart,
+    createForceDirectedChart,
+    createFunnelChart,
+    createGanttChart,
+    createGaugeChart,
+    createHeatmapChart,
+    createHistogramChart,
+    createLineChart,
+    createPackedCircleChart,
+    createPieChart,
+    createPolarAreaChart,
+    createPolarScatterChart,
+    createRadarChart,
+    createRadialBarChart,
+    createRealtimeChart,
+    createSankeyChart,
+    createScatterChart,
+    createStockChart,
+    createSunburstChart,
+    createTreemapChart,
+    createTrendChart,
+} from '../src';
+
+interface MarkCase {
+    name: string;
+    create(): {
+        chart: {
+            render(): Promise<unknown>;
+            destroy(): void;
+        };
+        highlight(): boolean;
+    };
+}
+
+interface Sample {
+    month: string;
+    revenue: number;
+    cost: number;
+}
+
+interface Latency {
+    region: string;
+    latency: number;
+}
+
+interface Task {
+    id: string;
+    name: string;
+    start: Date;
+    end: Date;
+}
+
+interface Candle {
+    date: string;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+}
+
+interface Cell {
+    day: string;
+    hour: string;
+    load: number;
+}
+
+interface Reading {
+    angle: number;
+    speed: number;
+}
+
+interface Stat {
+    axis: string;
+    player: number;
+}
+
+const SAMPLES: Sample[] = [
+    {
+        month: 'Jan',
+        revenue: 120,
+        cost: 80,
+    },
+    {
+        month: 'Feb',
+        revenue: 150,
+        cost: 90,
+    },
+    {
+        month: 'Mar',
+        revenue: 170,
+        cost: 110,
+    },
+];
+
+const LATENCIES: Latency[] = [
+    {
+        region: 'US',
+        latency: 40,
+    },
+    {
+        region: 'US',
+        latency: 55,
+    },
+    {
+        region: 'US',
+        latency: 60,
+    },
+    {
+        region: 'US',
+        latency: 62,
+    },
+    {
+        region: 'US',
+        latency: 120,
+    },
+    {
+        region: 'EU',
+        latency: 70,
+    },
+    {
+        region: 'EU',
+        latency: 82,
+    },
+    {
+        region: 'EU',
+        latency: 88,
+    },
+    {
+        region: 'EU',
+        latency: 95,
+    },
+    {
+        region: 'EU',
+        latency: 130,
+    },
+];
+
+const TASKS: Task[] = [
+    {
+        id: 'design',
+        name: 'Design',
+        start: new Date('2024-01-01'),
+        end: new Date('2024-01-10'),
+    },
+    {
+        id: 'build',
+        name: 'Build',
+        start: new Date('2024-01-08'),
+        end: new Date('2024-01-22'),
+    },
+];
+
+const CANDLES: Candle[] = [
+    {
+        date: '2024-01-01',
+        open: 100,
+        high: 110,
+        low: 95,
+        close: 108,
+    },
+    {
+        date: '2024-01-02',
+        open: 108,
+        high: 115,
+        low: 104,
+        close: 106,
+    },
+];
+
+const HOURS = [
+    '9am',
+    '10am',
+];
+
+const DAYS = [
+    'Mon',
+    'Tue',
+];
+
+const CELLS: Cell[] = DAYS.flatMap((day, dayIndex) => HOURS.map((hour, hourIndex) => ({
+    day,
+    hour,
+    load: dayIndex * 10 + hourIndex,
+})));
+
+const READINGS: Reading[] = [
+    {
+        angle: 30,
+        speed: 60,
+    },
+    {
+        angle: 150,
+        speed: 80,
+    },
+];
+
+const STATS: Stat[] = [
+    {
+        axis: 'Speed',
+        player: 80,
+    },
+    {
+        axis: 'Strength',
+        player: 55,
+    },
+    {
+        axis: 'Defense',
+        player: 70,
+    },
+];
+
+polyfillPath2D();
+
+/** jsdom measures every element as 0×0; give the canvas a real size so every chart gets a plot to draw in. */
+function mockCanvasSize(width: number, height: number): void {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+function target(): HTMLElement {
+    return document.createElement('div');
+}
+
+const CASES: MarkCase[] = [
+    {
+        name: 'arc diagram node',
+        create() {
+            const chart = createArcDiagramChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'a',
+                        label: 'A',
+                    },
+                    {
+                        id: 'b',
+                        label: 'B',
+                    },
+                    {
+                        id: 'c',
+                        label: 'C',
+                    },
+                ],
+                links: [
+                    {
+                        source: 'a',
+                        target: 'b',
+                        value: 3,
+                    },
+                    {
+                        source: 'b',
+                        target: 'c',
+                        value: 2,
+                    },
+                ],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('a'),
+            };
+        },
+    },
+    {
+        name: 'arc diagram link',
+        create() {
+            const chart = createArcDiagramChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'a',
+                        label: 'A',
+                    },
+                    {
+                        id: 'b',
+                        label: 'B',
+                    },
+                ],
+                links: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 3,
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightLink({
+                    source: 'a',
+                    target: 'b',
+                }),
+            };
+        },
+    },
+    {
+        name: 'area marker',
+        create() {
+            const chart = createAreaChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    id: 'revenue',
+                    label: 'Revenue',
+                    value: 'revenue',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('Feb'),
+            };
+        },
+    },
+    {
+        name: 'bar',
+        create() {
+            const chart = createBarChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    id: 'revenue',
+                    label: 'Revenue',
+                    value: 'revenue',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightBar('Feb'),
+            };
+        },
+    },
+    {
+        name: 'box plot box',
+        create() {
+            const chart = createBoxPlotChart<Latency>(target(), {
+                autoRender: false,
+                animation: false,
+                data: LATENCIES,
+                key: 'region',
+                value: 'latency',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightBox('US'),
+            };
+        },
+    },
+    {
+        name: 'chord segment',
+        create() {
+            const chart = createChordChart(target(), {
+                autoRender: false,
+                animation: false,
+                groups: [
+                    'Engineering',
+                    'Design',
+                ],
+                matrix: [
+                    [0, 5],
+                    [5, 0],
+                ],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightSegment('Engineering'),
+            };
+        },
+    },
+    {
+        name: 'chord link',
+        create() {
+            const chart = createChordChart(target(), {
+                autoRender: false,
+                animation: false,
+                groups: [
+                    'Engineering',
+                    'Design',
+                ],
+                matrix: [
+                    [0, 5],
+                    [5, 0],
+                ],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightLink({
+                    source: 'Engineering',
+                    target: 'Design',
+                }),
+            };
+        },
+    },
+    {
+        name: 'force-directed node',
+        create() {
+            const chart = createForceDirectedChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'a',
+                        label: 'A',
+                    },
+                    {
+                        id: 'b',
+                        label: 'B',
+                    },
+                ],
+                links: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 3,
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('a'),
+            };
+        },
+    },
+    {
+        name: 'force-directed link',
+        create() {
+            const chart = createForceDirectedChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'a',
+                        label: 'A',
+                    },
+                    {
+                        id: 'b',
+                        label: 'B',
+                    },
+                ],
+                links: [{
+                    source: 'a',
+                    target: 'b',
+                    value: 3,
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightLink({
+                    source: 'a',
+                    target: 'b',
+                }),
+            };
+        },
+    },
+    {
+        name: 'funnel segment',
+        create() {
+            const chart = createFunnelChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                label: 'month',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightSegment('Feb'),
+            };
+        },
+    },
+    {
+        name: 'gantt task',
+        create() {
+            const chart = createGanttChart<Task>(target(), {
+                autoRender: false,
+                animation: false,
+                data: TASKS,
+                key: 'id',
+                label: 'name',
+                start: 'start',
+                end: 'end',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightTask('design'),
+            };
+        },
+    },
+    {
+        name: 'gauge value',
+        create() {
+            const chart = createGaugeChart(target(), {
+                autoRender: false,
+                animation: false,
+                value: 72,
+                min: 0,
+                max: 100,
+                label: 'Performance',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightValue(),
+            };
+        },
+    },
+    {
+        name: 'heatmap cell',
+        create() {
+            const chart = createHeatmapChart<Cell>(target(), {
+                autoRender: false,
+                animation: false,
+                data: CELLS,
+                keyX: 'hour',
+                keyY: 'day',
+                value: 'load',
+                xCategories: HOURS,
+                yCategories: DAYS,
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightCell({
+                    x: '9am',
+                    y: 'Mon',
+                }),
+            };
+        },
+    },
+    {
+        name: 'histogram bin',
+        create() {
+            const chart = createHistogramChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                value: 'revenue',
+                bins: 3,
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightBin(0),
+            };
+        },
+    },
+    {
+        name: 'line marker',
+        create() {
+            const chart = createLineChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    id: 'revenue',
+                    label: 'Revenue',
+                    value: 'revenue',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('Feb'),
+            };
+        },
+    },
+    {
+        name: 'packed circle node',
+        create() {
+            const chart = createPackedCircleChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                label: 'month',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('Feb'),
+            };
+        },
+    },
+    {
+        name: 'pie segment',
+        create() {
+            const chart = createPieChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                label: 'month',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightSegment('Feb'),
+            };
+        },
+    },
+    {
+        name: 'polar area segment',
+        create() {
+            const chart = createPolarAreaChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                label: 'month',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightSegment('Feb'),
+            };
+        },
+    },
+    {
+        name: 'polar scatter marker',
+        create() {
+            const chart = createPolarScatterChart<Reading>(target(), {
+                autoRender: false,
+                animation: false,
+                data: READINGS,
+                max: 100,
+                series: [{
+                    id: 'wind',
+                    label: 'Wind',
+                    angleBy: 'angle',
+                    radiusBy: 'speed',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('0'),
+            };
+        },
+    },
+    {
+        name: 'radar marker',
+        create() {
+            const chart = createRadarChart<Stat>(target(), {
+                autoRender: false,
+                animation: false,
+                categories: STATS.map(stat => stat.axis),
+                data: STATS,
+                series: [{
+                    id: 'player',
+                    label: 'Player',
+                    value: 'player',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('Speed'),
+            };
+        },
+    },
+    {
+        name: 'radial bar',
+        create() {
+            const chart = createRadialBarChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                max: 200,
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightBar('Feb'),
+            };
+        },
+    },
+    {
+        name: 'realtime series',
+        create() {
+            const chart = createRealtimeChart(target(), {
+                autoRender: false,
+                animation: false,
+                windowSize: 10,
+                transitionDuration: 0,
+                series: [
+                    {
+                        id: 'cpu',
+                        label: 'CPU',
+                    },
+                    {
+                        id: 'memory',
+                        label: 'Memory',
+                    },
+                ],
+            });
+
+            chart.push({
+                cpu: 10,
+                memory: 20,
+            });
+
+            chart.push({
+                cpu: 20,
+                memory: 30,
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightSeries('cpu'),
+            };
+        },
+    },
+    {
+        name: 'sankey node',
+        create() {
+            const chart = createSankeyChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'budget',
+                        label: 'Budget',
+                    },
+                    {
+                        id: 'engineering',
+                        label: 'Engineering',
+                    },
+                ],
+                links: [{
+                    source: 'budget',
+                    target: 'engineering',
+                    value: 300,
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('budget'),
+            };
+        },
+    },
+    {
+        name: 'sankey link',
+        create() {
+            const chart = createSankeyChart(target(), {
+                autoRender: false,
+                animation: false,
+                nodes: [
+                    {
+                        id: 'budget',
+                        label: 'Budget',
+                    },
+                    {
+                        id: 'engineering',
+                        label: 'Engineering',
+                    },
+                ],
+                links: [{
+                    source: 'budget',
+                    target: 'engineering',
+                    value: 300,
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightLink({
+                    source: 'budget',
+                    target: 'engineering',
+                }),
+            };
+        },
+    },
+    {
+        name: 'scatter marker',
+        create() {
+            const chart = createScatterChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    id: 'points',
+                    label: 'Months',
+                    xBy: 'cost',
+                    yBy: 'revenue',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('Feb'),
+            };
+        },
+    },
+    {
+        name: 'stock candle',
+        create() {
+            const chart = createStockChart<Candle>(target(), {
+                autoRender: false,
+                animation: false,
+                data: CANDLES,
+                key: 'date',
+                open: 'open',
+                high: 'high',
+                low: 'low',
+                close: 'close',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightCandle('2024-01-01'),
+            };
+        },
+    },
+    {
+        name: 'sunburst node',
+        create() {
+            const chart = createSunburstChart(target(), {
+                autoRender: false,
+                animation: false,
+                data: [{
+                    id: 'tech',
+                    label: 'Technology',
+                    value: 400,
+                    children: [
+                        {
+                            id: 'web',
+                            label: 'Web',
+                            value: 120,
+                        },
+                        {
+                            id: 'mobile',
+                            label: 'Mobile',
+                            value: 90,
+                        },
+                    ],
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('web'),
+            };
+        },
+    },
+    {
+        name: 'treemap node',
+        create() {
+            const chart = createTreemapChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                value: 'revenue',
+                label: 'month',
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightNode('Feb'),
+            };
+        },
+    },
+    {
+        name: 'trend bar',
+        create() {
+            const chart = createTrendChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    type: 'bar',
+                    id: 'cost',
+                    label: 'Cost',
+                    value: 'cost',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightBar('Feb'),
+            };
+        },
+    },
+    {
+        name: 'trend marker',
+        create() {
+            const chart = createTrendChart<Sample>(target(), {
+                autoRender: false,
+                animation: false,
+                data: SAMPLES,
+                key: 'month',
+                series: [{
+                    type: 'line',
+                    id: 'revenue',
+                    label: 'Revenue',
+                    value: 'revenue',
+                }],
+            });
+
+            return {
+                chart,
+                highlight: () => chart.highlightMarker('Feb'),
+            };
+        },
+    },
+];
+
+describe('mark registry', () => {
+
+    beforeEach(() => {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    for (const markCase of CASES) {
+        test(`${markCase.name} resolves its registered key after a render`, async () => {
+            const {
+                chart,
+                highlight,
+            } = markCase.create();
+
+            await chart.render();
+
+            expect(highlight()).toBe(true);
+
+            chart.destroy();
+        });
+    }
+
+});

--- a/packages/charts/test/programmatic-highlight.test.ts
+++ b/packages/charts/test/programmatic-highlight.test.ts
@@ -400,8 +400,8 @@ describe('heatmap cell selectors', () => {
 
         await vi.advanceTimersByTimeAsync(5000);
 
-        expect(elementById(chart, 'cell-9am-Mon').opacity).toBe(0.8);
-        expect(elementById(chart, 'cell-10am-Mon').opacity).not.toBe(0.8);
+        expect(elementById(chart, 'cell-9am-Mon-rect').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-10am-Mon-rect').opacity).not.toBe(0.8);
         expect(tooltipLines(chart)).toHaveLength(1);
 
         chart.destroy();
@@ -416,9 +416,9 @@ describe('heatmap cell selectors', () => {
         expect(chart.highlightCell('Mon', { tooltip: true })).toBe(true);
         await vi.advanceTimersByTimeAsync(5000);
 
-        expect(elementById(chart, 'cell-9am-Mon').opacity).toBe(0.8);
-        expect(elementById(chart, 'cell-10am-Mon').opacity).toBe(0.8);
-        expect(elementById(chart, 'cell-9am-Tue').opacity).not.toBe(0.8);
+        expect(elementById(chart, 'cell-9am-Mon-rect').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-10am-Mon-rect').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-9am-Tue-rect').opacity).not.toBe(0.8);
         expect(tooltipLines(chart)).toHaveLength(HOURS.length);
 
         chart.destroy();

--- a/packages/charts/test/programmatic-highlight.test.ts
+++ b/packages/charts/test/programmatic-highlight.test.ts
@@ -1,0 +1,427 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+import {
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import type {
+    Circle,
+    Element,
+    Group,
+    Scene,
+    Text,
+} from '@ripl/core';
+
+import {
+    createHeatmapChart,
+    createLineChart,
+    createPieChart,
+} from '../src';
+
+interface ChartInternals {
+    scene: Scene;
+}
+
+interface RejectionHost {
+    on(event: 'unhandledRejection', listener: (reason: unknown) => void): void;
+    off(event: 'unhandledRejection', listener: (reason: unknown) => void): void;
+}
+
+const PIE_DATA = [
+    {
+        label: 'a',
+        value: 3,
+    },
+    {
+        label: 'b',
+        value: 2,
+    },
+    {
+        label: 'c',
+        value: 1,
+    },
+];
+
+const LINE_DATA = [
+    {
+        m: 'a',
+        shown: 10,
+        hidden: 40,
+    },
+    {
+        m: 'b',
+        shown: 20,
+        hidden: 60,
+    },
+    {
+        m: 'c',
+        shown: 30,
+        hidden: 80,
+    },
+];
+
+const HOURS = [
+    '9am',
+    '10am',
+];
+
+const DAYS = [
+    'Mon',
+    'Tue',
+];
+
+const HEATMAP_DATA = DAYS.flatMap((day, dayIndex) => HOURS.map((hour, hourIndex) => ({
+    day,
+    hour,
+    load: dayIndex * 10 + hourIndex,
+})));
+
+polyfillPath2D();
+
+/** jsdom measures every element as 0×0; give the canvas a real size so the charts get a plot to draw in. */
+function mockCanvasSize(width: number, height: number): void {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    } as DOMRect);
+}
+
+function sceneOf(chart: unknown): Scene {
+    return (chart as unknown as ChartInternals).scene;
+}
+
+function elementById(chart: unknown, id: string): Element {
+    const element = sceneOf(chart).getElementById(id) as Element | null;
+
+    expect(element).toBeTruthy();
+
+    return element!;
+}
+
+function segmentArc(chart: unknown, key: string): Element {
+    const group = sceneOf(chart).getElementById(key) as Group | null;
+
+    expect(group).toBeTruthy();
+
+    return group!.query('arc') as unknown as Element;
+}
+
+function tooltipGroup(chart: unknown): Group {
+    const group = sceneOf(chart).getElementById('tooltip') as Group | null;
+
+    expect(group).toBeTruthy();
+
+    return group!;
+}
+
+function tooltipLines(chart: unknown): string[] {
+    const group = sceneOf(chart).getElementById('tooltip') as Group | null;
+
+    return group ? group.getElementsByType<Text>('text').map(text => String(text.content)) : [];
+}
+
+function hover(element: Element, event: 'mouseenter' | 'mouseleave') {
+    element.emit(event, null);
+}
+
+function createPie() {
+    return createPieChart<typeof PIE_DATA[number]>(document.createElement('div'), {
+        autoRender: false,
+        data: PIE_DATA,
+        key: 'label',
+        value: 'value',
+        label: 'label',
+    });
+}
+
+function createLine() {
+    return createLineChart<typeof LINE_DATA[number]>(document.createElement('div'), {
+        autoRender: false,
+        data: LINE_DATA,
+        key: 'm',
+        series: [
+            {
+                id: 'shown',
+                label: 'Shown',
+                value: 'shown',
+            },
+            {
+                id: 'hidden',
+                label: 'Hidden',
+                value: 'hidden',
+                markers: false,
+            },
+        ],
+    });
+}
+
+function createHeatmap() {
+    return createHeatmapChart<typeof HEATMAP_DATA[number]>(document.createElement('div'), {
+        autoRender: false,
+        data: HEATMAP_DATA,
+        keyX: 'hour',
+        keyY: 'day',
+        value: 'load',
+        xCategories: HOURS,
+        yCategories: DAYS,
+    });
+}
+
+describe('programmatic mark highlight', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+        mockCanvasSize(600, 400);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    test('replays a segment hover without emitting the segment events', async () => {
+        const chart = createPie();
+        const enter = vi.fn();
+        const leave = vi.fn();
+
+        chart.on('segmententer', enter);
+        chart.on('segmentleave', leave);
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightSegment('a')).toBe(true);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        chart.clearHighlight();
+
+        expect(enter).not.toHaveBeenCalled();
+        expect(leave).not.toHaveBeenCalled();
+
+        hover(segmentArc(chart, 'a'), 'mouseenter');
+
+        expect(enter).toHaveBeenCalledTimes(1);
+
+        chart.destroy();
+    });
+
+    test('dims the segments it excludes', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        chart.highlightSegment('a');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'a').opacity).toBe(1);
+        expect(segmentArc(chart, 'b').opacity).toBeLessThan(1);
+        expect(segmentArc(chart, 'c').opacity).toBeLessThan(1);
+
+        chart.destroy();
+    });
+
+    test('shows the tooltip content hovering the segment shows', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        hover(segmentArc(chart, 'a'), 'mouseenter');
+
+        const hovered = tooltipLines(chart);
+
+        hover(segmentArc(chart, 'a'), 'mouseleave');
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightSegment('a', { tooltip: true })).toBe(true);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(hovered).not.toEqual([]);
+        expect(tooltipLines(chart)).toEqual(hovered);
+        expect(tooltipGroup(chart).opacity).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('returns false for a key no segment carries', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightSegment('nope')).toBe(false);
+        expect(chart.highlightSegment('a')).toBe(true);
+
+        chart.destroy();
+    });
+
+    test('returns false for a series whose markers are hidden', async () => {
+        const chart = createLine();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightMarker({
+            key: 'b',
+            series: 'hidden',
+        })).toBe(false);
+
+        expect(chart.highlightMarker({
+            key: 'b',
+            series: 'shown',
+        })).toBe(true);
+
+        chart.destroy();
+    });
+
+    test('restores the chart and hides the tooltip on the next render', async () => {
+        const chart = createPie();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        chart.highlightSegment('a', { tooltip: true });
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'b').opacity).toBeLessThan(1);
+        expect(tooltipGroup(chart).opacity).toBe(1);
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(segmentArc(chart, 'b').opacity).toBe(1);
+        expect(tooltipGroup(chart).opacity).toBe(0);
+
+        chart.destroy();
+    });
+
+    test('restores the mark synchronously, without waiting a frame', async () => {
+        const chart = createLine();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        const marker = elementById(chart, 'shown-b') as unknown as Circle;
+        const rest = marker.radius;
+
+        chart.highlightMarker({
+            key: 'b',
+            series: 'shown',
+        });
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(marker.radius).toBeGreaterThan(rest);
+
+        chart.clearHighlight();
+
+        // A zero-duration transition would only land the restore a frame later, so it is written outright.
+        expect(marker.radius).toBe(rest);
+
+        chart.destroy();
+    });
+
+    test('leaves no unhandled rejection when a highlight is replaced mid-transition', async () => {
+        const rejections: unknown[] = [];
+        const capture = (reason: unknown) => rejections.push(reason);
+        const host = (globalThis as unknown as { process: RejectionHost }).process;
+
+        host.on('unhandledRejection', capture);
+
+        const chart = createLine();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        chart.highlightMarker({
+            key: 'b',
+            series: 'shown',
+        });
+
+        await vi.advanceTimersByTimeAsync(50);
+
+        chart.highlightMarker({
+            key: 'c',
+            series: 'shown',
+        });
+
+        chart.clearHighlight();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        host.off('unhandledRejection', capture);
+
+        expect(rejections).toEqual([]);
+
+        chart.destroy();
+    });
+
+});
+
+describe('heatmap cell selectors', () => {
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        mockCanvasContext();
+        mockCanvasSize(600, 400);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    test('an { x, y } ref lights the one cell at that pair of labels', async () => {
+        const chart = createHeatmap();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightCell({
+            x: '9am',
+            y: 'Mon',
+        }, { tooltip: true })).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(elementById(chart, 'cell-9am-Mon').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-10am-Mon').opacity).not.toBe(0.8);
+        expect(tooltipLines(chart)).toHaveLength(1);
+
+        chart.destroy();
+    });
+
+    test('a bare label lights its whole row, joining their tooltip contents', async () => {
+        const chart = createHeatmap();
+
+        chart.render();
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(chart.highlightCell('Mon', { tooltip: true })).toBe(true);
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(elementById(chart, 'cell-9am-Mon').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-10am-Mon').opacity).toBe(0.8);
+        expect(elementById(chart, 'cell-9am-Tue').opacity).not.toBe(0.8);
+        expect(tooltipLines(chart)).toHaveLength(HOURS.length);
+
+        chart.destroy();
+    });
+
+});


### PR DESCRIPTION
## The problem

`chart.update(options)` is the only imperative control a consumer has. Everything else a chart can do — lighting up a mark, dimming the other series, opening a tooltip, placing the crosshair — happens only when a real pointer enters a real element. So syncing a chart with an external table, driving a guided tour, restoring a selection after a data refresh, or building a keyboard-accessible focus mode all mean reaching into `chart.scene` and re-implementing the highlight by hand.

Nearly all the machinery already existed. It was just unreachable:

```ts
// core/interaction.ts — everything a highlight needs, sealed inside a closure
disposers.push(element.on('mouseenter', () => {
    if (tooltip && anchor && content) {
        const { x, y } = anchor();
        tooltip.show(x, y, content());
    }
    // ...highlight transition
}));
```

`Chart.highlightSeries` already dimmed every non-matching series, but was `protected` and only ever called from legend hover. `Tooltip.show` and `Crosshair.show` were already public on their components, but the components are not exported and each chart holds its instance privately.

## The fix

Two pieces, and the second is the one worth arguing about.

**A replayable handle.** `applyHoverHighlight` now builds a handle from the same closures it already captured and stores it on the element, and the `mouseenter`/`mouseleave` handlers delegate to it. Hover and code run one path, so they cannot drift. The chart-wide dim moved out of `onEnter`/`onLeave` into its own option, which is what keeps a programmatic highlight **silent** — the typed `*enter`/`*leave`/`*click` events stay bound to the pointer handlers only. Emitting them would loop the moment a consumer highlights from inside their own `barclick` handler, which is the most common integration pattern.

**An explicit mark registry, rather than element-id lookup.** This is the part I'd most like a second opinion on, because id lookup is the obvious cheaper choice and it does not work here:

- pie and polar-area arcs carry **no `id` at all**, only a class, so `getElementById` cannot reach them;
- ids are inconsistent across charts (`cell-${x}-${y}`, `bin-${index}`, `arc-${label}`, `node-${id}`), and radar and polar-scatter key by array index;
- `${seriesId}-${key}` collides with `${seriesId}-line` for a category literally named `line`;
- `getElementById` can return an element mid-`exitElement`, about to be destroyed.

So charts register marks beside the `applyHoverHighlight` call they already make — one line per call site.

### Four things that look right and are not

Each was verified against the source rather than assumed, and each would have shipped a bug:

- **A zero-duration transition is not synchronous.** `Renderer._processTransition` early-returns while `elapsed <= 0`, so the state lands a frame later, and an in-flight tween stays in `_transitionMap` and overwrites a synchronous write on the next frame. Restoring aborts the retained transition and assigns through `element.interpolate(state)(1)`.
- **Aborting rejects.** `Task.abort()` ends in `_reject(new TaskAbortError(reason))`. Nothing awaited hover transitions before, so retaining one and aborting it needs a swallowing `.catch()`.
- **A detached element leaks the render loop.** Transitioning an element that has left the scene never advances, never clears the renderer's map, and holds `isBusy` true forever. Guarded with `!element.parent`.
- **Dimming before checking the id was destructive.** `highlightSeries('typo')` dimmed every group *and* every legend entry, returned `false`, and recorded no highlight — which sent `clearHighlight()` down its early return and left the chart dimmed with no way back. The call documented as changing nothing was the most destructive in the API. Found in review; fixed in `20669a4`.

### Why `highlightSeries` is split in two

`reserveLegend` calls the series-dim primitive on every legend hover. If that same method were the public one-shot API, every legend hover would mark a highlight active, and the next resize or `update()` would clear a highlight the pointer is still resting on. So the primitive is `protected applySeriesHighlight` and the public `highlightSeries` delegates to it. `sunburst` overrides the primitive for its `series:`/`node:` namespacing and moved with it.

Nothing on screen distinguishes the two, so it is pinned by a test: rewiring the legend to the public method fails `a legend hover highlight survives a re-render` and nothing else.

## API

```ts
chart.highlightBar('2024-03');                                   // every series at that key
chart.highlightBar({ series: 'revenue', key: '2024-03' });        // narrowed to one
chart.highlightMarker(data => data[2].id, { tooltip: true });     // accessor form
chart.highlightSeries('revenue');                                 // series + its legend entry
chart.clearHighlight();
```

The method name mirrors the event you already subscribe to — a chart emitting `barenter` gets `highlightBar` — and the selector key is the same key the event payload reports, so whatever arrives in `event.data` can be handed straight back.

Highlight is a **one-shot command**: any re-render clears it. That keeps it from fighting the legend-hover highlight, which is state and must survive an update.

All 24 mark-bearing charts have a method; `realtime` draws no marks and gains only `highlightSeries`. The charts whose marks carry no natural key are addressed as: `heatmap` by a `CellRef { x, y }` (a bare string lights a whole row or column), `histogram` by bin index, `polar-scatter` by data index, `radar` by axis label.

## Verification

Honest accounting, because this environment is limited:

- **Type-checking passes** — package source compiles clean with `@ripl/*` mapped to source, verified after every change.
- **`node scripts/generate-chart-options.mjs --check` passes**, which type-checks every example on all 25 pages against the library source. Every snippet opens with its factory call so it is actually covered.
- **The public exports were probed by compilation** — a consumer-style file importing `MarkInteraction`, `MarkRef`, `LinkRef`, `CellRef`, `MarkSelector`, `HighlightOptions` and `getMarkInteraction` from `@ripl/charts` type-checks clean. They reach the entry point through the existing `core` barrel, so `index.ts` needed no change.
- **`yarn test`, `yarn lint`, `yarn typecheck` and TypeDoc's `notDocumented` validation have NOT been run.** There is no `node_modules` in the environment this was built in. A scripted JSDoc check over all 29 methods substituted for TypeDoc.
- **No test has been executed.** ~1,500 lines of new tests type-check and have never run. One real defect was already found in them *after* writing — assertions targeting a heatmap cell group, which carries no opacity, instead of the rect inside it — so treat them as unproven rather than clean.
- **No visual-regression comparison has been made.**

**A local `yarn test` run is genuinely load-bearing here, not a formality.**

## Known issues, deliberately left

- **Histogram's mark handle goes stale after an update render.** `_attachBinHover` runs only on the entry path while `registerMark` runs on both, so after an update `highlightBin(i, { tooltip: true })` reports the previous bin's range. Pre-existing for hover; the new API makes it reachable from code. The fix is to pre-existing hover wiring, not to this feature.
- **Horizontal bars in `trigger: 'axis'` mode** wire `setupAxisTooltip(plot, () => null)`, so `{ tooltip: true }` shows nothing. Consistent with hover, which also shows nothing, but it is a silent no-op.
- **Selector drift between the two index-keyed charts** — `highlightBin` takes a `number`, `polar-scatter` takes stringified indices. Both are documented accurately, but they solve the same problem two ways.

## Behaviour changes to note

- Legend hover now dims the hovered legend entry itself. Isolated in `2bf9ed9` so it can be reverted independently of the API.
- `realtime`'s legend hover now dims its series, aligning it with every other legend-bearing chart.
- Charts with no chart-wide dim on hover (histogram, box-plot, stock, gauge, heatmap, gantt) keep that behaviour; a programmatic highlight there applies the mark's own highlight state only.
- `PolarScatterMarkerEvent` gains an `index` field, so the key its events report is the key its `highlightMarker` accepts.