### PR TITLE
Require the leading hash on a hex colour

### DIFF
--- a/packages/core/src/color/constants.ts
+++ b/packages/core/src/color/constants.ts
@@ -5,7 +5,9 @@ import type {
 /** Validation patterns for each supported color space, keyed by {@link ColorSpace}. */
 export const PATTERNS = {
     // Full 6/8-digit branch first, then the 3/4-digit shorthand, so `#f00` resolves to a colour.
-    hex: /^#?(?:([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})?|([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])?)$/i,
+    // The `#` is required, as CSS requires it: without it any string of hex digits is a colour, so
+    // a plain number like `136` parses as `#136` and interpolates as one.
+    hex: /^#(?:([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})?|([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])([a-fA-F\d])?)$/i,
     // Fractional channels are legal CSS and are what an interpolator produces, so accept them.
     rgb: /^rgb\((\d{1,3}(?:\.\d+)?%?),\s*(\d{1,3}(?:\.\d+)?%?),\s*(\d{1,3}(?:\.\d+)?%?)\)$/i,
     rgba: /^rgba\((\d{1,3}(?:\.\d+)?%?),\s*(\d{1,3}(?:\.\d+)?%?),\s*(\d{1,3}(?:\.\d+)?%?),\s*(0|1|0?\.\d+|\d{1,3}(?:\.\d+)?%)\)$/i,

--- a/packages/core/test/color/parsers.test.ts
+++ b/packages/core/test/color/parsers.test.ts
@@ -88,6 +88,15 @@ describe('Color', () => {
             expect(parseColor('#ff')).toBeUndefined();
         });
 
+        // Without the `#`, any run of hex digits is a colour: an element's text `content` of `136`
+        // parsed as `#136` and animated as a colour rather than as text.
+        test('Should reject a HEX color missing its leading hash', () => {
+            expect(parseColor('136')).toBeUndefined();
+            expect(parseColor('1234')).toBeUndefined();
+            expect(parseColor('112233')).toBeUndefined();
+            expect(parseColor('ff0000cc')).toBeUndefined();
+        });
+
         test('Should parse an RGB color to RGBA', () => {
             const [
                 red,


### PR DESCRIPTION
`PATTERNS.hex` made the `#` optional:

```js
hex: /^#?(?:([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})([a-fA-F\d]{2})?|…)$/i,
```

So any run of 3, 4, 6 or 8 hex digits parsed as a colour — including plain numbers:

```js
parseColor('136')     // → [17, 51, 102, 1]   (i.e. #113366)
parseColor('1234')    // → [17, 34, 51, 0.27]
parseColor('112233')  // → [17, 34, 51, 1]
```

That is not just a parsing curiosity, because `getInterpolator` chooses an interpolator by probing parsers in order, with `interpolateColor` ahead of the discrete `interpolateAny` fallback. An element's text `content` animating from `112` to `136` is therefore interpolated as a **colour**:

```js
interpolateColor('112', '136')(1)   // → 'rgba(17, 51, 102, 1)'
```

Any numeric text label between 100 and 999 hits this. Two-digit labels (`50`) and non-numeric ones (`Jan`) do not, so it shows up as a subset of labels in a chart turning into `rgba(…)` strings.

## How it was found

Building a bar chart demo for the `@ripl/vue` docs (#104). Value labels above the bars rendered correctly on first paint, but as soon as the data changed, every label in the hundreds rendered as `rgba(17, 51, 102, 1)` instead of its number — and stayed that way once the transition settled, since the interpolated colour is what gets written to `content`.

That demo works around it by formatting labels as currency (`$7.4K`), which never matches the pattern. The workaround can come out once this lands.

## The fix

Make the `#` required — one character in the pattern. CSS has always required it, and `serializeHEX` already emits it, so the parse → serialize → parse round trip is unaffected.

The one behaviour change is that `fill: 'ff0000'` without a `#` stops resolving. That was never valid CSS and never worked in a browser's own colour parsing; it only worked here by accident of the optional `#`.

## Verification

- `yarn test` — 238 files / 3298 passed, 2 skipped. Nothing in the repo relied on bare-hex parsing.
- `yarn lint`, `yarn typecheck` — clean.
- New regression test in `packages/core/test/color/parsers.test.ts` asserting `136`, `1234`, `112233` and `ff0000cc` are not colours. It fails without the pattern change.
- Existing tests already pin the positive cases (`#f00`, `#ff000` rejected, named colours, `rgb()`/`hsl()` forms), and all still pass.
