### PR TITLE
Let the platform supply the charts backend and navigator, and drive input from pointer events

### DIFF
--- a/apps/website/src/charts/advanced/panning-and-zooming.md
+++ b/apps/website/src/charts/advanced/panning-and-zooming.md
@@ -53,6 +53,8 @@ Which axes the view affects depends on the chart:
 
 While a gesture is in flight the chart suppresses transition animations, so marks snap to the new view each frame instead of tweening behind the pointer. Marks are clipped to the plot rectangle so panning never smears them over the axes, title, or legend.
 
+Gestures are claimed within the plot rectangle only. A wheel or drag starting over the axis gutter, title, legend or overview strip is left alone — so a wheel there scrolls the page as usual, and dragging the overview window never also pans the plot behind it.
+
 ## The Overview Strip
 
 `overview: true` renders a miniature of the full dataset beside the plot (below it for category-on-x charts, to the right for a horizontal bar chart) with a draggable window over it:
@@ -101,7 +103,7 @@ chart.update({
 
 ## Imperative Control
 
-When the `navigator` option is on, `chart.navigator` exposes the underlying controller (`DOMNavigator`) for imperative framing and brush-and-link:
+When the `navigator` option is on, `chart.navigator` exposes the underlying `Navigator` for imperative framing and brush-and-link. The chart asks the platform for it, so importing `@ripl/web` gets you the gesture-bound `DOMNavigator` while `@ripl/node` gets the base controller — the imperative API below is the same either way:
 
 ```ts
 const nav = chart.navigator;

--- a/apps/website/src/charts/getting-started.md
+++ b/apps/website/src/charts/getting-started.md
@@ -13,23 +13,38 @@ outline: "deep"
 
 ## Installation
 
+`@ripl/charts` is context-agnostic — it draws onto whatever surface it is given and ships no
+rendering backend of its own. Install it alongside the backend for your environment:
+[`@ripl/web`](/docs/core/contexts/canvas) in a browser, or
+`@ripl/node` to render to a terminal.
+
 :::tabs
 == npm
 ```bash
-npm install @ripl/charts
+npm install @ripl/charts @ripl/web
 ```
 == yarn
 ```bash
-yarn add @ripl/charts
+yarn add @ripl/charts @ripl/web
 ```
 == pnpm
 ```bash
-pnpm add @ripl/charts
+pnpm add @ripl/charts @ripl/web
 ```
 :::
 
+Import the backend once, anywhere in your entry point:
+
+```ts
+import '@ripl/web';
+```
+
+That registers the platform bindings a chart needs — a rendering context, text measurement and an
+animation frame. Without one, a chart given a selector or an element throws rather than silently
+choosing a backend; a chart handed a `Context` you built yourself needs no import at all.
+
 > [!TIP]
-> `@ripl/charts` depends on `@ripl/core`, which is installed automatically. You don't need to install it separately.
+> `@ripl/core` is installed automatically as a dependency of both. You never install it directly.
 
 ## Your First Chart
 
@@ -40,6 +55,9 @@ Every chart follows the same pattern:
 3. **Update** the chart reactively via `chart.update(options)`
 
 ```ts
+// Registers the browser rendering backend. Swap for `@ripl/node` to render to a terminal.
+import '@ripl/web';
+
 import {
     createBarChart,
 } from '@ripl/charts';

--- a/apps/website/src/docs/api/typedoc-sidebar.json
+++ b/apps/website/src/docs/api/typedoc-sidebar.json
@@ -2861,6 +2861,10 @@
             "link": "/docs/api/@ripl/core/interfaces/LogarithmicScaleOptions.md"
           },
           {
+            "text": "NavigatorBounds",
+            "link": "/docs/api/@ripl/core/interfaces/NavigatorBounds.md"
+          },
+          {
             "text": "NavigatorBrush",
             "link": "/docs/api/@ripl/core/interfaces/NavigatorBrush.md"
           },
@@ -4206,10 +4210,6 @@
             "link": "/docs/api/@ripl/dom/interfaces/DOMElementResizeEvent.md"
           },
           {
-            "text": "DOMNavigatorOptions",
-            "link": "/docs/api/@ripl/dom/interfaces/DOMNavigatorOptions.md"
-          },
-          {
             "text": "ParentRef",
             "link": "/docs/api/@ripl/dom/interfaces/ParentRef.md"
           },
@@ -4238,6 +4238,10 @@
           {
             "text": "DOMEventHandler",
             "link": "/docs/api/@ripl/dom/type-aliases/DOMEventHandler.md"
+          },
+          {
+            "text": "DOMNavigatorOptions",
+            "link": "/docs/api/@ripl/dom/type-aliases/DOMNavigatorOptions.md"
           }
         ]
       },

--- a/apps/website/src/docs/api/typedoc-sidebar.json
+++ b/apps/website/src/docs/api/typedoc-sidebar.json
@@ -357,6 +357,10 @@
             "link": "/docs/api/@ripl/3d/type-aliases/RenderStrategy.md"
           },
           {
+            "text": "Shape3DDefaults",
+            "link": "/docs/api/@ripl/3d/type-aliases/Shape3DDefaults.md"
+          },
+          {
             "text": "Shape3DOptions",
             "link": "/docs/api/@ripl/3d/type-aliases/Shape3DOptions.md"
           },
@@ -3079,6 +3083,10 @@
             "link": "/docs/api/@ripl/core/type-aliases/Ease.md"
           },
           {
+            "text": "ElementDefaults",
+            "link": "/docs/api/@ripl/core/type-aliases/ElementDefaults.md"
+          },
+          {
             "text": "ElementInterpolationKeyFrame",
             "link": "/docs/api/@ripl/core/type-aliases/ElementInterpolationKeyFrame.md"
           },
@@ -3241,6 +3249,10 @@
           {
             "text": "SceneEventMap",
             "link": "/docs/api/@ripl/core/type-aliases/SceneEventMap.md"
+          },
+          {
+            "text": "Shape2DDefaults",
+            "link": "/docs/api/@ripl/core/type-aliases/Shape2DDefaults.md"
           },
           {
             "text": "Shape2DOptions",

--- a/apps/website/src/docs/api/typedoc-sidebar.json
+++ b/apps/website/src/docs/api/typedoc-sidebar.json
@@ -2801,6 +2801,10 @@
             "link": "/docs/api/@ripl/core/interfaces/ContextOptions.md"
           },
           {
+            "text": "ContextPointerEvent",
+            "link": "/docs/api/@ripl/core/interfaces/ContextPointerEvent.md"
+          },
+          {
             "text": "DivergingScaleOptions",
             "link": "/docs/api/@ripl/core/interfaces/DivergingScaleOptions.md"
           },
@@ -2859,10 +2863,6 @@
           {
             "text": "LogarithmicScaleOptions",
             "link": "/docs/api/@ripl/core/interfaces/LogarithmicScaleOptions.md"
-          },
-          {
-            "text": "NavigatorBounds",
-            "link": "/docs/api/@ripl/core/interfaces/NavigatorBounds.md"
           },
           {
             "text": "NavigatorBrush",
@@ -3077,6 +3077,10 @@
           {
             "text": "ContextFactory",
             "link": "/docs/api/@ripl/core/type-aliases/ContextFactory.md"
+          },
+          {
+            "text": "ContextPointerType",
+            "link": "/docs/api/@ripl/core/type-aliases/ContextPointerType.md"
           },
           {
             "text": "Direction",

--- a/apps/website/src/docs/core/advanced/events.md
+++ b/apps/website/src/docs/core/advanced/events.md
@@ -157,9 +157,11 @@ Following browser DOM behavior, pointer events target the **topmost element** (h
 
 Elements with `pointerEvents` set to `'none'` are transparent to hit testing, allowing events to pass through to the next element below.
 
+Input is read from DOM **pointer** events, so a finger or a stylus drives these exactly as a mouse does. The `mouse*` names are kept for the element-level vocabulary and report the primary pointer; for multi-pointer gestures and device details, subscribe to the context's own [pointer events](/docs/core/essentials/context#pointer-events) instead.
+
 ### Tracked Events
 
-The context tracks `click`, `mousedown`, `mouseup`, `mouseenter`, `mouseleave`, `mousemove`, `dragstart`, `drag`, and `dragend` events automatically.
+The context tracks `click`, `mousedown`, `mouseup`, `mouseenter`, `mouseleave`, `mousemove`, `dragstart`, `drag`, and `dragend` events on elements automatically.
 
 ```ts
 const scene = createScene('.container', {

--- a/apps/website/src/docs/core/advanced/navigator.md
+++ b/apps/website/src/docs/core/advanced/navigator.md
@@ -249,6 +249,36 @@ const navigator = createNavigator(context, {
 
 The gesture model is intentionally Figma-like: click-and-hold (left or middle button, with or without ⌘/Ctrl) pans, the wheel and two-finger pinch zoom toward the pointer, and shift-drag brushes a rectangle. Call `navigator.destroy()` to detach every listener.
 
+### Claiming part of the surface
+
+By default a navigator claims the whole surface. Pass `bounds` (or assign `navigator.bounds` later) to scope it to a rectangle, in logical pixels, leaving the rest to whatever else is listening — this is how a chart keeps its overview strip draggable without the plot panning underneath it:
+
+```ts
+navigator.bounds = {
+    x: 40,
+    y: 16,
+    width: 520,
+    height: 300,
+};
+```
+
+Only the wheel and a gesture's **first press** are gated, so a drag that starts inside the region keeps tracking after it leaves. A wheel outside the region is not consumed at all, so the page scrolls as usual.
+
+### Choosing a navigator by platform
+
+`factory.createNavigator` is the platform seam. Importing `@ripl/web` registers the gesture-bound `DOMNavigator`; importing `@ripl/node` registers the base `Navigator`, which owns the same view model but binds no input because a terminal has no pointer. Code that wants whichever one the host installed — `@ripl/charts` does exactly this — goes through the factory rather than importing a class:
+
+```ts
+import {
+    factory,
+    Navigator,
+} from '@ripl/core';
+
+const navigator = factory.createNavigator
+    ? factory.createNavigator(context, { interactions: true })
+    : new Navigator();
+```
+
 ## The view transform
 
 The transform is a plain `{ k, x, y }` object: a content-space point `p` maps to the screen as `k · p + [x, y]`. Two helpers convert between spaces:

--- a/apps/website/src/docs/core/advanced/navigator.md
+++ b/apps/website/src/docs/core/advanced/navigator.md
@@ -251,16 +251,18 @@ The gesture model is intentionally Figma-like: click-and-hold (left or middle bu
 
 ### Claiming part of the surface
 
-By default a navigator claims the whole surface. Pass `bounds` (or assign `navigator.bounds` later) to scope it to a rectangle, in logical pixels, leaving the rest to whatever else is listening — this is how a chart keeps its overview strip draggable without the plot panning underneath it:
+By default a navigator claims the whole surface. Pass `bounds` (or assign `navigator.bounds` later) to scope it to a [`Box`](/docs/api/@ripl/core/classes/Box), in logical pixels, leaving the rest to whatever else is listening — this is how a chart keeps its overview strip draggable without the plot panning underneath it:
 
 ```ts
-navigator.bounds = {
-    x: 40,
-    y: 16,
-    width: 520,
-    height: 300,
-};
+import {
+    Box,
+} from '@ripl/web';
+
+// top, left, bottom, right
+navigator.bounds = new Box(16, 40, 316, 560);
 ```
+
+Assign a new `Box` rather than mutating the one already there.
 
 Only the wheel and a gesture's **first press** are gated, so a drag that starts inside the region keeps tracking after it leaves. A wheel outside the region is not consumed at all, so the page scrolls as usual.
 

--- a/apps/website/src/docs/core/essentials/context.md
+++ b/apps/website/src/docs/core/essentials/context.md
@@ -115,9 +115,28 @@ context.markRenderEnd();
 
 ## Interaction
 
-The context owns all pointer interactivity. It listens for DOM mouse events on its element, performs hit testing against rendered elements, and delegates `click`, `mousedown`, `mouseup`, `mouseenter`, `mouseleave`, `mousemove`, `dragstart`, `drag`, and `dragend` events to the topmost Ripl element at the cursor automatically. This matches browser DOM behavior: when elements overlap, only the frontmost element (highest `zIndex`) receives the event, and it [bubbles](/docs/core/advanced/events#event-bubbling) up through the parent hierarchy.
+The context owns all pointer interactivity. It listens for DOM **pointer** events on its element — so mouse, pen and touch all work the same way — performs hit testing against rendered elements, and delegates `click`, `mousedown`, `mouseup`, `mouseenter`, `mouseleave`, `mousemove`, `dragstart`, `drag`, and `dragend` events to the topmost Ripl element at the cursor automatically. This matches browser DOM behavior: when elements overlap, only the frontmost element (highest `zIndex`) receives the event, and it [bubbles](/docs/core/advanced/events#event-bubbling) up through the parent hierarchy.
 
-The context emits the same pointer events itself, whether or not an element was hit — subscribe to `context.on('mousedown' | 'mouseup' | 'click' | 'mousemove' | 'mouseenter' | 'mouseleave' | 'dragstart' | 'drag' | 'dragend', …)` for surface-wide interaction. `mouseup` fires exactly once per button press, including when the release lands outside the surface and when a second button is pressed mid-gesture; the release that ends a drag suppresses the `click` that follows it, but still emits `mouseup`.
+The context emits the same events itself, whether or not an element was hit — subscribe to `context.on('mousedown' | 'mouseup' | 'click' | 'mousemove' | 'mouseenter' | 'mouseleave' | 'dragstart' | 'drag' | 'dragend', …)` for surface-wide interaction. `mouseup` fires exactly once per button press, including when the release lands outside the surface and when a second button is pressed mid-gesture; the release that ends a drag suppresses the `click` that follows it, but still emits `mouseup`.
+
+### Pointer events
+
+Alongside those, the context emits `pointerenter`, `pointerleave`, `pointerdown`, `pointermove`, `pointerup` and `pointercancel`. Two differences matter:
+
+- They fire for **every** pointer, where the `mouse*` events report only the primary one. A `pointerId` tells concurrent pointers apart, which is what makes a two-finger pinch expressible.
+- Their payload carries `pointerId`, `pointerType` (`'mouse' | 'pen' | 'touch'`), `isPrimary`, `button`, `buttons` and the `altKey`/`ctrlKey`/`metaKey`/`shiftKey` modifiers, on top of the `x`/`y` every payload has.
+
+```ts
+context.on('pointerdown', (event) => {
+    const { x, y, pointerId, pointerType, isPrimary } = event.data;
+
+    if (pointerType === 'touch' && !isPrimary) {
+        // a second finger — the start of a pinch
+    }
+});
+```
+
+The surface captures the pointer for the duration of a press, so a drag that leaves the surface keeps reporting moves and still ends with a `pointerup`. Crossing the edge mid-drag emits `pointerleave`/`mouseleave` on the way out and `pointerenter`/`mouseenter` on the way back, exactly once each. `pointercancel` ends a gesture the host took over (a browser deciding a touch was a scroll); it emits `mouseup` and `dragend` like a release, but is never followed by a `click`.
 
 All pointer payloads report coordinates in the same space elements are authored in, so a point you receive can be fed straight back into anything that takes one — `element.intersectsWith(x, y)` included. See [Coordinates](#coordinates) below.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -532,5 +532,30 @@ export default tseslint.config(
                 message: 'Use a keyed object-lookup dispatch instead of switch (see AGENTS.md → Control Flow).',
             }],
         },
+    },
+
+    // `@ripl/core` and `@ripl/charts` are context-agnostic: they render through the `Context`
+    // abstraction and reach platform capabilities through `factory`, so the same code runs in a
+    // browser and in a terminal. Depending on a backend would decide that for the consumer.
+    {
+        name: 'ripl/context-agnostic',
+        files: ['packages/core/src/**/*.ts', 'packages/charts/src/**/*.ts'],
+        rules: {
+            'no-restricted-imports': ['error', {
+                patterns: [{
+                    group: [
+                        '@ripl/3d',
+                        '@ripl/canvas',
+                        '@ripl/dom',
+                        '@ripl/node',
+                        '@ripl/svg',
+                        '@ripl/terminal',
+                        '@ripl/web',
+                        '@ripl/webgpu',
+                    ],
+                    message: 'This package must stay context-agnostic. Reach the platform through `factory` in @ripl/core instead.',
+                }],
+            }],
+        },
     }
 );

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -15,7 +15,7 @@
 - **Same chart, several targets** — Canvas or SVG in the browser, and braille text or raw `ImageData` from a headless Node script via [`@ripl/node`](https://www.npmjs.com/package/@ripl/node).
 - **Three built-in themes** — `lightTheme`, `darkTheme` and `colorBlindTheme`, with `registerTheme` for your own and per-chart or per-series overrides.
 - **Tree-shakable** — importing one factory ships one chart type.
-- **No third-party runtime dependencies** — the only dependencies are four sibling packages in this repository (`@ripl/core`, `@ripl/canvas`, `@ripl/dom`, `@ripl/utilities`).
+- **No third-party runtime dependencies** — the only dependencies are two sibling packages in this repository (`@ripl/core`, `@ripl/utilities`). Nothing DOM-specific, so the same chart code runs in a terminal.
 
 ## Chart types
 

--- a/packages/charts/README.md
+++ b/packages/charts/README.md
@@ -29,22 +29,33 @@
 
 ## Installation
 
+`@ripl/charts` is context-agnostic: it draws a chart onto whatever surface it is given and ships no
+rendering backend of its own. Install it **alongside** the backend for your environment.
+
 ```bash
-# npm
-npm install @ripl/charts
+# In a browser, with Canvas or SVG
+npm install @ripl/charts @ripl/web
 
-# yarn
-yarn add @ripl/charts
-
-# pnpm
-pnpm add @ripl/charts
+# In Node, rendering to the terminal
+npm install @ripl/charts @ripl/node
 ```
 
-Pair it with [`@ripl/web`](https://www.npmjs.com/package/@ripl/web) when the same page also draws its own graphics; charts alone need nothing else.
+Import the backend once, anywhere in your entry point. It registers the platform bindings a chart
+needs — a rendering context, text measurement and an animation frame:
+
+```typescript
+import '@ripl/web';
+```
+
+Without one, a chart given a selector or an element throws rather than guessing a backend. Passing
+a `Context` you built yourself needs no backend import at all.
 
 ## Quick start
 
 ```typescript
+// Registers the browser rendering backend. Swap for `@ripl/node` to render to a terminal.
+import '@ripl/web';
+
 import {
     createBarChart,
 } from '@ripl/charts';

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -61,7 +61,6 @@
     },
     "dependencies": {
         "@ripl/core": "workspace:^",
-        "@ripl/dom": "workspace:^",
         "@ripl/utilities": "workspace:^"
     }
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -60,7 +60,6 @@
         "test:browser": "playwright test -c test/visual/playwright.config.ts parity.spec.ts hit.spec.ts"
     },
     "dependencies": {
-        "@ripl/canvas": "workspace:^",
         "@ripl/core": "workspace:^",
         "@ripl/dom": "workspace:^",
         "@ripl/utilities": "workspace:^"

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -11,9 +11,10 @@
  * axis, scaled along the **cross** (value) axis.
  *
  * Dragging is wired through the context's own pointer events, which report logical coordinates — the
- * space the strip's geometry is authored in — so the strip is backend-agnostic and simply inert on a
- * context that emits no pointer events. The in-plot navigator is kept out of the band by its
- * `bounds`, which the host scopes to the plot rectangle.
+ * space the strip's geometry is authored in — so the strip is backend-agnostic, works under touch
+ * and pen as well as a mouse, and is simply inert on a context that emits no pointer events. The
+ * in-plot navigator is kept out of the band by its `bounds`, which the host scopes to the plot
+ * rectangle.
  */
 
 import {
@@ -148,15 +149,29 @@ export class ChartNavigator extends ChartComponent {
     /**
      * Subscribes the strip to the context's pointer events so its window can be dragged. Idempotent,
      * and inert on a context that emits no pointer events (e.g. the terminal).
+     *
+     * Only the primary pointer drives the window: a second finger arriving mid-drag would otherwise
+     * yank it to wherever that finger landed.
      */
     public attach(): void {
         if (this._attached) {
             return;
         }
 
-        this.retain(this.context.on('mousedown', ({ data }) => this._onPointerDown(data.x, data.y)), LISTENER_KEY);
-        this.retain(this.context.on('mousemove', ({ data }) => this._onPointerMove(data.x, data.y)), LISTENER_KEY);
-        this.retain(this.context.on('mouseup', () => this._onPointerUp()), LISTENER_KEY);
+        this.retain(this.context.on('pointerdown', ({ data }) => {
+            if (data.isPrimary) {
+                this._onPointerDown(data.x, data.y);
+            }
+        }), LISTENER_KEY);
+
+        this.retain(this.context.on('pointermove', ({ data }) => {
+            if (data.isPrimary) {
+                this._onPointerMove(data.x, data.y);
+            }
+        }), LISTENER_KEY);
+
+        this.retain(this.context.on('pointerup', () => this._onPointerUp()), LISTENER_KEY);
+        this.retain(this.context.on('pointercancel', () => this._onPointerUp()), LISTENER_KEY);
         this._attached = true;
     }
 

--- a/packages/charts/src/components/navigator.ts
+++ b/packages/charts/src/components/navigator.ts
@@ -10,9 +10,10 @@
  * type (lines as polylines, areas as filled bands, bars as silhouettes) along the **main** (category)
  * axis, scaled along the **cross** (value) axis.
  *
- * Dragging is wired with DOM pointer listeners on the render context (pointer capture keeps a drag
- * tracking outside the strip). A `pointerdown` inside the strip band calls `stopImmediatePropagation`
- * so the in-plot navigator, whose listeners attach after the strip's, never also pans.
+ * Dragging is wired through the context's own pointer events, which report logical coordinates — the
+ * space the strip's geometry is authored in — so the strip is backend-agnostic and simply inert on a
+ * context that emits no pointer events. The in-plot navigator is kept out of the band by its
+ * `bounds`, which the host scopes to the plot rectangle.
  */
 
 import {
@@ -46,14 +47,9 @@ import {
     arrayMapRange,
     numberClamp,
     numberSum,
-    typeIsFunction,
 } from '@ripl/utilities';
 
-import {
-    onDOMEvent,
-} from '@ripl/dom';
-
-/** Retention key for the strip's DOM pointer listeners. */
+/** Retention key for the strip's context pointer subscriptions. */
 const LISTENER_KEY = Symbol('navigator-strip-listeners');
 /** Pixel slop for grabbing an edge handle. */
 const HANDLE_SLOP = 10;
@@ -135,7 +131,6 @@ type DragMode = 'move' | 'resize-start' | 'resize-end';
 export class ChartNavigator extends ChartComponent {
 
     private _group?: Group;
-    private _element?: HTMLElement;
     private _orientation: ChartNavigatorOrientation = 'horizontal';
     private _area?: ChartArea;
     private _window: ChartNavigatorWindow = {
@@ -151,26 +146,17 @@ export class ChartNavigator extends ChartComponent {
     };
 
     /**
-     * Attaches the strip's DOM pointer listeners to the render context. Call this **before** the chart
-     * creates its in-plot navigator so the strip's `pointerdown` listener runs first and can suppress
-     * in-plot panning within the strip band. No-op on non-DOM contexts or if already attached.
+     * Subscribes the strip to the context's pointer events so its window can be dragged. Idempotent,
+     * and inert on a context that emits no pointer events (e.g. the terminal).
      */
     public attach(): void {
         if (this._attached) {
             return;
         }
 
-        const element = this.context.element as unknown as HTMLElement;
-
-        if (!element || !typeIsFunction(element.getBoundingClientRect) || !typeIsFunction(element.addEventListener)) {
-            return;
-        }
-
-        this._element = element;
-        this.retain(onDOMEvent(element, 'pointerdown', this._onPointerDown), LISTENER_KEY);
-        this.retain(onDOMEvent(element, 'pointermove', this._onPointerMove), LISTENER_KEY);
-        this.retain(onDOMEvent(element, 'pointerup', this._onPointerUp), LISTENER_KEY);
-        this.retain(onDOMEvent(element, 'pointercancel', this._onPointerUp), LISTENER_KEY);
+        this.retain(this.context.on('mousedown', ({ data }) => this._onPointerDown(data.x, data.y)), LISTENER_KEY);
+        this.retain(this.context.on('mousemove', ({ data }) => this._onPointerMove(data.x, data.y)), LISTENER_KEY);
+        this.retain(this.context.on('mouseup', () => this._onPointerUp()), LISTENER_KEY);
         this._attached = true;
     }
 
@@ -525,23 +511,14 @@ export class ChartNavigator extends ChartComponent {
         return this._group;
     }
 
-    private _localPoint(event: PointerEvent): Point {
-        const rect = this._element!.getBoundingClientRect();
-
-        return [
-            event.clientX - rect.left,
-            event.clientY - rect.top,
-        ];
-    }
-
     /** The pointer coordinate along the main (window) axis. */
-    private _mainCoord(point: Point): number {
-        return this._horizontal ? point[0] : point[1];
+    private _mainCoord(x: number, y: number): number {
+        return this._horizontal ? x : y;
     }
 
     /** The pointer coordinate along the cross axis (used for the band hit test). */
-    private _crossCoord(point: Point): number {
-        return this._horizontal ? point[1] : point[0];
+    private _crossCoord(x: number, y: number): number {
+        return this._horizontal ? y : x;
     }
 
     private _hitTest(main: number): DragMode | null {
@@ -563,24 +540,19 @@ export class ChartNavigator extends ChartComponent {
         return null;
     }
 
-    private _onPointerDown = (event: PointerEvent): void => {
-        if (!this._area || !this._onWindow || !this._element) {
+    private _onPointerDown(x: number, y: number): void {
+        if (!this._area || !this._onWindow) {
             return;
         }
 
-        const point = this._localPoint(event);
-        const cross = this._crossCoord(point);
+        const cross = this._crossCoord(x, y);
 
-        // Only claim pointers that land inside the strip band; leave the rest to the in-plot navigator.
+        // Only claim presses that land inside the strip band; the rest belong to the plot.
         if (cross < this._crossStart() || cross > this._crossStart() + this._crossSize()) {
             return;
         }
 
-        // Block the in-plot navigator (its listeners were attached after ours) from also panning.
-        event.stopImmediatePropagation();
-        event.preventDefault();
-
-        const main = this._mainCoord(point);
+        const main = this._mainCoord(x, y);
         const mode = this._hitTest(main);
 
         if (!mode) {
@@ -592,16 +564,14 @@ export class ChartNavigator extends ChartComponent {
             startMain: main,
             startWindow: { ...this._window },
         };
+    }
 
-        this._element.setPointerCapture?.(event.pointerId);
-    };
-
-    private _onPointerMove = (event: PointerEvent): void => {
+    private _onPointerMove(x: number, y: number): void {
         if (!this._drag || !this._area || !this._onWindow) {
             return;
         }
 
-        const main = this._mainCoord(this._localPoint(event));
+        const main = this._mainCoord(x, y);
         const delta = (main - this._drag.startMain) / Math.max(1, this._mainSize());
         const { mode, startWindow } = this._drag;
 
@@ -622,15 +592,10 @@ export class ChartNavigator extends ChartComponent {
             start,
             end,
         });
-    };
+    }
 
-    private _onPointerUp = (event: PointerEvent): void => {
-        if (!this._drag) {
-            return;
-        }
-
+    private _onPointerUp(): void {
         this._drag = undefined;
-        this._element?.releasePointerCapture?.(event.pointerId);
-    };
+    }
 
 }

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -126,6 +126,7 @@ import type {
     EventMap,
     Group,
     NavigatorInteractions,
+    NavigatorOptions,
     NavigatorTransform,
     Rect,
     Scale,
@@ -136,6 +137,8 @@ import {
     createFrameBuffer,
     createGroup,
     createRect,
+    factory,
+    Navigator,
     scaleContinuous,
 } from '@ripl/core';
 
@@ -153,14 +156,6 @@ import {
     typeIsNumber,
     typeIsObject,
 } from '@ripl/utilities';
-
-import {
-    createNavigator,
-} from '@ripl/dom';
-
-import type {
-    DOMNavigator,
-} from '@ripl/dom';
 
 /** Resolved animation used to snap geometry into place during navigator-driven re-renders. */
 const NO_ANIMATION = normalizeAnimation(false);
@@ -231,10 +226,15 @@ export interface CartesianChartOptions<TData = unknown> extends BaseChartOptions
     annotations?: ChartAnnotation[];
     /**
      * Enables pan/zoom (and optionally brush) navigation on the plot. `true` turns on wheel-zoom and
-     * click-drag pan; an object configures each interaction individually. The chart auto-creates a
-     * {@link DOMNavigator} on its context and rescales the axis domains as the view changes, with no
-     * data rebuild. Access the underlying controller via `chart.navigator` for imperative framing
-     * (`centerOn`/`fitBounds`) or brush-and-link.
+     * click-drag pan; an object configures each interaction individually. The chart auto-creates the
+     * platform's {@link Navigator} on its context and rescales the axis domains as the view changes,
+     * with no data rebuild. Access the underlying controller via `chart.navigator` for imperative
+     * framing (`centerOn`/`fitBounds`) or brush-and-link.
+     *
+     * Gestures are claimed within the plot rectangle only, so a drag starting over the axis gutter,
+     * title, legend or overview strip is left to whatever else is there. Which gestures are wired at
+     * all is the platform's business: `@ripl/web` binds wheel/pointer/touch, while `@ripl/node` has
+     * no pointer and leaves the controller drivable only from code.
      */
     navigator?: boolean | NavigatorInteractions;
     /**
@@ -295,7 +295,7 @@ export abstract class CartesianChart<
     private _annotations?: ChartAnnotations;
     private _setup: CartesianSetup = {};
 
-    private _navigator?: DOMNavigator;
+    private _navigator?: Navigator;
     private _navigatorConfigKey?: string;
     private _view: NavigatorTransform = {
         k: 1,
@@ -320,7 +320,7 @@ export abstract class CartesianChart<
      * Use it for imperative framing (`centerOn`, `fitBounds`, `reset`) and to subscribe to
      * `brush`/`brushend` for brush-and-link.
      */
-    public get navigator(): DOMNavigator | undefined {
+    public get navigator(): Navigator | undefined {
         return this._navigator;
     }
 
@@ -368,7 +368,6 @@ export abstract class CartesianChart<
     protected setupCartesian(setup: CartesianSetup = {}) {
         this._setup = setup;
 
-        // Strip before the in-plot navigator, so a strip `pointerdown` is claimed by the strip alone.
         this._navigatorStrip = new ChartNavigator({
             scene: this.scene,
             renderer: this.renderer,
@@ -568,11 +567,17 @@ export abstract class CartesianChart<
             }
             : config;
 
-        this._navigator = createNavigator(this.scene.context, {
+        const options: NavigatorOptions = {
             interactions,
             // Lower bound `1` is the full-data identity view; never zoom out past the dataset extent.
             scaleExtent: [1, NAV_MAX_ZOOM],
-        });
+            bounds: this._navPlot,
+        };
+
+        // Same guard as `Scene`: without a platform package the base controller still drives the view.
+        this._navigator = factory.createNavigator
+            ? factory.createNavigator(this.scene.context, options)
+            : new Navigator(options);
 
         this._navigator.on('change', event => {
             // Clamping is a fixpoint, so re-applying the clamped transform re-enters once then settles.
@@ -941,6 +946,11 @@ export abstract class CartesianChart<
     protected clipPlot(area: ChartArea): void {
         this._navPlot = area;
         this._ensurePlotContent();
+
+        // The plot is also what the navigator claims for input, leaving the overview strip its own band.
+        if (this._navigator) {
+            this._navigator.bounds = area;
+        }
 
         // Only clip the axis that actually slides; clipping the held value axis bisected its min/max labels.
         const navigating = !!this._navigator;

--- a/packages/charts/src/core/cartesian.ts
+++ b/packages/charts/src/core/cartesian.ts
@@ -202,6 +202,11 @@ function isSameTransform(a: NavigatorTransform, b: NavigatorTransform): boolean 
     return a.k === b.k && a.x === b.x && a.y === b.y;
 }
 
+/** The plot rectangle as a {@link Box}, the form the navigator gates its gestures against. */
+function plotBounds(area: ChartArea): Box {
+    return new Box(area.y, area.x, area.y + area.height, area.x + area.width);
+}
+
 /**
  * Clamps a view translation so the visible window stays within the full domain: given the axis plot
  * `origin`/`size` and zoom `k`, the translate must lie in `[(origin+size)(1-k), origin(1-k)]`.
@@ -571,7 +576,7 @@ export abstract class CartesianChart<
             interactions,
             // Lower bound `1` is the full-data identity view; never zoom out past the dataset extent.
             scaleExtent: [1, NAV_MAX_ZOOM],
-            bounds: this._navPlot,
+            bounds: this._navPlot && plotBounds(this._navPlot),
         };
 
         // Same guard as `Scene`: without a platform package the base controller still drives the view.
@@ -949,7 +954,7 @@ export abstract class CartesianChart<
 
         // The plot is also what the navigator claims for input, leaving the overview strip its own band.
         if (this._navigator) {
-            this._navigator.bounds = area;
+            this._navigator.bounds = plotBounds(area);
         }
 
         // Only clip the axis that actually slides; clipping the held value axis bisected its min/max labels.

--- a/packages/charts/src/core/chart.ts
+++ b/packages/charts/src/core/chart.ts
@@ -2,7 +2,6 @@ import {
     createRenderer,
     createScene,
     EventBus,
-    factory,
 } from '@ripl/core';
 
 import type {
@@ -14,10 +13,6 @@ import type {
     Renderer,
     Scene,
 } from '@ripl/core';
-
-import {
-    createContext,
-} from '@ripl/canvas';
 
 import {
     COLORS,
@@ -101,10 +96,6 @@ import {
     typeIsFunction,
     typeIsNumber,
 } from '@ripl/utilities';
-
-if (!factory.createContext) {
-    factory.set({ createContext });
-}
 
 export type {
     ChartAnimationOptions,

--- a/packages/charts/test/accessibility.test.ts
+++ b/packages/charts/test/accessibility.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/annotation.test.ts
+++ b/packages/charts/test/annotation.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/arc-diagram-hit.test.ts
+++ b/packages/charts/test/arc-diagram-hit.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     beforeEach,

--- a/packages/charts/test/axis-spacing.test.ts
+++ b/packages/charts/test/axis-spacing.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/axis-tooltip.test.ts
+++ b/packages/charts/test/axis-tooltip.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/axis-transition.test.ts
+++ b/packages/charts/test/axis-transition.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/box-plot.test.ts
+++ b/packages/charts/test/box-plot.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     describe,

--- a/packages/charts/test/cartesian-update.test.ts
+++ b/packages/charts/test/cartesian-update.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/export.test.ts
+++ b/packages/charts/test/export.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/gantt.test.ts
+++ b/packages/charts/test/gantt.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     describe,

--- a/packages/charts/test/heatmap-labels.test.ts
+++ b/packages/charts/test/heatmap-labels.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/hover-highlight.test.ts
+++ b/packages/charts/test/hover-highlight.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     beforeEach,

--- a/packages/charts/test/legend-toggle.test.ts
+++ b/packages/charts/test/legend-toggle.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/line-style.test.ts
+++ b/packages/charts/test/line-style.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/multi-axis.test.ts
+++ b/packages/charts/test/multi-axis.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/navigator.test.ts
+++ b/packages/charts/test/navigator.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/node.node.test.ts
+++ b/packages/charts/test/node.node.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+
+/**
+ * The charts suite otherwise runs under jsdom with `@ripl/web`, which would pass even if the package
+ * reached for the DOM. This file is the guard: no `window`, no `document`, `@ripl/node` for the
+ * platform bindings, and a terminal surface to draw onto.
+ */
+
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+// Side-effect import: registers the node factory bindings (terminal context, text measurement, rAF).
+import '@ripl/node';
+
+import {
+    Navigator,
+} from '@ripl/core';
+
+import {
+    createContext,
+} from '@ripl/terminal';
+
+import type {
+    TerminalOutput,
+} from '@ripl/terminal';
+
+import {
+    createBarChart,
+    createLineChart,
+    createPieChart,
+} from '../src';
+
+interface Row {
+    month: string;
+    a: number;
+    b: number;
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May'];
+const DATA: Row[] = MONTHS.map((month, index) => ({
+    month,
+    a: (index + 1) * 100,
+    b: (index + 1) * 40,
+}));
+
+const SERIES = [
+    {
+        id: 'a',
+        label: 'A',
+        value: 'a' as const,
+    },
+    {
+        id: 'b',
+        label: 'B',
+        value: 'b' as const,
+    },
+];
+
+/** A terminal surface that captures everything written to it. */
+function capturingOutput() {
+    const frames: string[] = [];
+
+    return {
+        frames,
+        output: {
+            write: (data: string) => void frames.push(data),
+            columns: 120,
+            rows: 40,
+        } as TerminalOutput,
+    };
+}
+
+describe('Charts outside a DOM', () => {
+
+    // `Chart.render` catches and logs, so without this a broken render would still pass every assertion.
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        expect(console.error).not.toHaveBeenCalled();
+        vi.restoreAllMocks();
+    });
+
+    test('Should be running without a document or a window', () => {
+        expect(typeof window).toBe('undefined');
+        expect(typeof document).toBe('undefined');
+    });
+
+    test('Should render a bar chart to a terminal surface', async () => {
+        const { frames, output } = capturingOutput();
+
+        const chart = createBarChart<Row>(createContext(output), {
+            autoRender: false,
+            animation: false,
+            title: 'Sales',
+            data: DATA,
+            key: 'month',
+            series: SERIES,
+        });
+
+        await chart.render();
+
+        expect(frames.join('')).not.toBe('');
+
+        chart.destroy();
+    });
+
+    test('Should render a pie chart to a terminal surface', async () => {
+        const { frames, output } = capturingOutput();
+
+        const chart = createPieChart<Row>(createContext(output), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            label: 'month',
+            value: 'a',
+        });
+
+        await chart.render();
+
+        expect(frames.join('')).not.toBe('');
+
+        chart.destroy();
+    });
+
+    test('Should render a chart with a navigator and an overview strip', async () => {
+        const { frames, output } = capturingOutput();
+
+        const chart = createLineChart<Row>(createContext(output), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            navigator: true,
+            overview: true,
+            series: SERIES,
+        });
+
+        await chart.render();
+
+        expect(frames.join('')).not.toBe('');
+        expect(chart.navigator).toBeInstanceOf(Navigator);
+
+        chart.destroy();
+    });
+
+    test('Should drive the view from code where there is no pointer to drive it', async () => {
+        const { output } = capturingOutput();
+
+        const chart = createLineChart<Row>(createContext(output), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            navigator: true,
+            series: SERIES,
+        });
+
+        await chart.render();
+
+        chart.navigator?.zoomTo(2, [10, 10]);
+
+        expect(chart.navigator?.transform.k).toBe(2);
+
+        chart.destroy();
+    });
+
+    // A target that is neither a `Context` nor a DOM element still resolves, via `factory.createContext`.
+    test('Should resolve a chart target through the factory', async () => {
+        const { frames, output } = capturingOutput();
+
+        const chart = createBarChart<Row>(output as unknown as string, {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            series: SERIES,
+        });
+
+        await chart.render();
+
+        expect(chart.context.type).toBe('terminal');
+        expect(frames.join('')).not.toBe('');
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/numeric-dataset.test.ts
+++ b/packages/charts/test/numeric-dataset.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     beforeEach,

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     describe,

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -671,3 +671,128 @@ describe('Overview navigator strip', () => {
     });
 
 });
+
+describe('Overview navigator strip dragging', () => {
+
+    async function stripChart() {
+        mockCanvasContext();
+        mockCanvasSize(640, 400);
+
+        const chart = createLineChart<Row>(document.createElement('div'), {
+            autoRender: false,
+            animation: false,
+            data: DATA,
+            key: 'month',
+            overview: true,
+            series: [
+                {
+                    id: 'a',
+                    label: 'A',
+                    value: 'a',
+                },
+            ],
+        });
+
+        await chart.render();
+
+        return chart;
+    }
+
+    /** Dispatches a real mouse event on the chart's surface, the way a browser would. */
+    function mouse(chart: { context: { element: unknown } }, type: string, x: number, y: number): void {
+        (chart.context.element as HTMLElement).dispatchEvent(new MouseEvent(type, {
+            bubbles: true,
+            clientX: x,
+            clientY: y,
+        }));
+    }
+
+    /** Dispatches a pointer event, which only the navigator listens for. */
+    function pointer(chart: { context: { element: unknown } }, type: string, x: number, y: number): void {
+        const event = new Event(type, {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        Object.assign(event, {
+            pointerId: 1,
+            clientX: x,
+            clientY: y,
+        });
+
+        (chart.context.element as HTMLElement).dispatchEvent(event);
+    }
+
+    test('Should narrow the window when an edge handle is dragged, driving the view transform', async () => {
+        const chart = await stripChart();
+        const strip = rectOf(chart, 'navigator-strip');
+        const crossY = strip.y + strip.height / 2;
+
+        mouse(chart, 'mousedown', strip.x + strip.width, crossY);
+        mouse(chart, 'mousemove', strip.x + strip.width / 2, crossY);
+        mouse(chart, 'mouseup', strip.x + strip.width / 2, crossY);
+
+        // Halving the window doubles the zoom of the category axis.
+        expect(chart.navigator?.transform.k).toBeCloseTo(2, 1);
+
+        chart.destroy();
+    });
+
+    test('Should ignore a press outside the strip band', async () => {
+        const chart = await stripChart();
+        const strip = rectOf(chart, 'navigator-strip');
+
+        mouse(chart, 'mousedown', strip.x + strip.width, strip.y - strip.height);
+        mouse(chart, 'mousemove', strip.x + strip.width / 2, strip.y - strip.height);
+
+        expect(chart.navigator?.transform.k).toBe(1);
+
+        chart.destroy();
+    });
+
+    test('Should scope the navigator to the plot rectangle', async () => {
+        const chart = await stripChart();
+
+        expect(chart.navigator?.bounds).toEqual(plotOf(chart));
+
+        chart.destroy();
+    });
+
+    // The strip used to block the navigator by stopping propagation; the bounds gate replaces it.
+    test('Should not pan the plot when a gesture starts in the strip band', async () => {
+        const chart = await stripChart();
+        const strip = rectOf(chart, 'navigator-strip');
+        const crossY = strip.y + strip.height / 2;
+
+        pointer(chart, 'pointerdown', strip.x + strip.width / 2, crossY);
+        pointer(chart, 'pointermove', strip.x + strip.width / 4, crossY);
+
+        expect(chart.navigator?.transform).toEqual({
+            k: 1,
+            x: 0,
+            y: 0,
+        });
+
+        chart.destroy();
+    });
+
+    test('Should still pan when a gesture starts inside the plot', async () => {
+        const chart = await stripChart();
+        const plot = plotOf(chart);
+        const midX = plot.x + plot.width / 2;
+        const midY = plot.y + plot.height / 2;
+
+        // The identity view is the full data extent, where translation clamps to zero; zoom in to pan at all.
+        chart.navigator?.zoomTo(2, [midX, midY]);
+
+        const before = chart.navigator!.transform.x;
+
+        pointer(chart, 'pointerdown', midX, midY);
+        pointer(chart, 'pointermove', midX + 20, midY);
+
+        expect(chart.navigator!.transform.x).toBeGreaterThan(before);
+
+        chart.destroy();
+    });
+
+});

--- a/packages/charts/test/overview-navigator.test.ts
+++ b/packages/charts/test/overview-navigator.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'vitest';
 
 import {
+    dispatchPointerEvent,
     mockCanvasContext,
     polyfillPath2D,
 } from '@ripl/test-utils';
@@ -21,6 +22,10 @@ import {
     createLineChart,
     createTrendChart,
 } from '../src';
+
+import {
+    Box,
+} from '@ripl/core';
 
 import type {
     Group,
@@ -698,29 +703,19 @@ describe('Overview navigator strip dragging', () => {
         return chart;
     }
 
-    /** Dispatches a real mouse event on the chart's surface, the way a browser would. */
-    function mouse(chart: { context: { element: unknown } }, type: string, x: number, y: number): void {
-        (chart.context.element as HTMLElement).dispatchEvent(new MouseEvent(type, {
-            bubbles: true,
+    /** Dispatches a pointer event on the chart's surface, the way a browser would. */
+    function pointer(chart: { context: { element: unknown } }, type: string, x: number, y: number): void {
+        dispatchPointerEvent(chart.context.element as HTMLElement, type, {
             clientX: x,
             clientY: y,
-        }));
+        });
     }
 
-    /** Dispatches a pointer event, which only the navigator listens for. */
-    function pointer(chart: { context: { element: unknown } }, type: string, x: number, y: number): void {
-        const event = new Event(type, {
-            bubbles: true,
-            cancelable: true,
-        });
+    /** The plot rectangle the navigator claims, in the `Box` form it stores. */
+    function plotBox(chart: unknown): Box {
+        const plot = plotOf(chart);
 
-        Object.assign(event, {
-            pointerId: 1,
-            clientX: x,
-            clientY: y,
-        });
-
-        (chart.context.element as HTMLElement).dispatchEvent(event);
+        return new Box(plot.y, plot.x, plot.y + plot.height, plot.x + plot.width);
     }
 
     test('Should narrow the window when an edge handle is dragged, driving the view transform', async () => {
@@ -728,9 +723,9 @@ describe('Overview navigator strip dragging', () => {
         const strip = rectOf(chart, 'navigator-strip');
         const crossY = strip.y + strip.height / 2;
 
-        mouse(chart, 'mousedown', strip.x + strip.width, crossY);
-        mouse(chart, 'mousemove', strip.x + strip.width / 2, crossY);
-        mouse(chart, 'mouseup', strip.x + strip.width / 2, crossY);
+        pointer(chart, 'pointerdown', strip.x + strip.width, crossY);
+        pointer(chart, 'pointermove', strip.x + strip.width / 2, crossY);
+        pointer(chart, 'pointerup', strip.x + strip.width / 2, crossY);
 
         // Halving the window doubles the zoom of the category axis.
         expect(chart.navigator?.transform.k).toBeCloseTo(2, 1);
@@ -742,8 +737,8 @@ describe('Overview navigator strip dragging', () => {
         const chart = await stripChart();
         const strip = rectOf(chart, 'navigator-strip');
 
-        mouse(chart, 'mousedown', strip.x + strip.width, strip.y - strip.height);
-        mouse(chart, 'mousemove', strip.x + strip.width / 2, strip.y - strip.height);
+        pointer(chart, 'pointerdown', strip.x + strip.width, strip.y - strip.height);
+        pointer(chart, 'pointermove', strip.x + strip.width / 2, strip.y - strip.height);
 
         expect(chart.navigator?.transform.k).toBe(1);
 
@@ -753,7 +748,7 @@ describe('Overview navigator strip dragging', () => {
     test('Should scope the navigator to the plot rectangle', async () => {
         const chart = await stripChart();
 
-        expect(chart.navigator?.bounds).toEqual(plotOf(chart));
+        expect(chart.navigator?.bounds).toEqual(plotBox(chart));
 
         chart.destroy();
     });

--- a/packages/charts/test/percent-stack.test.ts
+++ b/packages/charts/test/percent-stack.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/pie-transition.test.ts
+++ b/packages/charts/test/pie-transition.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     beforeEach,

--- a/packages/charts/test/plot-alignment.test.ts
+++ b/packages/charts/test/plot-alignment.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/radial-labels.test.ts
+++ b/packages/charts/test/radial-labels.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/radial-rest-alpha.test.ts
+++ b/packages/charts/test/radial-rest-alpha.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     beforeEach,

--- a/packages/charts/test/sankey.test.ts
+++ b/packages/charts/test/sankey.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/scales.test.ts
+++ b/packages/charts/test/scales.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/series-paint.test.ts
+++ b/packages/charts/test/series-paint.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/stacked-rounding.test.ts
+++ b/packages/charts/test/stacked-rounding.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/stock.test.ts
+++ b/packages/charts/test/stock.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     describe,

--- a/packages/charts/test/symbols.test.ts
+++ b/packages/charts/test/symbols.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/symlog-axis.test.ts
+++ b/packages/charts/test/symlog-axis.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/theme.test.ts
+++ b/packages/charts/test/theme.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     afterEach,
     describe,

--- a/packages/charts/test/time-scale.test.ts
+++ b/packages/charts/test/time-scale.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/charts/test/trend.test.ts
+++ b/packages/charts/test/trend.test.ts
@@ -1,3 +1,7 @@
+// Side-effect import: `@ripl/web` registers the browser factory (canvas context, text
+// measurement, rAF). `@ripl/charts` is context-agnostic and installs no backend of its own.
+import '@ripl/web';
+
 import {
     describe,
     expect,

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -144,6 +144,12 @@ export abstract class Context<TElement extends Element = Element, TMeta extends 
             'mouseleave',
             'mousemove',
             'mouseup',
+            'pointercancel',
+            'pointerdown',
+            'pointerenter',
+            'pointerleave',
+            'pointermove',
+            'pointerup',
             'render',
             'resize',
         ];

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -69,17 +69,64 @@ export interface RenderElement {
     emit(type: string, data: any): void;
 }
 
+/** How a pointer input was produced. */
+export type ContextPointerType = 'mouse' | 'pen' | 'touch';
+
+/**
+ * A single pointer's state during an interaction with the context surface.
+ *
+ * Unlike the `mouse*` events, which report only the primary pointer, these carry every pointer —
+ * `pointerId` is what lets a consumer track two fingers through a pinch. Backends that cannot
+ * distinguish devices report `pointerType: 'mouse'` with `isPrimary: true`.
+ */
+export interface ContextPointerEvent {
+    /** X coordinate of the pointer, in logical space (CSS pixels relative to the context's top-left). */
+    x: number;
+    /** Y coordinate of the pointer, in logical space (CSS pixels relative to the context's top-left). */
+    y: number;
+    /** Identifies this pointer for the duration of its gesture, so concurrent pointers can be told apart. */
+    pointerId: number;
+    /** The kind of device that produced the input. */
+    pointerType: ContextPointerType;
+    /** Whether this is the first pointer of a multi-pointer gesture. Only the primary pointer also emits the `mouse*` events. */
+    isPrimary: boolean;
+    /** The button whose state changed, or `-1` when no button changed (as on a plain move). */
+    button: number;
+    /** Bitmask of the buttons currently held. */
+    buttons: number;
+    /** Whether the alt key was held. */
+    altKey: boolean;
+    /** Whether the control key was held. */
+    ctrlKey: boolean;
+    /** Whether the meta (command/windows) key was held. */
+    metaKey: boolean;
+    /** Whether the shift key was held. */
+    shiftKey: boolean;
+}
+
 /** Event map for a rendering context, including resize and pointer events. */
 export interface ContextEventMap extends EventMap {
+    /** Emitted when a pointer enters the context surface. */
+    pointerenter: ContextPointerEvent;
+    /** Emitted when a pointer leaves the context surface. */
+    pointerleave: ContextPointerEvent;
+    /** Emitted when a pointer button is pressed over the surface. */
+    pointerdown: ContextPointerEvent;
+    /** Emitted as a pointer moves over the surface. */
+    pointermove: ContextPointerEvent;
+    /** Emitted when a pointer button is released; fires once per press, even when the release lands outside the surface. */
+    pointerup: ContextPointerEvent;
+    /** Emitted when a gesture is cancelled by the host (e.g. the browser taking over for a scroll), ending it without a `click`. */
+    pointercancel: ContextPointerEvent;
     /** Emitted when the context's rendering surface is resized. */
     resize: null;
     /** Emitted to request that the bound scene repaint on the next frame, for context-level changes (e.g. a 3D camera move) that mutate no element. */
     render: null;
-    /** Emitted when the pointer enters the context surface. */
+    /** Emitted when the primary pointer enters the context surface. */
     mouseenter: null;
-    /** Emitted when the pointer leaves the context surface. */
+    /** Emitted when the primary pointer leaves the context surface. */
     mouseleave: null;
-    /** Emitted as the pointer moves over the surface, carrying its position. */
+    /** Emitted as the primary pointer moves over the surface, carrying its position. */
     mousemove: {
         /** X coordinate of the pointer, in logical space (CSS pixels relative to the context's top-left). */
         x: number;

--- a/packages/core/src/core/factory.ts
+++ b/packages/core/src/core/factory.ts
@@ -5,6 +5,12 @@ import type {
     MeasureTextOptions,
 } from '../context';
 
+// Type-only: a value import would cycle (factory → navigator → event-bus → factory).
+import type {
+    Navigator,
+    NavigatorOptions,
+} from './navigator';
+
 /** Platform-specific function implementations injected at runtime. */
 export interface FactoryOptions {
     /** Schedules `callback` to run before the next repaint, returning a handle used to cancel it. */
@@ -22,6 +28,13 @@ export interface FactoryOptions {
     };
     /** Creates a rendering {@link Context} bound to the given target selector or element. */
     createContext(target: string | HTMLElement, options?: ContextOptions): Context;
+    /**
+     * Creates the platform's pan/zoom/brush {@link Navigator} for the given context, wired to
+     * whatever input that platform has. `@ripl/web` registers the gesture-bound DOM navigator;
+     * `@ripl/node` registers the base {@link Navigator}, which owns the same view model but binds
+     * no input.
+     */
+    createNavigator(context: Context, options?: NavigatorOptions): Navigator;
     /** Creates a DOM element with the given tag name. */
     createElement(tagName: string): HTMLElement;
     /** Creates a namespaced DOM element (e.g. SVG) with the given namespace URI and tag name. */
@@ -64,6 +77,11 @@ class Factory {
     /** The platform {@link Context} factory function. */
     public get createContext() {
         return this._state.createContext!;
+    }
+
+    /** The platform {@link Navigator} factory function. */
+    public get createNavigator() {
+        return this._state.createNavigator!;
     }
 
     /** The platform element-creation function. */

--- a/packages/core/src/core/navigator.ts
+++ b/packages/core/src/core/navigator.ts
@@ -7,6 +7,7 @@ import type {
 } from './event-bus';
 
 import type {
+    Box,
     Point,
 } from '../math';
 
@@ -42,18 +43,6 @@ export interface NavigatorViewport {
     /** Width of the surface, in logical pixels. */
     width: number;
     /** Height of the surface, in logical pixels. */
-    height: number;
-}
-
-/** The region of the surface a navigator claims for input, in logical pixels. */
-export interface NavigatorBounds {
-    /** X coordinate of the region's left edge, in logical pixels (CSS pixels relative to the context's top-left, unaffected by the device pixel ratio). */
-    x: number;
-    /** Y coordinate of the region's top edge, in logical pixels (CSS pixels relative to the context's top-left, unaffected by the device pixel ratio). */
-    y: number;
-    /** Width of the region, in logical pixels. */
-    width: number;
-    /** Height of the region, in logical pixels. */
     height: number;
 }
 
@@ -96,11 +85,12 @@ export interface NavigatorOptions {
      */
     interactions?: boolean | NavigatorInteractions;
     /**
-     * The region of the surface the navigator claims for input. A gesture starting outside it is
-     * left to whatever else is there; an unset region claims the whole surface. Honored by
-     * input-bound navigators; the base {@link Navigator} binds no input and ignores it.
+     * The region of the surface the navigator claims for input, in logical pixels. A gesture
+     * starting outside it is left to whatever else is there; an unset region claims the whole
+     * surface. Honored by input-bound navigators; the base {@link Navigator} binds no input and
+     * ignores it.
      */
-    bounds?: NavigatorBounds;
+    bounds?: Box;
 }
 
 /** Options for {@link Navigator.fitBounds}. */
@@ -199,7 +189,7 @@ export function rescaleDomain<TDomain>(
 export class Navigator extends EventBus<NavigatorEventMap> {
 
     protected _brush: NavigatorBrush | null = null;
-    protected _bounds?: NavigatorBounds;
+    protected _bounds?: Box;
     protected _scaleExtent: [number, number];
     protected _viewport: NavigatorViewport;
     protected _transform: NavigatorTransform = {
@@ -259,17 +249,17 @@ export class Navigator extends EventBus<NavigatorEventMap> {
      * of it. Input-bound subclasses ignore gestures starting outside it; the base class binds no
      * input and only stores it. Set it to hand the rest of the surface to something else — a chart
      * scopes its navigator to the plot rectangle so the overview strip beneath owns its own band.
+     *
+     * Assign a new {@link Box} rather than mutating the existing one. Unlike the other accessors
+     * here this returns the instance, not a copy: a `Box` carries `width`/`height` as prototype
+     * getters, which a spread would silently drop.
      */
-    public get bounds(): NavigatorBounds | undefined {
-        return this._bounds && {
-            ...this._bounds,
-        };
+    public get bounds(): Box | undefined {
+        return this._bounds;
     }
 
-    public set bounds(bounds: NavigatorBounds | undefined) {
-        this._bounds = bounds && {
-            ...bounds,
-        };
+    public set bounds(bounds: Box | undefined) {
+        this._bounds = bounds;
     }
 
     constructor(options?: NavigatorOptions) {

--- a/packages/core/src/core/navigator.ts
+++ b/packages/core/src/core/navigator.ts
@@ -45,6 +45,18 @@ export interface NavigatorViewport {
     height: number;
 }
 
+/** The region of the surface a navigator claims for input, in logical pixels. */
+export interface NavigatorBounds {
+    /** X coordinate of the region's left edge, in logical pixels (CSS pixels relative to the context's top-left, unaffected by the device pixel ratio). */
+    x: number;
+    /** Y coordinate of the region's top edge, in logical pixels (CSS pixels relative to the context's top-left, unaffected by the device pixel ratio). */
+    y: number;
+    /** Width of the region, in logical pixels. */
+    width: number;
+    /** Height of the region, in logical pixels. */
+    height: number;
+}
+
 /** Enable/disable a single interaction, optionally with a sensitivity multiplier. */
 export type NavigatorInteractionOption = boolean | {
     /** Whether the interaction is enabled. */
@@ -77,6 +89,18 @@ export interface NavigatorOptions {
     scaleExtent?: [number, number];
     /** Initial viewport dimensions used by {@link Navigator.centerOn}/{@link Navigator.fitBounds}. */
     viewport?: NavigatorViewport;
+    /**
+     * Enables all gestures, or configures pan, zoom, and brush individually. Honored by
+     * input-bound navigators (e.g. the one `@ripl/web` registers on {@link FactoryOptions.createNavigator});
+     * the base {@link Navigator} binds no input and ignores it. See {@link NavigatorInteractions}.
+     */
+    interactions?: boolean | NavigatorInteractions;
+    /**
+     * The region of the surface the navigator claims for input. A gesture starting outside it is
+     * left to whatever else is there; an unset region claims the whole surface. Honored by
+     * input-bound navigators; the base {@link Navigator} binds no input and ignores it.
+     */
+    bounds?: NavigatorBounds;
 }
 
 /** Options for {@link Navigator.fitBounds}. */
@@ -175,6 +199,7 @@ export function rescaleDomain<TDomain>(
 export class Navigator extends EventBus<NavigatorEventMap> {
 
     protected _brush: NavigatorBrush | null = null;
+    protected _bounds?: NavigatorBounds;
     protected _scaleExtent: [number, number];
     protected _viewport: NavigatorViewport;
     protected _transform: NavigatorTransform = {
@@ -229,6 +254,24 @@ export class Navigator extends EventBus<NavigatorEventMap> {
         };
     }
 
+    /**
+     * The region of the surface this navigator claims for input, or `undefined` when it claims all
+     * of it. Input-bound subclasses ignore gestures starting outside it; the base class binds no
+     * input and only stores it. Set it to hand the rest of the surface to something else — a chart
+     * scopes its navigator to the plot rectangle so the overview strip beneath owns its own band.
+     */
+    public get bounds(): NavigatorBounds | undefined {
+        return this._bounds && {
+            ...this._bounds,
+        };
+    }
+
+    public set bounds(bounds: NavigatorBounds | undefined) {
+        this._bounds = bounds && {
+            ...bounds,
+        };
+    }
+
     constructor(options?: NavigatorOptions) {
         super();
 
@@ -237,6 +280,7 @@ export class Navigator extends EventBus<NavigatorEventMap> {
             width: options?.viewport?.width ?? 0,
             height: options?.viewport?.height ?? 0,
         };
+        this.bounds = options?.bounds;
     }
 
     protected _commit(event: 'zoom' | 'pan'): void {

--- a/packages/core/src/elements/image.ts
+++ b/packages/core/src/elements/image.ts
@@ -87,7 +87,12 @@ function getSourceSize(image: CanvasImageSource): [number, number] {
     return [0, 0];
 }
 
-/** Interpolator factory that cross-fades between two image sources using an offscreen canvas. */
+/**
+ * Interpolator factory that cross-fades between two image sources using an offscreen canvas.
+ *
+ * The canvas comes from the platform, so off-platform (e.g. under `@ripl/node`, where there is
+ * none) this degrades to swapping images at the halfway point rather than throwing.
+ */
 export const interpolateImage: InterpolatorFactory<CanvasImageSource> = (valueA, valueB) => {
     const [sourceWidth, sourceHeight] = getSourceSize(valueA);
 

--- a/packages/core/src/math/geometry.ts
+++ b/packages/core/src/math/geometry.ts
@@ -239,7 +239,12 @@ const getRefPathElement = functionCache(() => {
     return factory.createElementNS('http://www.w3.org/2000/svg', 'path') as SVGPathElement;
 });
 
-/** Computes the total length of an SVG path from its `d` attribute string. */
+/**
+ * Computes the total length of an SVG path from its `d` attribute string.
+ *
+ * Measured by a real SVG `<path>` element, so this needs a DOM. Off-platform (e.g. under
+ * `@ripl/node`) the element is a stub and this returns `0` rather than throwing.
+ */
 export function getPathLength(pathData: string): number {
     const pathEl = getRefPathElement();
     pathEl.setAttribute('d', pathData);
@@ -247,7 +252,12 @@ export function getPathLength(pathData: string): number {
     return pathEl.getTotalLength();
 }
 
-/** Samples a point and tangent angle at the given distance along an SVG path. */
+/**
+ * Samples a point and tangent angle at the given distance along an SVG path.
+ *
+ * Measured by a real SVG `<path>` element, so this needs a DOM. Off-platform (e.g. under
+ * `@ripl/node`) the element is a stub and this returns the origin rather than throwing.
+ */
 export function samplePathPoint(pathData: string, distance: number): PathPoint {
     const pathEl = getRefPathElement();
 

--- a/packages/core/test/core/navigator.test.ts
+++ b/packages/core/test/core/navigator.test.ts
@@ -6,6 +6,7 @@ import {
 } from 'vitest';
 
 import {
+    Box,
     Navigator,
     rescaleDomain,
 } from '../../src';
@@ -233,6 +234,42 @@ describe('rescaleDomain', () => {
         }, [0, 200]);
 
         expect(domain).toEqual([50, 150]);
+    });
+
+});
+
+describe('Navigator bounds', () => {
+
+    test('Should claim the whole surface by default', () => {
+        expect(new Navigator().bounds).toBeUndefined();
+    });
+
+    test('Should take a claimed region from the options', () => {
+        const bounds = new Box(16, 30, 304, 624);
+        const navigator = new Navigator({ bounds });
+
+        expect(navigator.bounds).toBe(bounds);
+        expect(navigator.bounds?.width).toBe(594);
+        expect(navigator.bounds?.height).toBe(288);
+    });
+
+    // The accessor hands back the instance, so `width`/`height` survive; a spread would drop them.
+    test('Should hand back the assigned box rather than a copy of its own', () => {
+        const navigator = new Navigator();
+        const bounds = new Box(0, 0, 100, 200);
+
+        navigator.bounds = bounds;
+
+        expect(navigator.bounds).toBe(bounds);
+        expect(navigator.bounds).toBeInstanceOf(Box);
+    });
+
+    test('Should clear the claimed region', () => {
+        const navigator = new Navigator({ bounds: new Box(0, 0, 10, 10) });
+
+        navigator.bounds = undefined;
+
+        expect(navigator.bounds).toBeUndefined();
     });
 
 });

--- a/packages/core/test/node.node.test.ts
+++ b/packages/core/test/node.node.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment node
+
+/**
+ * Core's suite otherwise runs under jsdom, so a DOM dependency creeping into the render path would
+ * go unnoticed. This file renders the element set with no `window` and no `document`, and pins the
+ * two capabilities that are known to degrade rather than work off-platform.
+ */
+
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from 'vitest';
+
+// Side-effect import: registers the node factory bindings (overrides vitest.setup.ts).
+import '@ripl/node';
+
+import {
+    createArc,
+    createCircle,
+    createEllipse,
+    createGroup,
+    createLine,
+    createPolygon,
+    createPolyline,
+    createRect,
+    createRenderer,
+    createScene,
+    createText,
+    factory,
+    getPathLength,
+    measureText,
+    Navigator,
+    samplePathPoint,
+} from '@ripl/core';
+
+import {
+    createContext,
+} from '@ripl/terminal';
+
+import type {
+    TerminalOutput,
+} from '@ripl/terminal';
+
+function capturingOutput() {
+    const frames: string[] = [];
+
+    return {
+        frames,
+        output: {
+            write: (data: string) => void frames.push(data),
+            columns: 80,
+            rows: 24,
+        } as TerminalOutput,
+    };
+}
+
+describe('Core outside a DOM', () => {
+
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        expect(console.error).not.toHaveBeenCalled();
+        vi.restoreAllMocks();
+    });
+
+    test('Should be running without a document or a window', () => {
+        expect(typeof window).toBe('undefined');
+        expect(typeof document).toBe('undefined');
+    });
+
+    test('Should render every built-in element to a terminal surface', () => {
+        const { frames, output } = capturingOutput();
+        const scene = createScene(createContext(output));
+
+        scene.add(createGroup({
+            id: 'shapes',
+            children: [
+                createArc({
+                    cx: 30,
+                    cy: 30,
+                    radius: 10,
+                    startAngle: 0,
+                    endAngle: Math.PI,
+                    fill: '#ff0000',
+                }),
+                createCircle({
+                    cx: 60,
+                    cy: 30,
+                    radius: 8,
+                    fill: '#00ff00',
+                }),
+                createEllipse({
+                    cx: 90,
+                    cy: 30,
+                    radiusX: 12,
+                    radiusY: 6,
+                    fill: '#0000ff',
+                }),
+                createLine({
+                    x1: 10,
+                    y1: 60,
+                    x2: 110,
+                    y2: 60,
+                    stroke: '#ffffff',
+                }),
+                createPolygon({
+                    points: [[10, 80], [40, 80], [25, 100]],
+                    fill: '#ffff00',
+                }),
+                createPolyline({
+                    points: [[60, 80], [80, 100], [100, 80]],
+                    stroke: '#00ffff',
+                }),
+                createRect({
+                    x: 10,
+                    y: 110,
+                    width: 40,
+                    height: 20,
+                    fill: '#ff00ff',
+                }),
+                createText({
+                    x: 60,
+                    y: 120,
+                    content: 'ripl',
+                    fill: '#ffffff',
+                }),
+            ],
+        }));
+
+        scene.render();
+
+        expect(frames.join('')).not.toBe('');
+
+        scene.destroy(true);
+    });
+
+    test('Should drive a renderer off the platform animation frame', async () => {
+        const { output } = capturingOutput();
+        const scene = createScene(createContext(output));
+        const renderer = createRenderer(scene);
+
+        const circle = createCircle({
+            cx: 10,
+            cy: 10,
+            radius: 4,
+            fill: '#ffffff',
+        });
+
+        scene.add(circle);
+
+        await renderer.transition(circle, {
+            duration: 10,
+            state: {
+                radius: 8,
+            },
+        });
+
+        expect(circle.radius).toBe(8);
+
+        renderer.destroy();
+        scene.destroy(true);
+    });
+
+    test('Should measure text through the platform binding', () => {
+        expect(measureText('ripl').width).toBeGreaterThan(0);
+    });
+
+    test('Should hand back the base navigator, which drives the view without input', () => {
+        const { output } = capturingOutput();
+        const navigator = factory.createNavigator(createContext(output));
+
+        expect(navigator).toBeInstanceOf(Navigator);
+
+        navigator.zoomTo(3, [0, 0]);
+
+        expect(navigator.transform.k).toBe(3);
+
+        navigator.destroy();
+    });
+
+    // Known gap: path metrics are measured by an SVG `<path>`, so off-DOM they degrade rather than throw.
+    test('Should degrade path metrics rather than throw', () => {
+        expect(getPathLength('M0,0 L10,10')).toBe(0);
+        expect(samplePathPoint('M0,0 L10,10', 5)).toEqual({
+            x: 0,
+            y: 0,
+            angle: 0,
+        });
+    });
+
+});

--- a/packages/dom/src/context.ts
+++ b/packages/dom/src/context.ts
@@ -6,6 +6,8 @@ import {
 
 import type {
     ContextOptions,
+    ContextPointerEvent,
+    ContextPointerType,
     RenderElement,
 } from '@ripl/core';
 
@@ -29,11 +31,14 @@ interface InteractionState {
     left: number;
     top: number;
     pointerButtons: Set<number>;
+    activePointers: Set<number>;
     dragElement: RenderElement | undefined;
     dragStartX: number;
     dragStartY: number;
     dragStarted: boolean;
     suppressClick: boolean;
+    withinSurface: boolean;
+    capturedPointerId: number | undefined;
     scheduleHitTest: ReturnType<typeof createFrameBuffer>;
 }
 
@@ -141,27 +146,90 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this._activeElements.clear();
     }
 
-    private _handleMouseEnter(): void {
-        this._refreshOrigin(true);
-        this.emit('mouseenter', null);
-    }
-
-    private _handleMouseLeave(): void {
-        this._flushActiveElements();
-        this.emit('mouseleave', null);
-    }
-
     private _getLogicalPoint(event: MouseEvent): [number, number] {
         const state = this._interactionState!;
 
         return [event.clientX - state.left, event.clientY - state.top];
     }
 
-    private _handleMouseDown(event: MouseEvent): void {
+    private _pointerPayload(event: PointerEvent, x: number, y: number): ContextPointerEvent {
+        return {
+            x,
+            y,
+            pointerId: event.pointerId,
+            pointerType: event.pointerType as ContextPointerType,
+            isPrimary: event.isPrimary,
+            button: event.button,
+            buttons: event.buttons,
+            altKey: event.altKey,
+            ctrlKey: event.ctrlKey,
+            metaKey: event.metaKey,
+            shiftKey: event.shiftKey,
+        };
+    }
+
+    /**
+     * The single gate for context-level enter/leave, so the native events and the ones synthesized
+     * during a captured drag cannot double up. Capture retargets moves to the surface and suppresses
+     * the browser's own leave, so crossing the edge mid-gesture is only visible here.
+     */
+    private _setWithinSurface(inside: boolean, event: PointerEvent, x: number, y: number): void {
+        const state = this._interactionState!;
+
+        if (state.withinSurface === inside) {
+            return;
+        }
+
+        state.withinSurface = inside;
+
+        const payload = this._pointerPayload(event, x, y);
+
+        if (inside) {
+            this._refreshOrigin(true);
+            this.emit('pointerenter', payload);
+
+            if (event.isPrimary) {
+                this.emit('mouseenter', null);
+            }
+
+            return;
+        }
+
+        this._flushActiveElements();
+        this.emit('pointerleave', payload);
+
+        if (event.isPrimary) {
+            this.emit('mouseleave', null);
+        }
+    }
+
+    private _handlePointerEnter(event: PointerEvent): void {
+        this._refreshOrigin(true);
+        this._setWithinSurface(true, event, ...this._getLogicalPoint(event));
+    }
+
+    private _handlePointerLeave(event: PointerEvent): void {
+        this._flushActiveElements();
+        this._setWithinSurface(false, event, ...this._getLogicalPoint(event));
+    }
+
+    private _handlePointerDown(event: PointerEvent): void {
         this._refreshOrigin();
 
         const state = this._interactionState!;
         const [x, y] = this._getLogicalPoint(event);
+
+        state.activePointers.add(event.pointerId);
+        this.emit('pointerdown', this._pointerPayload(event, x, y));
+
+        if (!event.isPrimary) {
+            return;
+        }
+
+        // Capture keeps a drag tracking once it leaves the surface; without it the gesture strands.
+        (this.element as unknown as HTMLElement).setPointerCapture?.(event.pointerId);
+        state.capturedPointerId = event.pointerId;
+        state.withinSurface = true;
 
         const payload = {
             x,
@@ -183,11 +251,25 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         hitElements.find(element => element.has('mousedown'))?.emit('mousedown', payload);
     }
 
-    private _handleMouseMove(event: MouseEvent): void {
+    private _handlePointerMove(event: PointerEvent): void {
         this._refreshOrigin();
 
         const state = this._interactionState!;
         const [x, y] = this._getLogicalPoint(event);
+
+        this.emit('pointermove', this._pointerPayload(event, x, y));
+
+        if (!event.isPrimary) {
+            return;
+        }
+
+        // While captured the browser reports no leave of its own, so the edge crossing is only visible here.
+        if (state.capturedPointerId !== undefined) {
+            this._setWithinSurface(this._isWithinSurface(x, y), event, x, y);
+        } else if (this._isWithinSurface(x, y)) {
+            // A move over the surface proves the pointer is on it, even where the enter was missed.
+            state.withinSurface = true;
+        }
 
         this.emit('mousemove', {
             x,
@@ -275,15 +357,20 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
      * {@link DOMContext.disableInteraction} has already dropped — hence the null check rather than
      * the non-null assertion the surface-bound handlers use.
      */
-    private _handleMouseUp(event: MouseEvent): void {
+    private _handlePointerUp(event: PointerEvent, cancelled?: boolean): void {
         const state = this._interactionState;
+
+        // Per pointer, so every finger of a pinch is released and the double-bound handler dedupes.
+        if (state?.activePointers.delete(event.pointerId)) {
+            this._refreshOrigin();
+            this._releaseCapture(event);
+            this.emit(cancelled ? 'pointercancel' : 'pointerup', this._pointerPayload(event, ...this._getLogicalPoint(event)));
+        }
 
         // Per button, so a second button gets its own `mouseup` and the double-bound handler dedupes.
         if (!state?.pointerButtons.delete(event.button)) {
             return;
         }
-
-        this._refreshOrigin();
 
         const [x, y] = this._getLogicalPoint(event);
 
@@ -317,6 +404,27 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         state.dragStarted = false;
     }
 
+    /**
+     * A gesture the host took over (a browser deciding the touch was a scroll). It ends the same way
+     * a release does — a consumer half-way through a drag must not be stranded — but no `click`
+     * follows one, so the suppression flag is left alone.
+     */
+    private _handlePointerCancel(event: PointerEvent): void {
+        this._handlePointerUp(event, true);
+    }
+
+    /** Hands the pointer back to the browser, so its own leave/enter reporting resumes. */
+    private _releaseCapture(event: PointerEvent): void {
+        const state = this._interactionState!;
+
+        if (state.capturedPointerId !== event.pointerId) {
+            return;
+        }
+
+        (this.element as unknown as HTMLElement).releasePointerCapture?.(event.pointerId);
+        state.capturedPointerId = undefined;
+    }
+
     private _handleClick(event: MouseEvent): void {
         const state = this._interactionState!;
 
@@ -340,7 +448,17 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         this.hitTest(['click'], x, y).at(0)?.emit('click', payload);
     }
 
-    /** Enables DOM interaction events (mouse enter, leave, move, down, up, click, drag) with element hit testing. */
+    /**
+     * Enables interaction events (pointer enter, leave, move, down, up, cancel, click, drag) with
+     * element hit testing.
+     *
+     * Pointer events are the single input source: they cover mouse, pen and touch alike, where the
+     * mouse events they replace only reached touch through the browser's compatibility shims. Each
+     * one emits its `pointer*` event for every pointer, then — for the primary pointer only — the
+     * `mouse*`/`drag*` events with their original payloads, so existing consumers are unchanged and
+     * gain touch and pen for free. `click` keeps its own binding; its suppression-after-drag
+     * semantics are unrelated.
+     */
     public enableInteraction(): void {
         if (this._interactionEnabled) {
             return;
@@ -352,19 +470,23 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             left: 0,
             top: 0,
             pointerButtons: new Set(),
+            activePointers: new Set(),
             dragElement: undefined,
             dragStartX: 0,
             dragStartY: 0,
             dragStarted: false,
             suppressClick: false,
+            withinSurface: false,
+            capturedPointerId: undefined,
             scheduleHitTest: createFrameBuffer(),
         };
 
-        this._attachInteractionEvent('mouseenter', () => this._handleMouseEnter());
-        this._attachInteractionEvent('mouseleave', () => this._handleMouseLeave());
-        this._attachInteractionEvent('mousedown', event => this._handleMouseDown(event));
-        this._attachInteractionEvent('mousemove', event => this._handleMouseMove(event));
-        this._attachInteractionEvent('mouseup', event => this._handleMouseUp(event));
+        this._attachInteractionEvent('pointerenter', event => this._handlePointerEnter(event));
+        this._attachInteractionEvent('pointerleave', event => this._handlePointerLeave(event));
+        this._attachInteractionEvent('pointerdown', event => this._handlePointerDown(event));
+        this._attachInteractionEvent('pointermove', event => this._handlePointerMove(event));
+        this._attachInteractionEvent('pointerup', event => this._handlePointerUp(event));
+        this._attachInteractionEvent('pointercancel', event => this._handlePointerCancel(event));
         this._attachInteractionEvent('click', event => this._handleClick(event));
 
         if (hasWindow) {
@@ -377,10 +499,11 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
             this.retain(onDOMEvent(window, 'resize', () => this._originDirty = true), INTERACTION_KEY);
 
             // A release outside the surface never reaches the element, stranding the drag with no `dragend`.
-            this.retain(onDOMEvent(window, 'mouseup', event => this._handleMouseUp(event)), INTERACTION_KEY);
+            this.retain(onDOMEvent(window, 'pointerup', event => this._handlePointerUp(event)), INTERACTION_KEY);
+            this.retain(onDOMEvent(window, 'pointercancel', event => this._handlePointerCancel(event)), INTERACTION_KEY);
         }
 
-        // Seeded now rather than on the first `mouseenter`, which never fires for a surface mounted under the pointer.
+        // Seeded now rather than on the first enter, which never fires for a surface mounted under the pointer.
         this._refreshOrigin(true);
     }
 
@@ -391,6 +514,12 @@ export abstract class DOMContext<TElement extends Element = Element, TMeta exten
         }
 
         this._interactionEnabled = false;
+
+        const captured = this._interactionState?.capturedPointerId;
+
+        if (captured !== undefined) {
+            (this.element as unknown as HTMLElement).releasePointerCapture?.(captured);
+        }
 
         // Ahead of dropping the state, which holds the frame buffer the flush has to cancel.
         this._flushActiveElements();

--- a/packages/dom/src/navigator.ts
+++ b/packages/dom/src/navigator.ts
@@ -22,11 +22,8 @@ import {
     onDOMEvent,
 } from './dom';
 
-/** Options for constructing a {@link DOMNavigator}, adding interaction wiring to the base options. */
-export interface DOMNavigatorOptions extends NavigatorOptions {
-    /** Enables all wheel/pointer/touch interactions, or configures pan, zoom, and brush individually. */
-    interactions?: boolean | NavigatorInteractions;
-}
+/** Options for constructing a {@link DOMNavigator}. Alias of {@link NavigatorOptions}, which carries the `interactions` and `bounds` this class honors. */
+export type DOMNavigatorOptions = NavigatorOptions;
 
 const INTERACTION_KEY = Symbol('navigator-interaction');
 const VIEWPORT_KEY = Symbol('navigator-viewport');
@@ -57,6 +54,10 @@ function isInteractiveElement(element: unknown): element is HTMLElement {
  * Because the base transform is unbounded, dragging past the viewport edge (the pointer is captured
  * for the duration of the drag) keeps panning, so content outside the current viewport can be reached
  * and then re-framed with the base `centerOn`/`fitBounds` helpers.
+ *
+ * {@link Navigator.bounds} scopes which gestures are claimed: the wheel and a gesture's first press
+ * are ignored outside the region, leaving the rest of the surface to whatever else is listening.
+ * Continuation is never gated, so a drag that leaves the region keeps tracking.
  */
 export class DOMNavigator extends Navigator {
 
@@ -143,6 +144,25 @@ export class DOMNavigator extends Navigator {
         ];
     }
 
+    /** Whether a gesture starting at `point` belongs to this navigator, per its {@link Navigator.bounds}. */
+    private _withinBounds(point: Point): boolean {
+        if (!this._bounds) {
+            return true;
+        }
+
+        const {
+            x,
+            y,
+            width,
+            height,
+        } = this._bounds;
+
+        return point[0] >= x
+            && point[0] <= x + width
+            && point[1] >= y
+            && point[1] <= y + height;
+    }
+
     private _setCursor(cursor: string): void {
         if (this._panCursorEnabled) {
             this._element.style.cursor = cursor;
@@ -174,11 +194,18 @@ export class DOMNavigator extends Navigator {
 
         if (zoom.enabled) {
             this.retain(onDOMEvent(this._element, 'wheel', event => {
+                const point = this._localPoint(event);
+
+                // Ahead of `preventDefault`, so a wheel outside the claimed region still scrolls the page.
+                if (!this._withinBounds(point)) {
+                    return;
+                }
+
                 event.preventDefault();
 
                 const factor = Math.exp(-event.deltaY * WHEEL_SENSITIVITY * zoom.sensitivity);
 
-                this.zoomBy(factor, this._localPoint(event));
+                this.zoomBy(factor, point);
             }), INTERACTION_KEY);
         }
 
@@ -199,7 +226,14 @@ export class DOMNavigator extends Navigator {
 
     private _attachPointerInteractions(pan: ResolvedInteraction, brush: ResolvedInteraction): void {
         this.retain(onDOMEvent(this._element, 'pointerdown', event => {
-            this._pointers.set(event.pointerId, this._localPoint(event));
+            const origin = this._localPoint(event);
+
+            // Only a gesture's first press is gated; a second finger completing a pinch may land anywhere.
+            if (this._pointers.size === 0 && !this._withinBounds(origin)) {
+                return;
+            }
+
+            this._pointers.set(event.pointerId, origin);
 
             // Every tracked pointer, not just the gesturing ones: an uncaptured release off the element leaks its entry.
             this._element.setPointerCapture?.(event.pointerId);
@@ -221,7 +255,7 @@ export class DOMNavigator extends Navigator {
                 return;
             }
 
-            this._dragStart = this._localPoint(event);
+            this._dragStart = origin;
 
             if (this._panning) {
                 this._setCursor('grabbing');

--- a/packages/dom/src/navigator.ts
+++ b/packages/dom/src/navigator.ts
@@ -1,4 +1,5 @@
 import {
+    isPointInBox,
     Navigator,
     resolveInteraction,
 } from '@ripl/core';
@@ -51,9 +52,12 @@ function isInteractiveElement(element: unknown): element is HTMLElement {
  * - **wheel** zooms toward the pointer, and a two-finger **pinch** zooms toward the gesture center;
  * - **⇧ shift-drag** brushes a rectangular selection when brushing is enabled.
  *
- * Because the base transform is unbounded, dragging past the viewport edge (the pointer is captured
- * for the duration of the drag) keeps panning, so content outside the current viewport can be reached
- * and then re-framed with the base `centerOn`/`fitBounds` helpers.
+ * Pointer input arrives through the context's own `pointer*` events, which report every pointer in
+ * logical space and cover mouse, pen and touch alike; only the wheel is read from the DOM directly,
+ * because suppressing page scroll needs the raw event. Because the base transform is unbounded,
+ * dragging past the viewport edge keeps panning — the context captures the pointer for the duration
+ * of the gesture — so content outside the current viewport can be reached and then re-framed with
+ * the base `centerOn`/`fitBounds` helpers.
  *
  * {@link Navigator.bounds} scopes which gestures are claimed: the wheel and a gesture's first press
  * are ignored outside the region, leaving the rest of the surface to whatever else is listening.
@@ -61,6 +65,7 @@ function isInteractiveElement(element: unknown): element is HTMLElement {
  */
 export class DOMNavigator extends Navigator {
 
+    private _context: Context;
     private _element: HTMLElement;
     private _previousTouchAction = '';
     private _previousCursor = '';
@@ -78,6 +83,7 @@ export class DOMNavigator extends Navigator {
     constructor(context: Context, options?: DOMNavigatorOptions) {
         super(options);
 
+        this._context = context;
         this._element = context.element as unknown as HTMLElement;
 
         // Non-DOM contexts (e.g. terminal) carry a dummy element, so feature-detect and stay inert, not crash.
@@ -146,21 +152,7 @@ export class DOMNavigator extends Navigator {
 
     /** Whether a gesture starting at `point` belongs to this navigator, per its {@link Navigator.bounds}. */
     private _withinBounds(point: Point): boolean {
-        if (!this._bounds) {
-            return true;
-        }
-
-        const {
-            x,
-            y,
-            width,
-            height,
-        } = this._bounds;
-
-        return point[0] >= x
-            && point[0] <= x + width
-            && point[1] >= y
-            && point[1] <= y + height;
+        return !this._bounds || isPointInBox(point, this._bounds);
     }
 
     private _setCursor(cursor: string): void {
@@ -225,8 +217,8 @@ export class DOMNavigator extends Navigator {
     }
 
     private _attachPointerInteractions(pan: ResolvedInteraction, brush: ResolvedInteraction): void {
-        this.retain(onDOMEvent(this._element, 'pointerdown', event => {
-            const origin = this._localPoint(event);
+        this.retain(this._context.on('pointerdown', ({ data: event }) => {
+            const origin: Point = [event.x, event.y];
 
             // Only a gesture's first press is gated; a second finger completing a pinch may land anywhere.
             if (this._pointers.size === 0 && !this._withinBounds(origin)) {
@@ -235,9 +227,6 @@ export class DOMNavigator extends Navigator {
 
             this._pointers.set(event.pointerId, origin);
 
-            // Every tracked pointer, not just the gesturing ones: an uncaptured release off the element leaks its entry.
-            this._element.setPointerCapture?.(event.pointerId);
-
             if (this._pointers.size === 2) {
                 this._pinchDistance = this._pointerDistance();
                 this._panning = false;
@@ -245,7 +234,7 @@ export class DOMNavigator extends Navigator {
                 return;
             }
 
-            const button = event.button ?? 0;
+            const button = event.button;
 
             // Shift-drag brushes; any other left/middle click-and-hold pans, matching the Figma grab gesture.
             this._brushing = brush.enabled && event.shiftKey;
@@ -262,12 +251,12 @@ export class DOMNavigator extends Navigator {
             }
         }), INTERACTION_KEY);
 
-        this.retain(onDOMEvent(this._element, 'pointermove', event => {
+        this.retain(this._context.on('pointermove', ({ data: event }) => {
             if (!this._pointers.has(event.pointerId)) {
                 return;
             }
 
-            const point = this._localPoint(event);
+            const point: Point = [event.x, event.y];
             this._pointers.set(event.pointerId, point);
 
             if (this._pointers.size >= 2) {
@@ -291,8 +280,8 @@ export class DOMNavigator extends Navigator {
             }
         }), INTERACTION_KEY);
 
-        const endPointer = (event: PointerEvent) => {
-            this._pointers.delete(event.pointerId);
+        const endPointer = (pointerId: number) => {
+            this._pointers.delete(pointerId);
 
             if (this._brushing) {
                 this.emit('brushend', this.brush);
@@ -315,8 +304,8 @@ export class DOMNavigator extends Navigator {
             this._setCursor('grab');
         };
 
-        this.retain(onDOMEvent(this._element, 'pointerup', endPointer), INTERACTION_KEY);
-        this.retain(onDOMEvent(this._element, 'pointercancel', endPointer), INTERACTION_KEY);
+        this.retain(this._context.on('pointerup', ({ data }) => endPointer(data.pointerId)), INTERACTION_KEY);
+        this.retain(this._context.on('pointercancel', ({ data }) => endPointer(data.pointerId)), INTERACTION_KEY);
     }
 
     private _pointerDistance(): number {

--- a/packages/dom/test/context.test.ts
+++ b/packages/dom/test/context.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'vitest';
 
 import {
+    dispatchPointerEvent,
     mockCanvasContext,
     polyfillPath2D,
 } from '@ripl/test-utils';
@@ -85,10 +86,10 @@ describe('DOMContext interaction origin', () => {
 
         const subscription = context.on('mousemove', event => positions.push(event.data));
 
-        context.element.dispatchEvent(new MouseEvent('mousemove', {
+        dispatchPointerEvent(context.element, 'pointermove', {
             clientX,
             clientY,
-        }));
+        });
 
         subscription.dispose();
 
@@ -112,7 +113,7 @@ describe('DOMContext interaction origin', () => {
 
         const context = create();
 
-        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+        dispatchPointerEvent(context.element, 'pointerenter');
 
         expect(mouseMove(context, 200, 150)).toEqual({
             x: 80,
@@ -126,7 +127,7 @@ describe('DOMContext interaction origin', () => {
 
         const context = create();
 
-        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+        dispatchPointerEvent(context.element, 'pointerenter');
         setOrigin(120, 20);
         window.dispatchEvent(new Event('scroll'));
 
@@ -141,7 +142,7 @@ describe('DOMContext interaction origin', () => {
 
         const context = create();
 
-        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+        dispatchPointerEvent(context.element, 'pointerenter');
         setOrigin(40, 80);
         window.dispatchEvent(new Event('resize'));
 
@@ -156,7 +157,7 @@ describe('DOMContext interaction origin', () => {
 
         const context = create();
 
-        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+        dispatchPointerEvent(context.element, 'pointerenter');
         setOrigin(10, 10);
 
         context['rescale'](SURFACE_WIDTH, SURFACE_HEIGHT);
@@ -196,10 +197,10 @@ describe('DOMContext interaction origin', () => {
         const getBoundingClientRect = vi.spyOn(context.element, 'getBoundingClientRect').mockClear();
 
         window.dispatchEvent(new Event('scroll'));
-        context.element.dispatchEvent(new MouseEvent('mousemove', {
+        dispatchPointerEvent(context.element, 'pointermove', {
             clientX: 200,
             clientY: 150,
-        }));
+        });
 
         expect(getBoundingClientRect).not.toHaveBeenCalled();
     });
@@ -292,7 +293,28 @@ describe('DOMContext pointer state machine', () => {
         return element.events.map(({ type }) => type);
     }
 
+    // `click` is still sourced from the DOM click; everything else now comes from a pointer event.
+    const POINTER_EQUIVALENT: Record<string, string> = {
+        mousedown: 'pointerdown',
+        mousemove: 'pointermove',
+        mouseup: 'pointerup',
+        mouseenter: 'pointerenter',
+        mouseleave: 'pointerleave',
+    };
+
     function mouse(context: ReturnType<typeof create>, type: string, clientX: number, clientY: number, button = 0): void {
+        const pointerType = POINTER_EQUIVALENT[type];
+
+        if (pointerType) {
+            dispatchPointerEvent(context.element, pointerType, {
+                clientX,
+                clientY,
+                button,
+            });
+
+            return;
+        }
+
         context.element.dispatchEvent(new MouseEvent(type, {
             clientX,
             clientY,
@@ -315,7 +337,7 @@ describe('DOMContext pointer state machine', () => {
 
         expect(typesOf(element)).toEqual(['mouseenter']);
 
-        context.element.dispatchEvent(new MouseEvent('mouseleave'));
+        dispatchPointerEvent(context.element, 'pointerleave');
 
         expect(typesOf(element)).toEqual(['mouseenter', 'mouseleave']);
     });
@@ -327,8 +349,8 @@ describe('DOMContext pointer state machine', () => {
         register(context, [element]);
         hover(context, 50, 50);
 
-        context.element.dispatchEvent(new MouseEvent('mouseleave'));
-        context.element.dispatchEvent(new MouseEvent('mouseenter'));
+        dispatchPointerEvent(context.element, 'pointerleave');
+        dispatchPointerEvent(context.element, 'pointerenter');
 
         hover(context, 50, 50);
 
@@ -389,10 +411,10 @@ describe('DOMContext pointer state machine', () => {
         mouse(context, 'mousemove', 100, 100);
         mouse(context, 'mousemove', 140, 140);
 
-        window.dispatchEvent(new MouseEvent('mouseup', {
+        dispatchPointerEvent(window, 'pointerup', {
             clientX: 900,
             clientY: 900,
-        }));
+        });
 
         expect(typesOf(element)).toEqual(['dragstart', 'drag', 'dragend']);
     });
@@ -477,10 +499,10 @@ describe('DOMContext pointer state machine', () => {
         mouse(context, 'mousedown', 10, 10);
         mouse(context, 'mousemove', 100, 100);
 
-        window.dispatchEvent(new MouseEvent('mouseup', {
+        dispatchPointerEvent(window, 'pointerup', {
             clientX: 900,
             clientY: 900,
-        }));
+        });
 
         element.events.length = 0;
 
@@ -635,10 +657,10 @@ describe('DOMContext pointer state machine', () => {
 
         context.on('mouseup', event => releases.push(event.data));
 
-        window.dispatchEvent(new MouseEvent('mouseup', {
+        dispatchPointerEvent(window, 'pointerup', {
             clientX: 900,
             clientY: 900,
-        }));
+        });
 
         expect(releases).toHaveLength(0);
     });
@@ -656,10 +678,10 @@ describe('DOMContext pointer state machine', () => {
         mouse(context, 'mousedown', 10, 10);
         mouse(context, 'mousemove', 100, 100);
 
-        window.dispatchEvent(new MouseEvent('mouseup', {
+        dispatchPointerEvent(window, 'pointerup', {
             clientX: 900,
             clientY: 900,
-        }));
+        });
 
         expect(events).toEqual(['mouseup', 'dragend']);
         expect(typesOf(element)).toEqual(['dragstart', 'dragend']);
@@ -697,10 +719,10 @@ describe('DOMContext pointer state machine', () => {
         mouse(context, 'mousedown', 10, 10);
         mouse(context, 'mousemove', 100, 100);
 
-        window.dispatchEvent(new MouseEvent('mouseup', {
+        dispatchPointerEvent(window, 'pointerup', {
             clientX: 900,
             clientY: 900,
-        }));
+        });
 
         mouse(context, 'click', 100, 100);
 
@@ -771,6 +793,179 @@ describe('DOMContext pointer state machine', () => {
             x: 50,
             y: 50,
         });
+    });
+
+    describe('DOMContext pointer events', () => {
+
+        function pointer(context: ReturnType<typeof create>, type: string, init?: Parameters<typeof dispatchPointerEvent>[2]): void {
+            dispatchPointerEvent(context.element, type, init);
+        }
+
+        test('Should emit a pointer event carrying the device, the pointer id and the modifiers', () => {
+            const context = create();
+            const payloads: unknown[] = [];
+
+            context.on('pointerdown', event => payloads.push(event.data));
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 60,
+                pointerId: 7,
+                pointerType: 'touch',
+                shiftKey: true,
+            });
+
+            expect(payloads).toEqual([{
+                x: 50,
+                y: 60,
+                pointerId: 7,
+                pointerType: 'touch',
+                isPrimary: true,
+                button: 0,
+                buttons: 0,
+                altKey: false,
+                ctrlKey: false,
+                metaKey: false,
+                shiftKey: true,
+            }]);
+        });
+
+        // A second finger must reach a pinch handler, but must not fire a second `mousedown`.
+        test('Should emit pointer events for a non-primary pointer but no mouse events', () => {
+            const context = create();
+            const events: string[] = [];
+
+            context.on('pointerdown', () => events.push('pointerdown'));
+            context.on('mousedown', () => events.push('mousedown'));
+            context.on('pointermove', () => events.push('pointermove'));
+            context.on('mousemove', () => events.push('mousemove'));
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 50,
+                pointerId: 2,
+                isPrimary: false,
+            });
+
+            pointer(context, 'pointermove', {
+                clientX: 60,
+                clientY: 60,
+                pointerId: 2,
+                isPrimary: false,
+            });
+
+            expect(events).toEqual(['pointerdown', 'pointermove']);
+        });
+
+        test('Should emit both vocabularies for the primary pointer', () => {
+            const context = create();
+            const events: string[] = [];
+
+            context.on('pointerdown', () => events.push('pointerdown'));
+            context.on('mousedown', () => events.push('mousedown'));
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            expect(events).toEqual(['pointerdown', 'mousedown']);
+        });
+
+        test('Should end a gesture on pointercancel without emitting a click', () => {
+            const context = create();
+            const element = createMockElement('a', [...DRAG_EVENTS, 'click']);
+            const events: string[] = [];
+
+            register(context, [element]);
+
+            context.on('pointercancel', () => events.push('pointercancel'));
+            context.on('mouseup', () => events.push('mouseup'));
+            context.on('dragend', () => events.push('dragend'));
+            context.on('click', () => events.push('click'));
+
+            pointer(context, 'pointerdown', {
+                clientX: 10,
+                clientY: 10,
+            });
+
+            pointer(context, 'pointermove', {
+                clientX: 100,
+                clientY: 100,
+            });
+
+            pointer(context, 'pointercancel', {
+                clientX: 100,
+                clientY: 100,
+            });
+
+            expect(events).toEqual(['pointercancel', 'mouseup', 'dragend']);
+            expect(typesOf(element)).toEqual(['dragstart', 'dragend']);
+        });
+
+        test('Should release the button state on pointercancel so the next press is not swallowed', () => {
+            const context = create();
+            const events: string[] = [];
+
+            context.on('mouseup', () => events.push('mouseup'));
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointercancel', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointerup', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            expect(events).toEqual(['mouseup', 'mouseup']);
+        });
+
+        // Capture retargets moves to the surface, so the browser reports no leave of its own.
+        test('Should keep tracking a captured drag past the surface edge, leaving and re-entering once each', () => {
+            const context = create();
+            const events: string[] = [];
+            const moves: unknown[] = [];
+
+            context.on('mouseenter', () => events.push('mouseenter'));
+            context.on('mouseleave', () => events.push('mouseleave'));
+            context.on('mousemove', event => moves.push(event.data));
+
+            pointer(context, 'pointerdown', {
+                clientX: 50,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointermove', {
+                clientX: 900,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointermove', {
+                clientX: 950,
+                clientY: 50,
+            });
+
+            pointer(context, 'pointermove', {
+                clientX: 60,
+                clientY: 50,
+            });
+
+            expect(events).toEqual(['mouseleave', 'mouseenter']);
+            expect(moves).toHaveLength(3);
+        });
+
     });
 
 });

--- a/packages/dom/test/navigator.test.ts
+++ b/packages/dom/test/navigator.test.ts
@@ -452,3 +452,117 @@ describe('DOMNavigator interactions', () => {
     });
 
 });
+
+describe('DOMNavigator bounds', () => {
+
+    const BOUNDS = {
+        x: 40,
+        y: 40,
+        width: 100,
+        height: 100,
+    };
+
+    function boundedNavigator(): DOMNavigator {
+        return createNavigator(fakeContext(), {
+            bounds: BOUNDS,
+            interactions: {
+                zoom: true,
+                pan: true,
+            },
+        });
+    }
+
+    test('Should zoom on a wheel inside the claimed region', () => {
+        const navigator = boundedNavigator();
+
+        fire('wheel', {
+            deltaY: -100,
+            clientX: 90,
+            clientY: 90,
+        });
+
+        expect(navigator.transform.k).toBeGreaterThan(1);
+
+        navigator.destroy();
+    });
+
+    test('Should leave a wheel outside the claimed region to the page', () => {
+        const navigator = boundedNavigator();
+
+        const event = new Event('wheel', {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        Object.assign(event, {
+            deltaY: -100,
+            clientX: 10,
+            clientY: 10,
+        });
+
+        element.dispatchEvent(event);
+
+        expect(navigator.transform.k).toBe(1);
+        // Not consuming the gesture is the point: a swallowed wheel would freeze the page scroll.
+        expect(event.defaultPrevented).toBe(false);
+
+        navigator.destroy();
+    });
+
+    test('Should ignore a drag that starts outside the claimed region', () => {
+        const navigator = boundedNavigator();
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 10,
+            clientY: 10,
+        });
+
+        fire('pointermove', {
+            pointerId: 1,
+            clientX: 60,
+            clientY: 60,
+        });
+
+        expect(navigator.transform.x).toBe(0);
+
+        navigator.destroy();
+    });
+
+    test('Should keep tracking a drag that starts inside and leaves the region', () => {
+        const navigator = boundedNavigator();
+
+        fire('pointerdown', {
+            pointerId: 1,
+            clientX: 100,
+            clientY: 100,
+        });
+
+        fire('pointermove', {
+            pointerId: 1,
+            clientX: 400,
+            clientY: 100,
+        });
+
+        expect(navigator.transform.x).toBe(300);
+
+        navigator.destroy();
+    });
+
+    test('Should claim everything again once the region is cleared', () => {
+        const navigator = boundedNavigator();
+
+        navigator.bounds = undefined;
+
+        fire('wheel', {
+            deltaY: -100,
+            clientX: 10,
+            clientY: 10,
+        });
+
+        expect(navigator.transform.k).toBeGreaterThan(1);
+
+        navigator.destroy();
+    });
+
+});

--- a/packages/dom/test/navigator.test.ts
+++ b/packages/dom/test/navigator.test.ts
@@ -8,21 +8,45 @@ import {
 } from 'vitest';
 
 import {
+    createContext,
+} from '@ripl/canvas';
+
+import {
+    dispatchPointerEvent,
+    mockCanvasContext,
+    polyfillPath2D,
+} from '@ripl/test-utils';
+
+import {
     createNavigator,
     DOMNavigator,
 } from '../src';
+
+import {
+    Box,
+} from '@ripl/core';
 
 import type {
     Context,
 } from '@ripl/core';
 
-let element: HTMLDivElement;
+polyfillPath2D();
 
-/** A minimal stand-in context exposing only the DOM element the navigator binds to. */
+const SURFACE_WIDTH = 400;
+const SURFACE_HEIGHT = 300;
+
+const POINTER_EVENTS = ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'];
+
+let host: HTMLDivElement;
+let context: ReturnType<typeof createContext>;
+let element: HTMLElement;
+
+/**
+ * The navigator reads its gestures from the context's pointer events, so these run against a real
+ * one rather than a stand-in — the relay is half of what is under test.
+ */
 function fakeContext(): Context {
-    return {
-        element,
-    } as unknown as Context;
+    return context;
 }
 
 /** A non-DOM context, mirroring how the terminal context carries a dummy `{}` element. */
@@ -32,8 +56,13 @@ function fakeNonDOMContext(): Context {
     } as unknown as Context;
 }
 
-/** Dispatches a DOM event with arbitrary properties, sidestepping jsdom constructor gaps. */
+/** Dispatches a DOM event on the surface, sidestepping jsdom's missing pointer constructors. */
 function fire(type: string, props: Record<string, unknown>): void {
+    if (POINTER_EVENTS.includes(type)) {
+        dispatchPointerEvent(element, type, props);
+        return;
+    }
+
     const event = new Event(type, {
         bubbles: true,
         cancelable: true,
@@ -44,12 +73,30 @@ function fire(type: string, props: Record<string, unknown>): void {
 }
 
 beforeEach(() => {
-    element = document.createElement('div');
-    document.body.appendChild(element);
+    mockCanvasContext();
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+        left: 0,
+        top: 0,
+        right: SURFACE_WIDTH,
+        bottom: SURFACE_HEIGHT,
+        width: SURFACE_WIDTH,
+        height: SURFACE_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+    }) as DOMRect);
+
+    host = document.createElement('div');
+    document.body.appendChild(host);
+
+    context = createContext(host);
+    element = context.element as unknown as HTMLElement;
 });
 
 afterEach(() => {
-    element.remove();
+    context.destroy();
+    host.remove();
     vi.restoreAllMocks();
 });
 
@@ -346,32 +393,34 @@ describe('DOMNavigator interactions', () => {
         navigator.destroy();
     });
 
-    test('Should measure the element once per gesture, not once per pointer move', () => {
+    function wheel(clientX: number): void {
+        fire('wheel', {
+            deltaY: -10,
+            clientX,
+            clientY: 100,
+        });
+    }
+
+    // Pointer coordinates arrive already-resolved from the context; only the wheel is measured here.
+    test('Should measure the element once across a run of wheel events', () => {
         const navigator = createNavigator(fakeContext(), {
             interactions: {
-                pan: true,
+                zoom: true,
             },
         });
 
         const getBoundingClientRect = vi.spyOn(element, 'getBoundingClientRect');
 
-        fire('pointerdown', {
-            pointerId: 1,
-            clientX: 100,
-            clientY: 100,
-        });
+        // Absorbs the pending invalidation the resize observer leaves behind on construction.
+        wheel(100);
 
-        getBoundingClientRect.mockClear();
+        const settled = getBoundingClientRect.mock.calls.length;
 
         for (let i = 0; i < 10; i++) {
-            fire('pointermove', {
-                pointerId: 1,
-                clientX: 100 + i,
-                clientY: 100,
-            });
+            wheel(100 + i);
         }
 
-        expect(getBoundingClientRect).not.toHaveBeenCalled();
+        expect(getBoundingClientRect.mock.calls.length).toBe(settled);
 
         navigator.destroy();
     });
@@ -379,29 +428,20 @@ describe('DOMNavigator interactions', () => {
     test('Should re-measure the element after a scroll', () => {
         const navigator = createNavigator(fakeContext(), {
             interactions: {
-                pan: true,
+                zoom: true,
             },
         });
 
         const getBoundingClientRect = vi.spyOn(element, 'getBoundingClientRect');
 
-        fire('pointerdown', {
-            pointerId: 1,
-            clientX: 100,
-            clientY: 100,
-        });
+        wheel(100);
 
-        getBoundingClientRect.mockClear();
+        const settled = getBoundingClientRect.mock.calls.length;
 
         window.dispatchEvent(new Event('scroll'));
+        wheel(130);
 
-        fire('pointermove', {
-            pointerId: 1,
-            clientX: 130,
-            clientY: 100,
-        });
-
-        expect(getBoundingClientRect).toHaveBeenCalledOnce();
+        expect(getBoundingClientRect.mock.calls.length).toBe(settled + 1);
 
         navigator.destroy();
     });
@@ -455,12 +495,7 @@ describe('DOMNavigator interactions', () => {
 
 describe('DOMNavigator bounds', () => {
 
-    const BOUNDS = {
-        x: 40,
-        y: 40,
-        width: 100,
-        height: 100,
-    };
+    const BOUNDS = new Box(40, 40, 140, 140);
 
     function boundedNavigator(): DOMNavigator {
         return createNavigator(fakeContext(), {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,5 +1,6 @@
 import {
     factory,
+    Navigator,
 } from '@ripl/core';
 
 import type {
@@ -166,6 +167,8 @@ factory.set({
         resolveOutput(target),
         options as TerminalContextOptions
     ),
+    // The terminal has no pointer, so the base navigator's view model is the whole of what it can offer.
+    createNavigator: (_context, options) => new Navigator(options),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getComputedStyle: () => ({ font: '10px monospace' } as any),
     createElement: (tagName) => createNodeElement(tagName) as unknown as HTMLElement,

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -11,3 +11,10 @@ export type {
     MockCanvasStateStub,
     MockTextMetricsOptions,
 } from './canvas';
+
+export {
+    createPointerEvent,
+    dispatchPointerEvent,
+} from './pointer';
+
+export type { PointerEventInit } from './pointer';

--- a/packages/test-utils/src/pointer.ts
+++ b/packages/test-utils/src/pointer.ts
@@ -1,0 +1,72 @@
+/** Fields a synthetic pointer event can carry, beyond the defaults every dispatch gets. */
+export interface PointerEventInit {
+    /** Clientspace x coordinate of the pointer. */
+    clientX?: number;
+    /** Clientspace y coordinate of the pointer. */
+    clientY?: number;
+    /** Identifies the pointer across its gesture. Defaults to `1`. */
+    pointerId?: number;
+    /** The kind of device. Defaults to `'mouse'`. */
+    pointerType?: string;
+    /** Whether this is the gesture's first pointer. Defaults to `true`. */
+    isPrimary?: boolean;
+    /** The button whose state changed. Defaults to `0`. */
+    button?: number;
+    /** Bitmask of buttons held. Defaults to `0`. */
+    buttons?: number;
+    /** Whether the alt key was held. */
+    altKey?: boolean;
+    /** Whether the control key was held. */
+    ctrlKey?: boolean;
+    /** Whether the meta key was held. */
+    metaKey?: boolean;
+    /** Whether the shift key was held. */
+    shiftKey?: boolean;
+}
+
+const DEFAULTS = {
+    clientX: 0,
+    clientY: 0,
+    pointerId: 1,
+    pointerType: 'mouse',
+    isPrimary: true,
+    button: 0,
+    buttons: 0,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+};
+
+/**
+ * Builds a synthetic pointer event.
+ *
+ * jsdom ships no usable `PointerEvent` constructor, so this assigns the fields onto a plain `Event`
+ * rather than constructing one — which is also why the properties are writable here and read-only in
+ * a browser. Listeners only read them, so the difference does not show.
+ *
+ * @param type - The event type, e.g. `'pointerdown'`.
+ * @param init - Fields to override the defaults with.
+ * @returns The event, ready to dispatch.
+ */
+export function createPointerEvent(type: string, init?: PointerEventInit): Event {
+    const event = new Event(type, {
+        bubbles: true,
+        cancelable: true,
+    });
+
+    Object.assign(event, DEFAULTS, init);
+
+    return event;
+}
+
+/**
+ * Dispatches a synthetic pointer event at `target`.
+ *
+ * @param target - The element (or window) to dispatch on.
+ * @param type - The event type, e.g. `'pointermove'`.
+ * @param init - Fields to override the defaults with.
+ */
+export function dispatchPointerEvent(target: EventTarget, type: string, init?: PointerEventInit): void {
+    target.dispatchEvent(createPointerEvent(type, init));
+}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -12,6 +12,7 @@ import type {
 } from '@ripl/core';
 
 import {
+    createNavigator,
     hasWindow,
 } from '@ripl/dom';
 
@@ -84,6 +85,7 @@ if (hasWindow) {
         },
         getComputedStyle: (el) => window.getComputedStyle(el as Element),
         createContext,
+        createNavigator,
         createElement: (tagName) => document.createElement(tagName),
         createElementNS: (namespace, tagName) => document.createElementNS(namespace, tagName),
         getDefaultState,

--- a/packages/web/test/index.test.ts
+++ b/packages/web/test/index.test.ts
@@ -15,6 +15,7 @@ import {
     createContext,
     createRenderer,
     createScene,
+    DOMNavigator,
     factory,
 } from '@ripl/web';
 
@@ -22,6 +23,10 @@ describe('@ripl/web', () => {
 
     test('registers the canvas context factory for the browser', () => {
         expect(typeof factory.createContext).toBe('function');
+    });
+
+    test('registers the gesture-bound navigator for the browser', () => {
+        expect(typeof factory.createNavigator).toBe('function');
     });
 
     test('re-exports the core and canvas entry points', () => {
@@ -48,6 +53,15 @@ describe('@ripl/web', () => {
 
             expect(renderer).toBeDefined();
             expect(typeof renderer.start).toBe('function');
+        });
+
+        test('builds a DOM navigator through the factory', () => {
+            const scene = createScene(document.createElement('div'));
+            const navigator = factory.createNavigator(scene.context);
+
+            expect(navigator).toBeInstanceOf(DOMNavigator);
+
+            navigator.destroy();
         });
 
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,7 +1981,6 @@ __metadata:
   resolution: "@ripl/charts@workspace:packages/charts"
   dependencies:
     "@ripl/core": "workspace:^"
-    "@ripl/dom": "workspace:^"
     "@ripl/utilities": "workspace:^"
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,7 +1980,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ripl/charts@workspace:packages/charts"
   dependencies:
-    "@ripl/canvas": "workspace:^"
     "@ripl/core": "workspace:^"
     "@ripl/dom": "workspace:^"
     "@ripl/utilities": "workspace:^"


### PR DESCRIPTION
`@ripl/charts` is documented as context-agnostic — it draws onto whatever surface it is handed, web or terminal — but it did not behave that way. It depended on two platform packages and reached for both at runtime. Removing the second of those exposed a third problem in the layer underneath, so this PR ends up covering all three.

## 1. It installed a rendering backend

It depended on `@ripl/canvas` and registered that backend into the platform factory at module scope:

```ts
// packages/charts/src/core/chart.ts
import { createContext } from '@ripl/canvas';

if (!factory.createContext) {
    factory.set({ createContext });
}
```

Two consequences. A terminal consumer installed canvas code they could never use. And the backend was chosen by *import order* rather than by the consumer: whichever of `@ripl/web`, `@ripl/node` or `@ripl/charts` happened to be evaluated first won the `if (!factory.createContext)` race, silently.

The repository already half-followed the intended model. The visual-regression gallery declares its backend explicitly:

```ts
// packages/charts/test/visual/gallery.ts
// Side-effect import: '@ripl/web' registers the browser factory (canvas context, text measurement, rAF).
import '@ripl/web';
```

**The fix.** Drop the dependency and the registration. `@ripl/charts` installs no backend at all and is installed *alongside* `@ripl/web` or `@ripl/node`, which supply the factory. The install docs in `packages/charts/README.md` and `apps/website/src/charts/getting-started.md` are rewritten to say so.

The obvious alternative — keep the fallback but make it lazy — was rejected because it does not fix the actual problem. A lazy fallback still bundles canvas for terminal consumers, and still resolves the backend implicitly rather than by consumer choice. The whole point of the package being context-agnostic is that the surface is an input, not a default.

## 2. It reached into the DOM for pan and zoom

`@ripl/dom` remained a dependency, reached from two places. The cartesian chart built its controller with the DOM navigator, and leaked the class into the public API:

```ts
// packages/charts/src/core/cartesian.ts
import { createNavigator } from '@ripl/dom';

public get navigator(): DOMNavigator | undefined { … }
```

And the overview scrub strip attached raw pointer listeners to the context element, doing its own `getBoundingClientRect` coordinate math and capturing the pointer.

**The fix.** `factory.createNavigator` joins the existing `createContext` seam. `@ripl/web` registers the gesture-bound `DOMNavigator`; `@ripl/node` registers the base `Navigator`, which owns the same view model but binds no input because a terminal has no pointer. Charts go through the factory and fall back to the base class — the same guard `Scene` already uses for `createContext`. A no-op default was rejected: it would leave `chart.navigator` undefined and silently break `fitBounds`/`centerOn` for anyone who had not imported a platform.

The strip could not simply move to context events, and this is the part worth reviewing. It relied on `stopImmediatePropagation` to stop the in-plot navigator also panning:

```ts
// Block the in-plot navigator (its listeners were attached after ours) from also panning.
event.stopImmediatePropagation();
```

That worked only because `DOMContext` bound **mouse** events while the strip and the navigator bound **pointer** events, and pointer fires first in the browser. The moment the strip reads context-level events, the navigator's `pointerdown` has already started a pan and there is no event left to cancel — so the ordering hack had to be replaced, not ported.

It is replaced with a declarative region. `Navigator` gains `bounds`, a [`Box`](https://github.com/andrewcourtice/ripl/blob/main/packages/core/src/math/structs.ts); input-bound subclasses ignore the wheel and a gesture's first press outside it via the existing `isPointInBox`, and never gate continuation, so a drag that starts inside keeps tracking after it leaves. The chart scopes its navigator to the plot rectangle from `clipPlot`, which runs once per render with the plot rect already in hand.

`interactions` moves from `DOMNavigatorOptions` up to `NavigatorOptions` so the factory signature is platform-neutral. `DOMNavigatorOptions` stays as an alias, so `@ripl/dom` and `@ripl/web` consumers are unaffected.

## 3. The context's input was mouse-only

Both of the above lean on the context being the input surface, and it was a poor one. `DOMContext` bound DOM **mouse** events, so touch and pen reached it only through the browser's compatibility shims: no multi-touch, no `pointerId`, no pointer capture. Meanwhile `DOMNavigator` bound its own raw pointer events — two input pipelines on one surface, whose relative order was a browser timing detail rather than anything designed.

**The fix.** Pointer events become the single source. `ContextEventMap` gains `pointerenter`, `pointerleave`, `pointerdown`, `pointermove`, `pointerup` and `pointercancel`, carrying `pointerId`, `pointerType`, `isPrimary`, the buttons and the modifiers. Each handler emits its `pointer*` event for **every** pointer, then — for the primary pointer only — the `mouse*`/`drag*` events with their original payloads:

```ts
this._attachInteractionEvent('pointerdown', event => {
    this.emit('pointerdown', this._pointerPayload(event, x, y));

    if (!event.isPrimary) {
        return;
    }

    // …the existing mousedown/hit-test/drag machinery, unchanged
});
```

So every existing consumer — hover highlighting, tooltips, crosshair, legend — is byte-for-byte unchanged under a mouse and gains touch and pen for free. The `isPrimary` gate is what stops a second finger firing a second `mousedown`, which nothing today is written to expect.

The surface now captures the pointer for a press, which closes the drag-leaves-the-surface gap this PR previously accepted, for element-level `drag` as well as the strip. Capture suppresses the browser's own leave, so crossing the edge mid-gesture synthesizes `pointerleave`/`mouseleave` on the way out and the enter on the way back, exactly once each, through a single gate that also dedupes the native events.

`DOMNavigator` now reads gestures from the context and drops its own pointer listeners and capture. Only the wheel stays raw — suppressing page scroll needs the event itself, and keeping it that way means context payloads stay pure data with no callable escape hatch, which is what lets a non-DOM backend implement the same event map honestly.

**Element events stay `mouse*`.** The context is the input surface; element events are the semantic hover/click layer, and a parallel pointer vocabulary there would double `TRACKED_EVENTS` and the hit testing it drives for no gain. `TRACKED_EVENTS` and `PRESS_EVENTS` are untouched.

## Keeping it true

Neither `@ripl/core` nor `@ripl/charts` had any non-DOM test coverage — the whole suite runs under `jsdom`, so a DOM dependency creeping back in would pass every gate. Two guards close that:

- An ESLint `no-restricted-imports` rule over `packages/core/src` and `packages/charts/src` banning every backend package, pointing at the `factory` seam instead.
- `packages/{core,charts}/test/node.node.test.ts`, pinned to `environment: node` with `@ripl/node` for the bindings. The charts suite renders bar, pie and navigator-plus-overview charts to a terminal with no `window` and no `document`.

A sweep of `@ripl/core` found no unguarded DOM runtime usage anywhere — everything platform-shaped already routes through `factory`. Two capabilities degrade rather than work off-DOM and are now documented as such: `getPathLength`/`samplePathPoint` measure via a real SVG path element and return `0`/origin, and `interpolateImage` falls back to a hard swap at the halfway point.

## Verification

- `yarn test` — 242 files / 3370 tests passing (was 240 / 3336 before this branch).
- `yarn lint`, `yarn typecheck`, `yarn build`, `yarn typecheck:dist` clean.
- `yarn workspace @ripl/website build` succeeds.
- TypeDoc `notDocumented` reports nothing for `core`, `dom` or `charts`.
- `yarn workspace @ripl/charts test:browser` — 8 canvas↔svg parity and hit tests passing.
- The ESLint guard was verified by adding a banned import and confirming it errors, not by assuming.

New coverage for the parts with no precedent: a non-primary pointer emits `pointer*` but no `mouse*`; `pointercancel` ends a gesture without a `click` and releases the button state so the next press is not swallowed; a captured drag past the surface edge keeps reporting moves and emits exactly one `mouseleave` on the way out and one `mouseenter` on the way back. jsdom ships no usable `PointerEvent` constructor, so `@ripl/test-utils` gains a shared dispatch helper that both `@ripl/dom` suites use.

**Visual regression.** The `charts.spec.ts` baselines do not match this sandbox's Chromium: all 26 fail on `main` (`e6917a3`) as well as on this branch, so comparing against them proves nothing. Instead the gallery was rendered on `main` and on the branch in the same container and the two sets of renders diffed against each other — **all 26 are byte-for-byte identical**, including the trend chart, which is the one gallery entry with `overview: true`. The baselines still need a run on a machine where they match.

**Browser interaction.** The navigator and input rework are behavioural, so they were driven in a real headless Chromium against a trend chart with `overview: true`, all seven checks passing: a wheel over the plot zooms; a wheel over the overview strip and over the axis gutter do not; dragging the strip's edge handle to the midpoint halves the window (`k = 2.0`); a drag starting in the strip band leaves the plot's transform at identity; a drag inside the plot pans once zoomed in; and **the same strip drag driven by a CDP touch sequence rather than the mouse produces the identical result**, which is the whole point of §3 and did not work before.

## Breaking

**A chart built from a selector or an `HTMLElement` with no backend imported now throws**

```
Scene requires a Context instance or factory.createContext to be set
```

instead of silently rendering to canvas. A chart handed a `Context` instance is unaffected. Import the backend for your platform once, anywhere in the entry path:

```ts
import '@ripl/web';   // browser
import '@ripl/node';  // terminal

import { createBarChart } from '@ripl/charts';
```

**`chart.navigator` is typed `Navigator`, not `DOMNavigator`.** `DOMNavigator` adds no public member beyond `destroy()`, which the base class also has, so the usable surface is identical. Code that annotated the type needs the import changed from `@ripl/dom` to `@ripl/core`.

**Navigator gestures are claimed within the plot rectangle only.** A wheel or drag starting over the axis gutter, title, legend or overview strip is left alone — a wheel there now scrolls the page rather than zooming the chart. This is the mechanism that replaces the strip's propagation hack, and it also fixes drag-to-pan firing while interacting with the legend.

**`DOMContext` no longer binds `mouse*` DOM listeners** (only `click`). Anything relying on the compatibility-mouse path specifically, rather than on Ripl's own `mouse*` events, sees pointer events instead. Ripl's own event names and payloads are unchanged.

`package.json` drops both `@ripl/canvas` and `@ripl/dom` from `dependencies`, leaving `@ripl/core` and `@ripl/utilities`. A side effect worth noting: `sideEffects: false` on the package is now accurate, where before it directly contradicted a module-scope `factory.set`.

## Follow-ups left undone

- **DOM-free path metrics.** `getPathLength`/`samplePathPoint` still measure through an SVG element. Only `@ripl/canvas` consumes them, so nothing here depends on it, but a real fix means parsing path data and building an arc-length table over flattened béziers and arcs — its own piece of work. The current behaviour is documented and pinned by a test rather than left to be discovered.
- **Core's DOM types.** The `Context` base class still constrains its element type parameter to the DOM `Element`, which forces `TerminalContext` to pass `{} as Element`. Type-only, no runtime effect, and `AGENTS.md → Dependencies` already permits DOM lib types in published declarations, so it was deliberately left alone rather than rippled through six packages in this PR.
- **The 3D camera** keeps its own raw pointer/touch/wheel listeners. Migrating it to context events is the same shape of change as §3, but it is a separate package with its own gesture model.